### PR TITLE
7714 7831  E2E-tester for MELOSYS-7714 og MELOSYS-7831

### DIFF
--- a/pages/behandling/behandlingsmeny.page.ts
+++ b/pages/behandling/behandlingsmeny.page.ts
@@ -1,0 +1,76 @@
+import { Page } from '@playwright/test';
+import { BasePage } from '../shared/base.page';
+
+/**
+ * Page Object for Behandlingsmeny (hamburger menu)
+ *
+ * Responsibilities:
+ * - Open/close the hamburger menu
+ * - Navigate "Avslutt behandling" accordion
+ * - Perform bortfall (mark treatment as lapsed)
+ *
+ * UI structure (from behandlingsmeny.tsx):
+ * - Hamburger button: role="button", aria-label="Behandlingsmeny"
+ * - Accordion with two sections:
+ *   - "Legg behandling tilbake"
+ *   - "Avslutt behandling"
+ * - Actions under "Avslutt behandling" include:
+ *   - "Behandlingen er bortfalt" → opens confirmation modal
+ *
+ * Confirmation modal (from dialogboksBekreftValg.tsx):
+ * - Title: "Avslutt behandling som bortfalt"
+ * - Buttons: "Bekreft" and "Avbryt"
+ *
+ * @example
+ * const behandlingsmeny = new BehandlingsmenyPage(page);
+ * await behandlingsmeny.bortfallBehandling();
+ */
+export class BehandlingsmenyPage extends BasePage {
+  private readonly hamburgerButton = this.page.locator('[aria-label="Behandlingsmeny"]');
+  private readonly avsluttBehandlingHeader = this.page.getByRole('button', { name: 'Avslutt behandling' });
+  private readonly behandlingenErBortfaltButton = this.page.getByRole('button', { name: 'Behandlingen er bortfalt' });
+  private readonly bekreftButton = this.page.getByRole('button', { name: 'Bekreft' });
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Open the hamburger menu
+   */
+  async åpneMeny(): Promise<void> {
+    await this.hamburgerButton.click();
+    console.log('✅ Opened behandlingsmeny');
+  }
+
+  /**
+   * Mark the current treatment as bortfalt (lapsed)
+   *
+   * Steps:
+   * 1. Click hamburger menu button
+   * 2. Expand "Avslutt behandling" accordion
+   * 3. Click "Behandlingen er bortfalt"
+   * 4. Confirm in modal by clicking "Bekreft"
+   * 5. Wait for navigation back to frontpage
+   */
+  async bortfallBehandling(): Promise<void> {
+    await this.åpneMeny();
+
+    // Expand "Avslutt behandling" accordion
+    await this.avsluttBehandlingHeader.click();
+    console.log('   Expanded "Avslutt behandling" accordion');
+
+    // Click "Behandlingen er bortfalt"
+    await this.behandlingenErBortfaltButton.click();
+    console.log('   Clicked "Behandlingen er bortfalt"');
+
+    // Wait for confirmation modal and click "Bekreft"
+    await this.bekreftButton.waitFor({ state: 'visible' });
+    await this.bekreftButton.click();
+    console.log('   Confirmed bortfall');
+
+    // Wait for navigation away from behandling page
+    await this.page.waitForLoadState('networkidle');
+    console.log('✅ Behandling marked as bortfalt');
+  }
+}

--- a/pages/behandling/oppsummering.page.ts
+++ b/pages/behandling/oppsummering.page.ts
@@ -1,0 +1,73 @@
+import { Page, expect } from '@playwright/test';
+import { BasePage } from '../shared/base.page';
+
+/**
+ * Page Object for Oppsummering (Summary) section and EndreBehandling modal
+ *
+ * Responsibilities:
+ * - Open the "Endre behandling" modal
+ * - Verify behandlingstema editability and fakturaserie message
+ * - Close the modal
+ *
+ * UI structure (from endreBehandlingModal.tsx):
+ * - "Endre" button opens the modal
+ * - Modal contains selects for: Sakstype, Sakstema, Behandlingstema, Behandlingstype
+ * - When harBehandlingMedTrygdeavgift is true:
+ *   - Behandlingstema select is readOnly
+ *   - Message: "Du kan ikke endre behandlingstema når saken har en tilknyttet fakturaserie."
+ * - "Avbryt" button closes the modal
+ *
+ * @example
+ * const oppsummering = new OppsummeringPage(page);
+ * await oppsummering.klikkEndre();
+ * await oppsummering.verifiserBehandlingstemaRedigerbar();
+ * await oppsummering.verifiserIngenFakturaserieMelding();
+ * await oppsummering.lukkModal();
+ */
+export class OppsummeringPage extends BasePage {
+  private readonly endreButton = this.page.getByRole('button', { name: 'Endre' });
+  private readonly avbrytButton = this.page.getByRole('button', { name: 'Avbryt' });
+  private readonly fakturaserieMelding = this.page.getByText('tilknyttet fakturaserie');
+  private readonly behandlingstemaSelect = this.page.getByLabel('Behandlingstema');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  /**
+   * Click the "Endre" button to open the EndreBehandling modal
+   */
+  async klikkEndre(): Promise<void> {
+    await this.endreButton.click();
+    // Wait for modal to be visible
+    await this.page.getByText('Sakstype').waitFor({ state: 'visible' });
+    console.log('✅ Opened EndreBehandling modal');
+  }
+
+  /**
+   * Verify that the Behandlingstema select is editable (not read-only)
+   * This confirms bugfix Feil 1: field should be editable before ferdigbehandling
+   */
+  async verifiserBehandlingstemaRedigerbar(): Promise<void> {
+    await expect(this.behandlingstemaSelect).toBeVisible();
+    await expect(this.behandlingstemaSelect).toBeEnabled();
+    console.log('✅ Behandlingstema is editable');
+  }
+
+  /**
+   * Verify that the "tilknyttet fakturaserie" message is NOT visible
+   * This confirms bugfix Feil 1: no false warning about fakturaserie
+   */
+  async verifiserIngenFakturaserieMelding(): Promise<void> {
+    await expect(this.fakturaserieMelding).not.toBeVisible();
+    console.log('✅ No "tilknyttet fakturaserie" message visible');
+  }
+
+  /**
+   * Close the modal by clicking "Avbryt"
+   */
+  async lukkModal(): Promise<void> {
+    await this.avbrytButton.click();
+    console.log('✅ Closed EndreBehandling modal');
+  }
+}

--- a/tests/utenfor-avtaleland/workflows/arsavregning-manuell-endelig-avgift.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/arsavregning-manuell-endelig-avgift.spec.ts
@@ -1,0 +1,228 @@
+import {test} from '../../../fixtures';
+import {AuthHelper} from '../../../helpers/auth-helper';
+import {HovedsidePage} from '../../../pages/hovedside.page';
+import {OpprettNySakPage} from '../../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import {MedlemskapPage} from '../../../pages/behandling/medlemskap.page';
+import {ArbeidsforholdPage} from '../../../pages/behandling/arbeidsforhold.page';
+import {LovvalgPage} from '../../../pages/behandling/lovvalg.page';
+import {ResultatPeriodePage} from '../../../pages/behandling/resultat-periode.page';
+import {TrygdeavgiftPage} from '../../../pages/trygdeavgift/trygdeavgift.page';
+import {VedtakPage} from '../../../pages/vedtak/vedtak.page';
+import {USER_ID_VALID} from '../../../pages/shared/constants';
+import {UnleashHelper} from '../../../helpers/unleash-helper';
+import {waitForProcessInstances} from '../../../helpers/api-helper';
+import {expect} from '@playwright/test';
+
+
+test.describe('Årsavregning - Manuell endelig avgift (MELOSYS-7714)', () => {
+    test('skal fatte vedtak med manuell avgift uten feil i VARSLE_PENSJONSOPPTJENING', async ({page, request}) => {
+        // Extended timeout for this complex multi-step test (2 vedtak cycles)
+        test.setTimeout(120_000);
+
+        // Setup: Authentication and feature toggles
+        const auth = new AuthHelper(page);
+        const unleash = new UnleashHelper(request);
+
+        // Ensure POPP toggle is enabled so VARSLE_PENSJONSOPPTJENING actually runs
+        await unleash.enableFeature('melosys.send_popp_hendelse');
+        // Disable fakturering toggle (same as arsavregning-ikke-skattepliktig test)
+        await unleash.disableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+
+        await auth.login();
+
+        // Page objects
+        const hovedside = new HovedsidePage(page);
+        const opprettSak = new OpprettNySakPage(page);
+        const medlemskap = new MedlemskapPage(page);
+        const arbeidsforhold = new ArbeidsforholdPage(page);
+        const lovvalg = new LovvalgPage(page);
+        const resultatPeriode = new ResultatPeriodePage(page);
+        const trygdeavgift = new TrygdeavgiftPage(page);
+        const vedtak = new VedtakPage(page);
+
+        // ============================================================
+        // Part 1: Create initial case with vedtak
+        // (Same setup as arsavregning-ikke-skattepliktig.spec.ts)
+        // ============================================================
+
+        console.log('📝 Part 1: Creating initial case with vedtak...');
+
+        // Step 1: Create new FTRL case
+        console.log('📝 Step 1: Creating new case...');
+        await hovedside.gotoOgOpprettNySak();
+        await opprettSak.opprettStandardSak(USER_ID_VALID);
+        await opprettSak.assertions.verifiserBehandlingOpprettet();
+
+        // Step 2: Navigate to behandling
+        console.log('📝 Step 2: Opening behandling...');
+        await waitForProcessInstances(page.request, 30);
+        await hovedside.goto();
+        await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).click();
+
+        // Step 3: Fill Medlemskap
+        console.log('📝 Step 3: Filling medlemskap...');
+        await medlemskap.velgPeriode('01.01.2023', '01.07.2024');
+        await medlemskap.velgLand('Afghanistan');
+        await medlemskap.velgTrygdedekning('FTRL_2_9_FØRSTE_LEDD_C_HELSE_PENSJON');
+        await medlemskap.klikkBekreftOgFortsett();
+
+        // Step 4: Fill Arbeidsforhold
+        console.log('📝 Step 4: Selecting arbeidsforhold...');
+        await arbeidsforhold.fyllUtArbeidsforhold('Ståles Stål AS');
+
+        // Step 5: Fill Lovvalg
+        console.log('📝 Step 5: Answering lovvalg questions...');
+        await lovvalg.velgBestemmelse('FTRL_KAP2_2_8_FØRSTE_LEDD_A');
+        await lovvalg.svarJaPaaFørsteSpørsmål();
+        await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker vært medlem i minst');
+        await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker nær tilknytning til');
+        await lovvalg.klikkBekreftOgFortsett();
+
+        // Step 6: Fill Resultat Periode
+        console.log('📝 Step 6: Selecting resultat periode...');
+        await resultatPeriode.fyllUtResultatPeriode('INNVILGET');
+
+        // Step 7: Fill Trygdeavgift (ikke-skattepliktig)
+        console.log('📝 Step 7: Filling trygdeavgift...');
+        await trygdeavgift.ventPåSideLastet();
+        await trygdeavgift.velgSkattepliktig(false);
+        await trygdeavgift.velgSkattepliktig(false);
+        await trygdeavgift.velgInntektskilde('INNTEKT_FRA_UTLANDET');
+        await trygdeavgift.velgBetalesAga(false);
+        await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
+        await trygdeavgift.klikkBekreftOgFortsett();
+
+        // Step 8: Fatt initial vedtak
+        console.log('📝 Step 8: Making initial decision...');
+        await vedtak.klikkFattVedtak();
+
+        console.log('📝 Step 9: Waiting for process instances after initial vedtak...');
+        await waitForProcessInstances(page.request, 30);
+
+        // ============================================================
+        // Part 2: Create årsavregning with MANUELL_ENDELIG_AVGIFT
+        // ============================================================
+
+        console.log('📝 Part 2: Creating årsavregning with manuell endelig avgift...');
+
+        // Step 10: Navigate back to fagsak
+        console.log('📝 Step 10: Navigating back to fagsak...');
+        await hovedside.goto();
+        await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).click();
+
+        // Step 11: Navigate to Årsavregning tab
+        console.log('📝 Step 11: Opening årsavregning tab...');
+        const aarsavregningTab = page.locator('button[role="tab"]:has-text("Årsavregning")');
+        await aarsavregningTab.waitFor({state: 'visible', timeout: 10_000});
+        await aarsavregningTab.click();
+
+        // Verify årsavregning page loaded
+        await expect(
+            page.getByRole('heading', {name: 'Årsavregning'}),
+            'Årsavregning-overskrift skal være synlig'
+        ).toBeVisible({timeout: 10_000});
+
+        // Step 12: Select year from dropdown
+        console.log('📝 Step 12: Selecting year...');
+        const årDropdown = page.getByRole('combobox', {name: 'År'});
+        await årDropdown.waitFor({state: 'visible', timeout: 10_000});
+
+        // Get first available year
+        const førsteÅr = await årDropdown.locator('option:not([disabled])').first().textContent();
+        expect(førsteÅr, 'Skal finne tilgjengelig år i dropdown').toBeTruthy();
+
+        // Set up API listener before selecting year (creates årsavregning via POST)
+        const aarsavregningResponsePromise = page.waitForResponse(
+            response =>
+                response.url().includes('/aarsavregninger') &&
+                !response.url().includes('/grunnlagstype') &&
+                response.request().method() === 'POST',
+            {timeout: 15_000}
+        ).catch(() => null);
+
+        await årDropdown.selectOption({label: førsteÅr!.trim()});
+        await aarsavregningResponsePromise;
+        console.log(`✅ Selected year: ${førsteÅr!.trim()}`);
+
+        // Step 13: Handle "Skal du legge til trygdeavgift fra Avgiftssystemet?" question
+        console.log('📝 Step 13: Answering trygdeavgift fra Avgiftssystemet question...');
+        const trygdeavgiftSpørsmål = page.getByText(
+            'Skal du legge til trygdeavgift fra Avgiftssystemet til denne årsavregningen?'
+        );
+        await trygdeavgiftSpørsmål.waitFor({state: 'visible', timeout: 10_000});
+
+        // Answer "Nei" - we want to manually set the avgift, not use external data
+        const neiRadio = page.getByRole('radio', {name: 'Nei'}).first();
+        await neiRadio.waitFor({state: 'visible', timeout: 5_000});
+
+        // Set up API listener for grunnlagstype update
+        const grunnlagstypeResponsePromise = page.waitForResponse(
+            response =>
+                response.url().includes('/grunnlagstype') &&
+                response.request().method() === 'POST',
+            {timeout: 15_000}
+        ).catch(() => null);
+
+        await neiRadio.check();
+        await grunnlagstypeResponsePromise;
+        console.log('✅ Answered "Nei" to Avgiftssystemet question');
+
+        // Step 14: Select "Oppgi endelig beregnet trygdeavgift" (MANUELL_ENDELIG_AVGIFT)
+        console.log('📝 Step 14: Selecting manuell endelig avgift...');
+        const manuellRadio = page.getByRole('radio', {name: 'Oppgi endelig beregnet trygdeavgift'});
+        await manuellRadio.waitFor({state: 'visible', timeout: 15_000});
+
+        // Set up API listener for endeligAvgiftValg change
+        const endeligAvgiftResponsePromise = page.waitForResponse(
+            response =>
+                response.url().includes('/endeligAvgift') &&
+                response.request().method() === 'PUT',
+            {timeout: 15_000}
+        );
+
+        await manuellRadio.check();
+        await endeligAvgiftResponsePromise;
+        console.log('✅ Selected "Oppgi endelig beregnet trygdeavgift" (MANUELL_ENDELIG_AVGIFT)');
+
+        // Step 15: Enter manuelt avgift beløp
+        console.log('📝 Step 15: Entering manuelt beløp...');
+        const belopInput = page.getByRole('textbox', {name: 'Endelig beregnet trygdeavgift'});
+        await belopInput.waitFor({state: 'visible', timeout: 10_000});
+
+        // Set up API listener for manuelt beløp update (debounced PUT)
+        const manueltBelopResponsePromise = page.waitForResponse(
+            response =>
+                response.url().includes('/aarsavregninger') &&
+                response.request().method() === 'PUT' &&
+                response.status() === 200,
+            {timeout: 15_000}
+        );
+
+        await belopInput.fill('75000');
+        await belopInput.press('Tab'); // Trigger blur/debounce
+        await manueltBelopResponsePromise;
+        console.log('✅ Entered manuelt beløp: 75000');
+
+        // Step 16: Click "Bekreft og fortsett"
+        console.log('📝 Step 16: Confirming årsavregning...');
+        const bekreftButton = page.getByRole('button', {name: 'Bekreft og fortsett'});
+        await expect(bekreftButton).toBeEnabled({timeout: 10_000});
+        await bekreftButton.click();
+
+        // Step 17: Fatt vedtak for årsavregning
+        console.log('📝 Step 17: Fatting vedtak for årsavregning...');
+        await vedtak.klikkFattVedtak();
+
+        // Step 18: Wait for process instances (IVERKSETT_VEDTAK_AARSAVREGNING)
+        // This is the critical assertion: VARSLE_PENSJONSOPPTJENING should
+        // skip POPP-hendelse for MANUELL_ENDELIG_AVGIFT instead of failing
+        console.log('📝 Step 18: Waiting for IVERKSETT_VEDTAK_AARSAVREGNING process...');
+        await waitForProcessInstances(page.request, 30);
+
+        // Re-enable toggle (cleanup)
+        await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+
+        console.log('✅ MELOSYS-7714: Årsavregning med MANUELL_ENDELIG_AVGIFT fullført uten feil!');
+        console.log('✅ VARSLE_PENSJONSOPPTJENING hoppet over POPP-hendelse for manuell avgift');
+    });
+});

--- a/tests/utenfor-avtaleland/workflows/trygdeavgift-kontroller.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/trygdeavgift-kontroller.spec.ts
@@ -1,0 +1,233 @@
+import { test, expect } from '../../../fixtures';
+import { AuthHelper } from '../../../helpers/auth-helper';
+import { waitForProcessInstances } from '../../../helpers/api-helper';
+import { HovedsidePage } from '../../../pages/hovedside.page';
+import { OpprettNySakPage } from '../../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import { BehandlingPage } from '../../../pages/behandling/behandling.page';
+import { MedlemskapPage } from '../../../pages/behandling/medlemskap.page';
+import { ArbeidsforholdPage } from '../../../pages/behandling/arbeidsforhold.page';
+import { LovvalgPage } from '../../../pages/behandling/lovvalg.page';
+import { TrygdeavgiftPage } from '../../../pages/trygdeavgift/trygdeavgift.page';
+import { VedtakPage } from '../../../pages/vedtak/vedtak.page';
+import { BehandlingsmenyPage } from '../../../pages/behandling/behandlingsmeny.page';
+import { OppsummeringPage } from '../../../pages/behandling/oppsummering.page';
+import { USER_ID_VALID } from '../../../pages/shared/constants';
+
+/**
+ * Trygdeavgift-kontroller E2E-tester
+ *
+ * Tester to bugfikser (MELOSYS-7831):
+ *
+ * Feil 1: harBehandlingMedTrygdeavgift returnerte true for tidlig
+ *   - Fikset i TrygdeavgiftFagsakController.kt: sjekkFakturaserie=true
+ *   - Resultat: Behandlingstema skal være redigerbar FØR ferdigbehandling
+ *
+ * Feil 2: Kontroll ga advarsler om overlappende periode for bortfalte saker
+ *   - Fikset i Kontroll.kt: filtrer bort saker med UGYLDIGE_SAKSSTATUSER_FOR_TRYGDEAVGIFT
+ *   - Resultat: Bortfalt sak skal IKKE trigge advarsel på ny sak
+ *
+ * Flow: FTRL YRKESAKTIV (bevist i eksisterende E2E-tester)
+ */
+
+test.describe('Trygdeavgift-kontroller', () => {
+
+  test('Behandlingstema skal være redigerbar før ferdigbehandling', async ({ page }) => {
+    // Setup
+    const auth = new AuthHelper(page);
+    await auth.login();
+
+    const hovedside = new HovedsidePage(page);
+    const opprettSak = new OpprettNySakPage(page);
+    const behandling = new BehandlingPage(page);
+    const medlemskap = new MedlemskapPage(page);
+    const arbeidsforhold = new ArbeidsforholdPage(page);
+    const lovvalg = new LovvalgPage(page);
+    const trygdeavgift = new TrygdeavgiftPage(page);
+    const oppsummering = new OppsummeringPage(page);
+
+    // Steg 1: Opprett FTRL YRKESAKTIV sak
+    console.log('📋 Steg 1: Opprett sak');
+    await hovedside.gotoOgOpprettNySak();
+    await opprettSak.opprettStandardSak(USER_ID_VALID);
+
+    // Steg 2: Klikk på saken for å åpne den
+    console.log('📋 Steg 2: Åpne saken');
+    await page.getByRole('link', { name: 'TRIVIELL KARAFFEL -' }).click();
+
+    // Steg 3: Rediger dato
+    await behandling.endreDatoMedDatovelger('2024', 'november', 'fredag 1');
+
+    // Steg 4: Medlemskap
+    console.log('📋 Steg 3: Medlemskap');
+    await medlemskap.velgPeriode('01.11.2024', '14.11.2024');
+    await medlemskap.velgFlereLandIkkeKjentHvilke();
+    await medlemskap.velgTrygdedekning('FTRL_2_9_FØRSTE_LEDD_C_HELSE_PENSJON');
+    await medlemskap.klikkBekreftOgFortsett();
+
+    // Steg 5: Arbeidsforhold
+    console.log('📋 Steg 4: Arbeidsforhold');
+    await arbeidsforhold.fyllUtArbeidsforhold('Ståles Stål AS');
+
+    // Steg 6: Lovvalg
+    console.log('📋 Steg 5: Lovvalg');
+    await lovvalg.velgBestemmelse('FTRL_KAP2_2_8_FØRSTE_LEDD_A');
+    await lovvalg.svarJaPaaFørsteSpørsmål();
+    await lovvalg.svarJaPaaSpørsmål(['Har søker vært medlem i minst', 'Har søker nær tilknytning til']);
+    await lovvalg.klikkBekreftOgFortsettMedVent();
+    await lovvalg.klikkBekreftOgFortsettMedVent();
+
+    // Steg 7: Trygdeavgift - beregn trygdeavgift (men IKKE fatt vedtak)
+    console.log('📋 Steg 6: Trygdeavgift');
+    await behandling.gåTilTrygdeavgift();
+    await trygdeavgift.ventPåSideLastet();
+    await trygdeavgift.velgSkattepliktig(true);
+    await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
+    await trygdeavgift.klikkBekreftOgFortsett();
+
+    // Steg 8: Verifiser at behandlingstema er redigerbar i EndreBehandling-modalen
+    console.log('📋 Steg 7: Verifiser EndreBehandling-modal');
+    await oppsummering.klikkEndre();
+    await oppsummering.verifiserBehandlingstemaRedigerbar();
+    await oppsummering.verifiserIngenFakturaserieMelding();
+    await oppsummering.lukkModal();
+
+    console.log('✅ Test fullført: Behandlingstema er redigerbar før ferdigbehandling');
+  });
+
+  test('Bortfalt sak skal ikke gi kontroll-advarsel på ny sak', async ({ page, request }) => {
+    // Setup
+    const auth = new AuthHelper(page);
+    await auth.login();
+
+    const hovedside = new HovedsidePage(page);
+    const opprettSak = new OpprettNySakPage(page);
+    const behandling = new BehandlingPage(page);
+    const medlemskap = new MedlemskapPage(page);
+    const arbeidsforhold = new ArbeidsforholdPage(page);
+    const lovvalg = new LovvalgPage(page);
+    const trygdeavgift = new TrygdeavgiftPage(page);
+    const vedtak = new VedtakPage(page);
+    const behandlingsmeny = new BehandlingsmenyPage(page);
+
+    // ========== SAK 1: Opprett, ferdigbehandl, og bortfall ==========
+
+    // Steg 1: Opprett FTRL YRKESAKTIV sak
+    console.log('📋 SAK 1 - Steg 1: Opprett sak');
+    await hovedside.gotoOgOpprettNySak();
+    await opprettSak.opprettStandardSak(USER_ID_VALID);
+
+    // Steg 2: Åpne saken
+    console.log('📋 SAK 1 - Steg 2: Åpne saken');
+    await page.getByRole('link', { name: 'TRIVIELL KARAFFEL -' }).click();
+    await behandling.endreDatoMedDatovelger('2024', 'november', 'fredag 1');
+
+    // Steg 3: Medlemskap
+    console.log('📋 SAK 1 - Steg 3: Medlemskap');
+    await medlemskap.velgPeriode('01.11.2024', '14.11.2024');
+    await medlemskap.velgFlereLandIkkeKjentHvilke();
+    await medlemskap.velgTrygdedekning('FTRL_2_9_FØRSTE_LEDD_C_HELSE_PENSJON');
+    await medlemskap.klikkBekreftOgFortsett();
+
+    // Steg 4: Arbeidsforhold
+    console.log('📋 SAK 1 - Steg 4: Arbeidsforhold');
+    await arbeidsforhold.fyllUtArbeidsforhold('Ståles Stål AS');
+
+    // Steg 5: Lovvalg
+    console.log('📋 SAK 1 - Steg 5: Lovvalg');
+    await lovvalg.velgBestemmelse('FTRL_KAP2_2_8_FØRSTE_LEDD_A');
+    await lovvalg.svarJaPaaFørsteSpørsmål();
+    await lovvalg.svarJaPaaSpørsmål(['Har søker vært medlem i minst', 'Har søker nær tilknytning til']);
+    await lovvalg.klikkBekreftOgFortsettMedVent();
+    await lovvalg.klikkBekreftOgFortsettMedVent();
+
+    // Steg 6: Trygdeavgift
+    console.log('📋 SAK 1 - Steg 6: Trygdeavgift');
+    await behandling.gåTilTrygdeavgift();
+    await trygdeavgift.ventPåSideLastet();
+    await trygdeavgift.velgSkattepliktig(true);
+    await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
+    await trygdeavgift.klikkBekreftOgFortsett();
+
+    // Steg 7: Fatt vedtak
+    console.log('📋 SAK 1 - Steg 7: Fatt vedtak');
+    await vedtak.fattVedtak('fritekst', 'begrunnelse', 'trygdeavgift');
+
+    // Vent på asynkrone prosesser
+    await waitForProcessInstances(request, 30);
+
+    // Steg 8: Bortfall saken via behandlingsmeny
+    console.log('📋 SAK 1 - Steg 8: Bortfall saken');
+
+    // Naviger tilbake til saken (etter vedtak navigerer vi til forsiden)
+    await hovedside.goto();
+    await hovedside.åpneSak('TRIVIELL KARAFFEL');
+    await behandlingsmeny.bortfallBehandling();
+
+    // Vent på asynkrone prosesser etter bortfall
+    await waitForProcessInstances(request, 30);
+
+    // ========== SAK 2: Opprett ny sak med overlappende periode ==========
+
+    // Steg 9: Opprett ny sak for SAMME bruker
+    console.log('📋 SAK 2 - Steg 1: Opprett ny sak med overlappende periode');
+    await hovedside.gotoOgOpprettNySak();
+    await opprettSak.opprettStandardSak(USER_ID_VALID);
+
+    // Steg 10: Åpne saken
+    console.log('📋 SAK 2 - Steg 2: Åpne saken');
+    await page.getByRole('link', { name: 'TRIVIELL KARAFFEL -' }).click();
+    await behandling.endreDatoMedDatovelger('2024', 'november', 'fredag 1');
+
+    // Steg 11: Medlemskap med overlappende periode
+    console.log('📋 SAK 2 - Steg 3: Medlemskap (overlappende periode)');
+    await medlemskap.velgPeriode('01.11.2024', '14.11.2024');
+    await medlemskap.velgFlereLandIkkeKjentHvilke();
+    await medlemskap.velgTrygdedekning('FTRL_2_9_FØRSTE_LEDD_C_HELSE_PENSJON');
+    await medlemskap.klikkBekreftOgFortsett();
+
+    // Steg 12: Arbeidsforhold
+    console.log('📋 SAK 2 - Steg 4: Arbeidsforhold');
+    await arbeidsforhold.fyllUtArbeidsforhold('Ståles Stål AS');
+
+    // Steg 13: Lovvalg
+    console.log('📋 SAK 2 - Steg 5: Lovvalg');
+    await lovvalg.velgBestemmelse('FTRL_KAP2_2_8_FØRSTE_LEDD_A');
+    await lovvalg.svarJaPaaFørsteSpørsmål();
+    await lovvalg.svarJaPaaSpørsmål(['Har søker vært medlem i minst', 'Har søker nær tilknytning til']);
+    await lovvalg.klikkBekreftOgFortsettMedVent();
+    await lovvalg.klikkBekreftOgFortsettMedVent();
+
+    // Steg 14: Trygdeavgift
+    console.log('📋 SAK 2 - Steg 6: Trygdeavgift');
+    await behandling.gåTilTrygdeavgift();
+    await trygdeavgift.ventPåSideLastet();
+    await trygdeavgift.velgSkattepliktig(true);
+    await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
+    await trygdeavgift.klikkBekreftOgFortsett();
+
+    // Steg 15: Gå til vedtakssiden og verifiser INGEN advarsel
+    console.log('📋 SAK 2 - Steg 7: Verifiser ingen kontroll-advarsel på vedtakssiden');
+    await behandling.gåTilVedtak();
+
+    // Vent på at vedtakssiden er lastet
+    await page.waitForLoadState('networkidle');
+    await page.waitForTimeout(1000);
+
+    // VERIFISERING: Ingen .navds-alert--warning skal vises
+    // Kontroll-advarsler vises via feilmeldinger.tsx med klassen .advarsler-container
+    const warningAlerts = page.locator('.navds-alert--warning');
+    const warningCount = await warningAlerts.count();
+
+    if (warningCount > 0) {
+      const warningTexts: string[] = [];
+      for (let i = 0; i < warningCount; i++) {
+        const text = await warningAlerts.nth(i).textContent();
+        warningTexts.push(text || '');
+      }
+      console.error(`❌ Uventede advarsler funnet: ${warningTexts.join(', ')}`);
+    }
+
+    expect(warningCount).toBe(0);
+    console.log('✅ Test fullført: Ingen kontroll-advarsel for bortfalt sak');
+  });
+});


### PR DESCRIPTION
Summary

  - E2E-test for MELOSYS-7714: Verifiserer at årsavregning med MANUELL_ENDELIG_AVGIFT fullføres uten feil i VARSLE_PENSJONSOPPTJENING
  - E2E-tester for MELOSYS-7831: Verifiserer to bugfikser i trygdeavgift-kontroller (behandlingstema redigerbar + bortfalt sak gir ikke falsk advarsel)
  - Nye Page Object Models: BehandlingsmenyPage (hamburgermeny/bortfall) og OppsummeringPage (EndreBehandling-modal)

MELOSYS-7714 - Årsavregning med manuell endelig avgift:

  Ny test som oppretter en FTRL-sak med trygdeavgift (ikke-skattepliktig), navigerer til årsavregning, velger MANUELL_ENDELIG_AVGIFT, fatter vedtak og verifiserer at
  alle prosessinstanser (inkl. VARSLE_PENSJONSOPPTJENING) fullføres uten feil.

MELOSYS-7831 - Trygdeavgift-kontroller:

  To tester som dekker bugfiksene:
  1. Feil 1: Behandlingstema skal være redigerbar i EndreBehandling-modal før ferdigbehandling (fikset i TrygdeavgiftFagsakController)
  2. Feil 2: Bortfalt sak skal ikke trigge kontroll-advarsel om overlappende periode på ny sak (fikset i Kontroll.kt)

  Nye POMs

  - pages/behandling/behandlingsmeny.page.ts - Hamburgermeny og bortfall-handling
  - pages/behandling/oppsummering.page.ts - EndreBehandling-modal med verifikasjoner

  Test plan

  - Kjør arsavregning-manuell-endelig-avgift.spec.ts - vedtak fattes uten feil
  - Kjør trygdeavgift-kontroller.spec.ts - begge tester passerer
  - Verifiser at eksisterende tester ikke påvirkes