### PR TITLE
Disable Copilot auto-assignment after experiment

### DIFF
--- a/.github/workflows/analyze-e2e-failures.yml
+++ b/.github/workflows/analyze-e2e-failures.yml
@@ -423,42 +423,19 @@ jobs:
               # Extract issue number from URL
               ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
 
-              # Assign Copilot to analyze the issue
-              if [ -n "$ISSUE_NUM" ]; then
-                echo "   🤖 Assigning Copilot to issue #$ISSUE_NUM..."
-
-                # Get issue node ID
-                ISSUE_NODE_ID=$(gh api graphql -f query="query {
-                  repository(owner: \"${{ github.repository_owner }}\", name: \"${GITHUB_REPOSITORY#*/}\") {
-                    issue(number: $ISSUE_NUM) { id }
-                  }
-                }" --jq '.data.repository.issue.id' 2>/dev/null)
-
-                # Copilot SWE Agent bot ID - hardcoded because GITHUB_TOKEN cannot query suggestedActors
-                # This ID is stable across GitHub and was retrieved via:
-                # gh api graphql -f query='{ repository(owner:"navikt",name:"melosys-e2e-tests") {
-                #   suggestedActors(capabilities:[CAN_BE_ASSIGNED],first:100) {
-                #     nodes { __typename login ... on Bot { id } } } } }'
-                COPILOT_ID="BOT_kgDOC9w8XQ"
-
-                if [ -n "$ISSUE_NODE_ID" ]; then
-                  # Assign Copilot using special GraphQL header
-                  gh api graphql \
-                    -H "GraphQL-Features: issues_copilot_assignment_api_support" \
-                    -f query="mutation {
-                      addAssigneesToAssignable(input: {
-                        assignableId: \"$ISSUE_NODE_ID\",
-                        assigneeIds: [\"$COPILOT_ID\"]
-                      }) {
-                        assignable {
-                          ... on Issue { number }
-                        }
-                      }
-                    }" >/dev/null 2>&1 && echo "   ✅ Copilot assigned" || echo "   ⚠️ Failed to assign Copilot"
-                else
-                  echo "   ⚠️ Could not get issue node ID"
-                fi
-              fi
+              # NOTE: Copilot auto-assignment disabled (2025-12-22)
+              # Copilot Coding Agent creates PRs regardless of instructions - it doesn't have
+              # an "analyze only" mode. It would create workaround PRs (adding waits) instead
+              # of identifying root causes in other repos (melosys-api).
+              #
+              # To manually assign Copilot to an issue:
+              #   gh api graphql -H "GraphQL-Features: issues_copilot_assignment_api_support" \
+              #     -f query='mutation { addAssigneesToAssignable(input: {
+              #       assignableId: "<ISSUE_NODE_ID>", assigneeIds: ["BOT_kgDOC9w8XQ"]
+              #     }) { assignable { ... on Issue { number } } } }'
+              #
+              # See docs/copilot-analysis-experiment.md for details.
+              echo "   ℹ️  Issue created - assign Copilot manually if needed"
             fi
           done
 

--- a/docs/copilot-analysis-experiment.md
+++ b/docs/copilot-analysis-experiment.md
@@ -1,0 +1,138 @@
+# Copilot Coding Agent - E2E Failure Analysis Experiment
+
+**Date:** 2025-12-22
+**Status:** Paused - Copilot limitations prevent effective use
+**Revisit when:** Copilot gets "analyze only" mode or better cross-repo understanding
+
+## Goal
+
+Automatically analyze E2E test failures using GitHub Copilot Coding Agent to:
+1. Identify root cause location (melosys-api vs melosys-web vs test code)
+2. Link to existing issues (like #41 - SaksopplysningKilde race condition)
+3. Classify issues with appropriate labels
+4. Suggest fixes in the correct repository
+
+## What We Tried
+
+### Workflow Setup
+
+1. **Issue Creation** - `analyze-e2e-failures.yml` creates issues for failed/flaky tests
+2. **Rich Context** - Issues include error messages, Docker logs, image tags
+3. **Copilot Assignment** - Auto-assign Copilot to analyze the issue
+4. **Instructions** - Asked Copilot to "analyze only, don't create PR"
+
+### Copilot Assignment Code
+
+```bash
+# Get issue node ID
+ISSUE_NODE_ID=$(gh api graphql -f query="query {
+  repository(owner: \"navikt\", name: \"melosys-e2e-tests\") {
+    issue(number: $ISSUE_NUM) { id }
+  }
+}" --jq '.data.repository.issue.id')
+
+# Copilot bot ID (stable across GitHub)
+COPILOT_ID="BOT_kgDOC9w8XQ"
+
+# Assign using special GraphQL header
+gh api graphql \
+  -H "GraphQL-Features: issues_copilot_assignment_api_support" \
+  -f query="mutation {
+    addAssigneesToAssignable(input: {
+      assignableId: \"$ISSUE_NODE_ID\",
+      assigneeIds: [\"$COPILOT_ID\"]
+    }) { assignable { ... on Issue { number } } }
+  }"
+```
+
+**Note:** `GITHUB_TOKEN` in Actions cannot query `suggestedActors`, so we hardcoded the bot ID.
+
+## What Happened
+
+### Issues Created
+- #57: skal fullføre EU/EØS-arbeidsflyt med vedtak [timeout]
+- #58: skal fullføre "Arbeid i flere land" med selvstendig... [timeout]
+- #59: skal fullføre arbeid i flere land-arbeidsflyt [unknown]
+
+### Copilot's Response
+Copilot **ignored the "analyze only" instructions** and created PRs:
+- PR #60: Added waits in `eu-eos-behandling.page.ts`
+- PR #61: Added waits directly in test file (code duplication)
+- PR #62: Made network idle wait mandatory
+
+### Problems
+
+1. **No "analyze only" mode** - Copilot Coding Agent is designed to create PRs, period
+2. **Repo-scoped** - Cannot search melosys-api to find root cause
+3. **Workarounds, not fixes** - Just adds more waits in test code
+4. **No duplicate detection** - Didn't link to existing issue #41
+5. **No cross-repo understanding** - Doesn't know E2E failures often indicate backend bugs
+
+## Comparison: Copilot vs Claude Code
+
+| Capability | Copilot | Claude Code |
+|------------|---------|-------------|
+| See E2E test code | ✅ | ✅ |
+| See melosys-api code | ❌ | ✅ |
+| Connect to existing issues | ❌ | ✅ |
+| Understand backend race conditions | ❌ | ✅ |
+| Propose fix in correct repo | ❌ | ✅ |
+| Analyze only (no PR) | ❌ | ✅ |
+
+## Current State
+
+**Auto-assignment disabled** in `analyze-e2e-failures.yml`
+
+The workflow still:
+- Creates issues with rich context
+- Adds appropriate labels
+- References known issues in the template
+
+Humans triage and decide whether to:
+- Close as duplicate of #41
+- Assign Copilot for simple test fixes
+- Fix in melosys-api for backend issues
+
+## Manual Copilot Assignment
+
+If you want Copilot to attempt a fix:
+
+```bash
+# Get issue node ID
+ISSUE_NODE_ID=$(gh api graphql -f query='query {
+  repository(owner: "navikt", name: "melosys-e2e-tests") {
+    issue(number: <ISSUE_NUMBER>) { id }
+  }
+}' --jq '.data.repository.issue.id')
+
+# Assign Copilot
+gh api graphql \
+  -H "GraphQL-Features: issues_copilot_assignment_api_support" \
+  -f query="mutation {
+    addAssigneesToAssignable(input: {
+      assignableId: \"$ISSUE_NODE_ID\",
+      assigneeIds: [\"BOT_kgDOC9w8XQ\"]
+    }) { assignable { ... on Issue { number } } }
+  }"
+```
+
+## When to Revisit
+
+Check if Copilot improves with:
+- [ ] "Analyze only" mode - comment without creating PR
+- [ ] Cross-repo search - can look at melosys-api
+- [ ] Issue linking - can find related/duplicate issues
+- [ ] Root cause analysis - understands system architecture
+
+## Related Issues
+
+- #41 - Race condition in SaksopplysningKilde (melosys-api)
+- #57, #58, #59 - E2E failures (symptoms of #41)
+
+## Related PRs (Copilot's workarounds)
+
+- PR #60 - Waits in eu-eos-behandling.page.ts
+- PR #61 - Waits in test file (duplicate code)
+- PR #62 - Network idle wait changes
+
+These PRs add workarounds, not real fixes. Consider closing them.


### PR DESCRIPTION
## Summary

- Disabled automatic Copilot assignment for E2E failure issues
- Added knowledge document documenting our experiment and findings
- Kept improved issue template with better context and labels

## Background

We experimented with using GitHub Copilot Coding Agent to automatically analyze E2E test failures. The goal was to have Copilot:
1. Identify root cause location (melosys-api vs melosys-web vs test code)
2. Link to existing issues (like #41)
3. Classify and label issues appropriately

## What We Found

**Copilot limitations:**
- No "analyze only" mode - always creates PRs regardless of instructions
- Repo-scoped - cannot search melosys-api for root causes  
- Creates workarounds (adding waits) instead of identifying real issues
- Doesn't detect duplicates or link to related issues

**Example:** For issues #57, #58, #59 (all related to #41's backend race condition), Copilot created PRs #60, #61, #62 that just add more waits in test code - treating symptoms, not causes.

## Changes

1. **Workflow** (`analyze-e2e-failures.yml`):
   - Disabled auto-assignment of Copilot
   - Kept improved issue template with labels and known issues reference
   - Added manual assignment instructions in comments

2. **Documentation** (`docs/copilot-analysis-experiment.md`):
   - What we tried and results
   - Copilot vs Claude Code comparison
   - Manual assignment instructions
   - Checklist for when to revisit

## What Still Works

- Issues are created automatically for failed/flaky tests
- Rich context: error messages, Docker logs, image tags
- New labels: `backend-bug`, `frontend-bug`, `test-bug`, `flaky-test`
- Reference to known issues (#41) in template
- Humans triage and decide next steps

## Test plan

- [x] Verify workflow still creates issues on test failure
- [x] Verify Copilot is NOT auto-assigned
- [x] Documentation is clear for future reference