### PR TITLE
Fix EU/EØS skip workflow stability and type errors

### DIFF
--- a/pages/behandling/eu-eos-skip-behandling.page.ts
+++ b/pages/behandling/eu-eos-skip-behandling.page.ts
@@ -23,7 +23,7 @@ import { EuEosSkipBehandlingAssertions } from './eu-eos-skip-behandling.assertio
  * await skipBehandling.klikkBekreftOgFortsett();
  */
 export class EuEosSkipBehandlingPage extends EuEosBehandlingPage {
-  readonly assertions: EuEosSkipBehandlingAssertions;
+  override readonly assertions: EuEosSkipBehandlingAssertions;
 
   // Locators - Yrkesaktiv på sokkel
   private readonly yrkesaktivPaSokkelRadio = this.page.getByRole('radio', {
@@ -114,6 +114,9 @@ export class EuEosSkipBehandlingPage extends EuEosBehandlingPage {
   async fyllInnSkipNavn(navn: string): Promise<void> {
     await this.skipNavnField.click();
     await this.skipNavnField.fill(navn);
+    // Trigger blur to ensure any API saves complete
+    await this.skipNavnField.blur();
+    await this.page.waitForTimeout(300);
     console.log(`✅ Fylte inn skipnavn: ${navn}`);
   }
 
@@ -124,6 +127,8 @@ export class EuEosSkipBehandlingPage extends EuEosBehandlingPage {
    */
   async velgFartsomrade(fartsomrade: 'UTENRIKS' | 'INNENRIKS'): Promise<void> {
     await this.fartsomradeDropdown.selectOption(fartsomrade);
+    // Allow time for any triggered API calls or field enabling
+    await this.page.waitForTimeout(300);
     console.log(`✅ Valgte fartsområde: ${fartsomrade}`);
   }
 
@@ -136,11 +141,19 @@ export class EuEosSkipBehandlingPage extends EuEosBehandlingPage {
   async velgFlaggstat(land: string): Promise<void> {
     await this.flaggstatCombobox.click();
     await this.flaggstatCombobox.fill(land);
+    // Press Enter to confirm selection and trigger any API calls
+    await this.flaggstatCombobox.press('Enter');
+    await this.page.waitForTimeout(300);
     console.log(`✅ Valgte flaggstat: ${land}`);
   }
 
   /**
    * Velg "På norsk sokkel eller" radio-knapp
+   *
+   * @remarks
+   * Alternative scenario method - not used in current test flow.
+   * Current test uses foreign ship scenario with `velgFlagglandSomArbeidsland()`.
+   * Keep for future Norwegian continental shelf test scenarios.
    */
   async velgNorskSokkel(): Promise<void> {
     // Vent på at radio-knapp er synlig og stabil før sjekking (unngår race condition)
@@ -187,6 +200,11 @@ export class EuEosSkipBehandlingPage extends EuEosBehandlingPage {
 
   /**
    * Velg "Arbeider på norsk skip" spørsmål
+   *
+   * @remarks
+   * Alternative scenario method - not used in current test flow.
+   * Current test uses foreign ship scenario with `velgArbeiderPaUtenlandskSkip()`.
+   * Keep for future Norwegian ship employment test scenarios.
    */
   async velgArbeiderPaNorskSkip(): Promise<void> {
     // Vent på at radio-knapp er synlig og stabil før sjekking (unngår race condition)
@@ -229,6 +247,8 @@ export class EuEosSkipBehandlingPage extends EuEosBehandlingPage {
     await this.velgFlaggstat(flaggstat);
     // VIKTIG: Må velge "Skip" først for å aktivere de andre valgene
     await this.velgSkip();
+    // Wait for dependent fields to become enabled after Skip selection
+    await this.page.waitForTimeout(300);
     await this.velgFlagglandSomArbeidsland(flagglandNavn);
     await this.velgSkipRegistrertIEttLand();
     console.log('✅ Fullførte skipdetaljer');


### PR DESCRIPTION
## Summary

Fixes flakiness in the EU/EØS skip workflow test by addressing race conditions and type safety issues.

### Stability Improvements (4 fixes)

1. **Skip name field** - Add blur + 300ms wait to ensure field saves complete
2. **Fartsområde dropdown** - Add 300ms wait after selection for field enabling  
3. **Flaggstat combobox** - Add Enter key confirmation + 300ms wait
4. **Skip selection** - Add 300ms wait after `velgSkip()` to allow dependent fields (flaggland, skipRegistrert) to enable

### Type Safety Fixes

- Make `EuEosSkipBehandlingAssertions` properly extend `EuEosBehandlingAssertions`
- Remove incorrect `override` keyword from new methods
- Add proper inheritance chain with skip-specific timeout (90s) for vedtak

### Code Quality

- Document unused methods (`velgNorskSokkel`, `velgArbeiderPaNorskSkip`) as alternative scenario methods for future Norwegian shelf/ship tests

## Context

These changes build on the recent API wait improvements (2025-11-20) documented in `docs/debugging/EU-EOS-API-WAITS-IMPLEMENTATION.md`. The skip workflow inherits those improvements automatically but needed additional race condition fixes for its conditional field dependencies.

## Test Plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Run skip test 5+ times to verify stability
- [ ] Verify JetBrains inspection shows no errors after IDE re-index

## Files Changed

- `pages/behandling/eu-eos-skip-behandling.page.ts` - Stability improvements + documentation
- `pages/behandling/eu-eos-skip-behandling.assertions.ts` - Type safety fixes