### PR TITLE
Fix flaky test: Correct operator precedence in waitForIkkeSkattepliktigeSakerJob

### DIFF
--- a/helpers/api-helper.ts
+++ b/helpers/api-helper.ts
@@ -157,7 +157,7 @@ export class AdminApiHelper {
 
       const elapsed = Math.round((Date.now() - startTime) / 1000);
 
-      if (!data.isRunning && data.antallProsessert > 0 || elapsed > 1) {
+      if (!data.isRunning && (data.antallProsessert > 0 || elapsed > 2)) {
         console.log(`✅ Job completed after ${elapsed}s`);
         console.log(`   - Funnet: ${data.antallFunnet || 0}`);
         console.log(`   - Prosessert: ${data.antallProsessert || 0}`);


### PR DESCRIPTION
## Problem

The test `skal endre skattestatus fra skattepliktig til ikke-skattepliktig via nyvurdering` was failing intermittently on GitHub Actions with:

```
Expected: 1
Received: 0
```

## Root Cause

Operator precedence bug in `helpers/api-helper.ts` line 160:

```typescript
if (!data.isRunning && data.antallProsessert > 0 || elapsed > 1)
```

This evaluated as:
```typescript
if ((!data.isRunning && data.antallProsessert > 0) || elapsed > 1)
```

**The bug:** After 2 seconds (`elapsed > 1`), the function returns **regardless** of whether the job is running or has results. On slow CI environments, the async job hasn't completed yet, so `antallProsessert = 0`.

## Solution

Added parentheses and increased threshold to 2 seconds:

```typescript
if (!data.isRunning && (data.antallProsessert > 0 || elapsed > 2))
```

Now returns only when:
- Job is NOT running (completed or not started)
- AND (has processed items OR we've waited >2s for async job to start)

This correctly handles the Spring Boot async queue behavior where `isRunning=false` initially before the job starts, while preventing early returns when the job is actively processing.

## Testing

Affected tests:
- `tests/utenfor-avtaleland/workflows/nyvurdering-endring-skattestatus.spec.ts` (line 288)
- `tests/utenfor-avtaleland/workflows/arsavregning-ikke-skattepliktig.spec.ts` (line 112)