### PR TITLE
Fix step transition race condition in arbeid-flere-land

### DIFF
--- a/pages/behandling/arbeid-flere-land-behandling.page.ts
+++ b/pages/behandling/arbeid-flere-land-behandling.page.ts
@@ -307,9 +307,10 @@ export class ArbeidFlereLandBehandlingPage extends BasePage {
    * IMPORTANT: This method waits for specific step transition API calls AND
    * optionally waits for specific content to appear on the next step.
    *
-   * @param waitForContent - Optional: Selector or text to wait for on next step.
-   *                         This ensures React has finished rendering before proceeding.
-   * @param waitForContentTimeout - Timeout for waiting for content (default: 30000ms)
+   * @param options - Optional configuration for step transition
+   * @param options.waitForContent - Optional Locator to wait for on the next step.
+   *                                 This ensures React has finished rendering before proceeding.
+   * @param options.waitForContentTimeout - Timeout in ms for waiting for content (default: 30000ms)
    *
    * @example
    * // Basic usage - just wait for API and network idle


### PR DESCRIPTION
## Summary
- Fixes flaky "Arbeid i flere land" tests that were timing out
- Simplified `klikkBekreftOgFortsett()` to wait for API responses + networkidle
- Removed faulty heading-change detection that was causing 15s delays per step

## Problem
Tests were failing with "Test timeout of 120000ms exceeded" because:
1. Initial fix tried to wait for step heading (h1) to change
2. The selector captured "Kontroller inngangsvilkår" (persistent sidebar heading)
3. This heading never changes, causing 15s timeout on each of 6-7 steps
4. Total extra wait: ~90-105s → test timeout

## Solution
Simplified back to reliable approach:
- Wait for step transition APIs (`/api/avklartefakta/`, `/api/vilkaar/`)
- Short React settle time (500ms)
- networkidle fallback

## Test plan
- [x] Triggered CI run on this branch
- [ ] Verify arbeid-flere-land tests pass
- [ ] Verify no regression in other EU/EØS tests