### PR TITLE
7795 E2E-tester for papir-A1 til ikke-EESSI-land (FO/GL)

### DIFF
--- a/helpers/db-helper.ts
+++ b/helpers/db-helper.ts
@@ -2,7 +2,7 @@ import oracledb from 'oracledb';
 
 /**
  * Database helper for verifying data in Oracle database
- *
+ * 
  * Usage:
  *   const db = new DatabaseHelper();
  *   await db.connect();
@@ -10,305 +10,304 @@ import oracledb from 'oracledb';
  *   await db.close();
  */
 export class DatabaseHelper {
-    private connection: oracledb.Connection | null = null;
+  private connection: oracledb.Connection | null = null;
 
-    /**
-     * Connect to Oracle database running in Docker Compose
-     */
-    async connect() {
-        if (this.connection) {
-            return;
-        }
-
-        try {
-            this.connection = await oracledb.getConnection({
-                user: process.env.DB_USER || 'MELOSYS',
-                password: process.env.DB_PASSWORD || 'melosyspwd',
-                connectString: process.env.DB_CONNECT_STRING || 'localhost:1521/freepdb1'
-            });
-
-            console.log('✅ Connected to Oracle database');
-        } catch (error) {
-            console.error('❌ Failed to connect to database:', error);
-            throw error;
-        }
+  /**
+   * Connect to Oracle database running in Docker Compose
+   */
+  async connect() {
+    if (this.connection) {
+      return;
     }
 
-    /**
-     * Execute a query
-     * @param suppressErrors - If true, don't log errors to console (useful when probing for table existence)
-     */
-    async query<T = any>(sql: string, binds: any = {}, suppressErrors = false): Promise<T[]> {
-        if (!this.connection) {
-            throw new Error('Database not connected. Call connect() first.');
-        }
+    try {
+      // Return CLOB columns as strings instead of LOB stream objects
+      oracledb.fetchAsString = [oracledb.CLOB];
 
-        try {
-            const result = await this.connection.execute(sql, binds, {
-                outFormat: oracledb.OUT_FORMAT_OBJECT
-            });
+      this.connection = await oracledb.getConnection({
+        user: process.env.DB_USER || 'MELOSYS',
+        password: process.env.DB_PASSWORD || 'melosyspwd',
+        connectString: process.env.DB_CONNECT_STRING || `localhost:1521/${process.env.MELOSYS_ORACLE_DB_NAME || 'freepdb1'}`
+      });
+      
+      console.log('✅ Connected to Oracle database');
+    } catch (error) {
+      console.error('❌ Failed to connect to database:', error);
+      throw error;
+    }
+  }
 
-            return (result.rows || []) as T[];
-        } catch (error) {
-            if (!suppressErrors) {
-                console.error('❌ Query failed:', error);
-            }
-            throw error;
-        }
+  /**
+   * Execute a query
+   * @param suppressErrors - If true, don't log errors to console (useful when probing for table existence)
+   */
+  async query<T = any>(sql: string, binds: any = {}, suppressErrors = false): Promise<T[]> {
+    if (!this.connection) {
+      throw new Error('Database not connected. Call connect() first.');
     }
 
-    /**
-     * Execute a single query and return first row
-     */
-    async queryOne<T = any>(sql: string, binds: any = {}): Promise<T | null> {
-        const results = await this.query<T>(sql, binds);
-        return results.length > 0 ? results[0] : null;
+    try {
+      const result = await this.connection.execute(sql, binds, {
+        outFormat: oracledb.OUT_FORMAT_OBJECT
+      });
+
+      return (result.rows || []) as T[];
+    } catch (error) {
+      if (!suppressErrors) {
+        console.error('❌ Query failed:', error);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Execute a single query and return first row
+   */
+  async queryOne<T = any>(sql: string, binds: any = {}): Promise<T | null> {
+    const results = await this.query<T>(sql, binds);
+    return results.length > 0 ? results[0] : null;
+  }
+
+  /**
+   * Clean all data tables except lookup tables and PROSESS_STEG
+   * Excludes: tables ending with _TYPE, _TEMA, _STATUS, and PROSESS_STEG
+   * @param silent - If true, suppress console output
+   */
+  async cleanDatabase(silent = false): Promise<{ cleanedCount: number; totalRowsDeleted: number }> {
+    if (!this.connection) {
+      throw new Error('Database not connected. Call connect() first.');
     }
 
-    /**
-     * Clean all data tables except lookup tables and PROSESS_STEG
-     * Excludes: tables ending with _TYPE, _TEMA, _STATUS, and PROSESS_STEG
-     * @param silent - If true, suppress console output
-     */
-    async cleanDatabase(silent = false): Promise<{ cleanedCount: number; totalRowsDeleted: number }> {
-        if (!this.connection) {
-            throw new Error('Database not connected. Call connect() first.');
-        }
-
-        if (!silent) {
-            console.log('\n🧹 Starting database cleanup...\n');
-        }
-
-        try {
-            // Get all tables
-            const tables = await this.query<{ TABLE_NAME: string }>(`
-                SELECT table_name
-                FROM user_tables
-                ORDER BY table_name
-            `, {}, true);
-
-            if (!silent) {
-                console.log(`Found ${tables.length} total tables\n`);
-            }
-
-            const tablesToClean: string[] = [];
-            const skippedTables: string[] = [];
-
-            // Filter tables to clean
-            for (const table of tables) {
-                const tableName = table.TABLE_NAME;
-
-                // Skip lookup/reference tables that should never be cleaned
-                // These tables contain static reference data needed by the application
-                const lookupTables = [
-                    'PROSESS_STEG',                  // Process step definitions
-                    'BEHANDLINGSMAATE',              // Treatment methods (referenced by FK_BEHANDLINGSMAATE)
-                    'PREFERANSE',                    // Preferences/settings
-                    'SAKSOPPLYSNING_KILDESYSTEM',    // Source system definitions
-                    'UTENLANDSK_MYNDIGHET',          // Foreign authority reference data
-                    'UTENLANDSK_MYNDIGHET_PREF',     // Foreign authority preferences
-                    'flyway_schema_history'          // Database migration history
-                ];
-
-                if (tableName.endsWith('_TYPE') ||
-                    tableName.endsWith('_TEMA') ||
-                    tableName.endsWith('_STATUS') ||
-                    lookupTables.includes(tableName)) {
-                    skippedTables.push(tableName);
-                    continue;
-                }
-
-                tablesToClean.push(tableName);
-            }
-
-            if (!silent) {
-                console.log(`📋 Tables to clean: ${tablesToClean.length}`);
-                console.log(`⏭️  Tables to skip: ${skippedTables.length} (lookup/reference tables)\n`);
-            }
-
-            // Disable foreign key constraints temporarily
-            await this.connection.execute('BEGIN\n' +
-                '  FOR c IN (SELECT constraint_name, table_name FROM user_constraints WHERE constraint_type = \'R\') LOOP\n' +
-                '    EXECUTE IMMEDIATE \'ALTER TABLE \' || c.table_name || \' DISABLE CONSTRAINT \' || c.constraint_name;\n' +
-                '  END LOOP;\n' +
-                'END;');
-
-            if (!silent) {
-                console.log('🔓 Disabled foreign key constraints\n');
-            }
-
-            let cleanedCount = 0;
-            let totalRowsDeleted = 0;
-
-            // Truncate data from each table (faster than DELETE and resets sequences)
-            for (const tableName of tablesToClean) {
-                try {
-                    // Count rows before truncation
-                    const countResult = await this.query(`SELECT COUNT(*) as cnt
-                                                          FROM ${tableName}`, {}, true);
-                    const rowCount = countResult[0]?.CNT || 0;
-
-                    if (rowCount > 0) {
-                        // TRUNCATE is faster than DELETE and resets auto-increment sequences
-                        await this.connection.execute(`TRUNCATE TABLE ${tableName}`);
-                        if (!silent) {
-                            console.log(`✅ Cleaned ${tableName.padEnd(40)} (${rowCount} rows truncated)`);
-                        }
-                        cleanedCount++;
-                        totalRowsDeleted += rowCount;
-                    }
-                } catch (error) {
-                    if (!silent) {
-                        console.log(`⚠️  Could not clean ${tableName}: ${(error as Error).message || error}`);
-                    }
-                }
-            }
-
-            // Re-enable foreign key constraints
-            await this.connection.execute('BEGIN\n' +
-                '  FOR c IN (SELECT constraint_name, table_name FROM user_constraints WHERE constraint_type = \'R\') LOOP\n' +
-                '    EXECUTE IMMEDIATE \'ALTER TABLE \' || c.table_name || \' ENABLE CONSTRAINT \' || c.constraint_name;\n' +
-                '  END LOOP;\n' +
-                'END;');
-
-            if (!silent) {
-                console.log('\n🔒 Re-enabled foreign key constraints');
-
-                console.log('\n' + '─'.repeat(60));
-                console.log(`\n✨ Database cleanup complete!`);
-                console.log(`   Tables cleaned: ${cleanedCount}`);
-                console.log(`   Total rows deleted: ${totalRowsDeleted}\n`);
-            }
-
-            return {cleanedCount, totalRowsDeleted};
-
-        } catch (error) {
-            if (!silent) {
-                console.error('❌ Database cleanup failed:', error);
-            }
-            throw error;
-        }
+    if (!silent) {
+      console.log('\n🧹 Starting database cleanup...\n');
     }
 
-    /**
-     * Show all database tables with their data
-     * Useful for debugging - shows what data exists in the database
-     * @param skipLookupTables - If true, skip tables ending with _TYPE, _TEMA, _STATUS (default: true)
-     */
-    async showAllData(skipLookupTables = true): Promise<void> {
-        if (!this.connection) {
-            throw new Error('Database not connected. Call connect() first.');
-        }
+    try {
+      // Get all tables
+      const tables = await this.query<{TABLE_NAME: string}>(`
+        SELECT table_name
+        FROM user_tables
+        ORDER BY table_name
+      `, {}, true);
 
-        console.log('\n🔍 Analyzing database contents...\n');
-
-        // Get all tables
-        const tables = await this.query<{ TABLE_NAME: string }>(`
-            SELECT table_name
-            FROM user_tables
-            ORDER BY table_name
-        `, {}, true);
-
+      if (!silent) {
         console.log(`Found ${tables.length} total tables\n`);
+      }
 
-        // Filter out lookup tables and check which have data
-        const tablesWithData: { name: string, count: number }[] = [];
+      const tablesToClean: string[] = [];
+      const skippedTables: string[] = [];
 
-        for (const table of tables) {
-            const tableName = table.TABLE_NAME;
+      // Filter tables to clean
+      for (const table of tables) {
+        const tableName = table.TABLE_NAME;
 
-            // Skip lookup tables if requested
-            if (skipLookupTables &&
-                (tableName.endsWith('_TYPE') ||
-                    tableName.endsWith('_TEMA') ||
-                    tableName.endsWith('_STATUS'))) {
-                continue;
-            }
+        // Skip lookup/reference tables that should never be cleaned
+        // These tables contain static reference data needed by the application
+        const lookupTables = [
+          'PROSESS_STEG',                  // Process step definitions
+          'BEHANDLINGSMAATE',              // Treatment methods (referenced by FK_BEHANDLINGSMAATE)
+          'PREFERANSE',                    // Preferences/settings
+          'SAKSOPPLYSNING_KILDESYSTEM',    // Source system definitions
+          'UTENLANDSK_MYNDIGHET',          // Foreign authority reference data
+          'UTENLANDSK_MYNDIGHET_PREF',     // Foreign authority preferences
+          'flyway_schema_history'          // Database migration history
+        ];
 
-            // Count rows in table
-            try {
-                const countResult = await this.query(`SELECT COUNT(*) as cnt
-                                                      FROM ${tableName}`, {}, true);
-                const count = countResult[0]?.CNT || 0;
-
-                if (count > 0) {
-                    tablesWithData.push({name: tableName, count: count});
-                }
-            } catch (error) {
-                console.log(`⚠️  Could not query ${tableName}: ${(error as Error).message || error}`);
-            }
+        if (tableName.endsWith('_TYPE') ||
+            tableName.endsWith('_TEMA') ||
+            tableName.endsWith('_STATUS') ||
+            lookupTables.includes(tableName)) {
+          skippedTables.push(tableName);
+          continue;
         }
 
-        // Display results
-        console.log(`\n📊 Tables with data (${tablesWithData.length} tables):\n`);
-        console.log('─'.repeat(60));
+        tablesToClean.push(tableName);
+      }
 
-        for (const table of tablesWithData) {
-            console.log(`📋 ${table.name.padEnd(40)} ${String(table.count).padStart(6)} rows`);
+      if (!silent) {
+        console.log(`📋 Tables to clean: ${tablesToClean.length}`);
+        console.log(`⏭️  Tables to skip: ${skippedTables.length} (lookup/reference tables)\n`);
+      }
 
-            // Show sample data from the table
-            try {
-                const sample = await this.query(`SELECT *
-                                                 FROM ${table.name}
-                                                 WHERE ROWNUM <= 1`, {}, true);
-                if (sample.length > 0) {
-                    const columns = Object.keys(sample[0]).slice(0, 5); // First 5 columns
-                    console.log(`   Columns: ${columns.join(', ')}${columns.length < Object.keys(sample[0]).length ? ', ...' : ''}`);
-                }
-            } catch (error) {
-                // Ignore errors in sample query
+      // Disable foreign key constraints temporarily
+      await this.connection.execute('BEGIN\n' +
+        '  FOR c IN (SELECT constraint_name, table_name FROM user_constraints WHERE constraint_type = \'R\') LOOP\n' +
+        '    EXECUTE IMMEDIATE \'ALTER TABLE \' || c.table_name || \' DISABLE CONSTRAINT \' || c.constraint_name;\n' +
+        '  END LOOP;\n' +
+        'END;');
+
+      if (!silent) {
+        console.log('🔓 Disabled foreign key constraints\n');
+      }
+
+      let cleanedCount = 0;
+      let totalRowsDeleted = 0;
+
+      // Truncate data from each table (faster than DELETE and resets sequences)
+      for (const tableName of tablesToClean) {
+        try {
+          // Count rows before truncation
+          const countResult = await this.query(`SELECT COUNT(*) as cnt FROM ${tableName}`, {}, true);
+          const rowCount = countResult[0]?.CNT || 0;
+
+          if (rowCount > 0) {
+            // TRUNCATE is faster than DELETE and resets auto-increment sequences
+            await this.connection.execute(`TRUNCATE TABLE ${tableName}`);
+            if (!silent) {
+              console.log(`✅ Cleaned ${tableName.padEnd(40)} (${rowCount} rows truncated)`);
             }
-            console.log('');
+            cleanedCount++;
+            totalRowsDeleted += rowCount;
+          }
+        } catch (error) {
+          if (!silent) {
+            console.log(`⚠️  Could not clean ${tableName}: ${(error as Error).message || error}`);
+          }
         }
+      }
 
-        console.log('─'.repeat(60));
-        console.log(`\nTotal rows across all tables: ${tablesWithData.reduce((sum, t) => sum + t.count, 0)}\n`);
+      // Re-enable foreign key constraints
+      await this.connection.execute('BEGIN\n' +
+        '  FOR c IN (SELECT constraint_name, table_name FROM user_constraints WHERE constraint_type = \'R\') LOOP\n' +
+        '    EXECUTE IMMEDIATE \'ALTER TABLE \' || c.table_name || \' ENABLE CONSTRAINT \' || c.constraint_name;\n' +
+        '  END LOOP;\n' +
+        'END;');
+
+      if (!silent) {
+        console.log('\n🔒 Re-enabled foreign key constraints');
+
+        console.log('\n' + '─'.repeat(60));
+        console.log(`\n✨ Database cleanup complete!`);
+        console.log(`   Tables cleaned: ${cleanedCount}`);
+        console.log(`   Total rows deleted: ${totalRowsDeleted}\n`);
+      }
+
+      return { cleanedCount, totalRowsDeleted };
+
+    } catch (error) {
+      if (!silent) {
+        console.error('❌ Database cleanup failed:', error);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Show all database tables with their data
+   * Useful for debugging - shows what data exists in the database
+   * @param skipLookupTables - If true, skip tables ending with _TYPE, _TEMA, _STATUS (default: true)
+   */
+  async showAllData(skipLookupTables = true): Promise<void> {
+    if (!this.connection) {
+      throw new Error('Database not connected. Call connect() first.');
     }
 
-    /**
-     * Close the database connection
-     */
-    async close() {
-        if (this.connection) {
-            try {
-                await this.connection.close();
-                this.connection = null;
-                console.log('✅ Database connection closed');
-            } catch (error) {
-                console.error('❌ Failed to close database:', error);
-                throw error;
-            }
+    console.log('\n🔍 Analyzing database contents...\n');
+
+    // Get all tables
+    const tables = await this.query<{TABLE_NAME: string}>(`
+      SELECT table_name
+      FROM user_tables
+      ORDER BY table_name
+    `, {}, true);
+
+    console.log(`Found ${tables.length} total tables\n`);
+
+    // Filter out lookup tables and check which have data
+    const tablesWithData: {name: string, count: number}[] = [];
+
+    for (const table of tables) {
+      const tableName = table.TABLE_NAME;
+
+      // Skip lookup tables if requested
+      if (skipLookupTables &&
+          (tableName.endsWith('_TYPE') ||
+           tableName.endsWith('_TEMA') ||
+           tableName.endsWith('_STATUS'))) {
+        continue;
+      }
+
+      // Count rows in table
+      try {
+        const countResult = await this.query(`SELECT COUNT(*) as cnt FROM ${tableName}`, {}, true);
+        const count = countResult[0]?.CNT || 0;
+
+        if (count > 0) {
+          tablesWithData.push({ name: tableName, count: count });
         }
+      } catch (error) {
+        console.log(`⚠️  Could not query ${tableName}: ${(error as Error).message || error}`);
+      }
     }
+
+    // Display results
+    console.log(`\n📊 Tables with data (${tablesWithData.length} tables):\n`);
+    console.log('─'.repeat(60));
+
+    for (const table of tablesWithData) {
+      console.log(`📋 ${table.name.padEnd(40)} ${String(table.count).padStart(6)} rows`);
+
+      // Show sample data from the table
+      try {
+        const sample = await this.query(`SELECT * FROM ${table.name} WHERE ROWNUM <= 1`, {}, true);
+        if (sample.length > 0) {
+          const columns = Object.keys(sample[0]).slice(0, 5); // First 5 columns
+          console.log(`   Columns: ${columns.join(', ')}${columns.length < Object.keys(sample[0]).length ? ', ...' : ''}`);
+        }
+      } catch (error) {
+        // Ignore errors in sample query
+      }
+      console.log('');
+    }
+
+    console.log('─'.repeat(60));
+    console.log(`\nTotal rows across all tables: ${tablesWithData.reduce((sum, t) => sum + t.count, 0)}\n`);
+  }
+
+  /**
+   * Close the database connection
+   */
+  async close() {
+    if (this.connection) {
+      try {
+        await this.connection.close();
+        this.connection = null;
+        console.log('✅ Database connection closed');
+      } catch (error) {
+        console.error('❌ Failed to close database:', error);
+        throw error;
+      }
+    }
+  }
 }
 
 /**
  * Helper function to create a database fixture for tests
  */
 export async function withDatabase<T>(
-    callback: (db: DatabaseHelper) => Promise<T>
+  callback: (db: DatabaseHelper) => Promise<T>
 ): Promise<T> {
-    const db = new DatabaseHelper();
-    try {
-        await db.connect();
-        return await callback(db);
-    } finally {
-        await db.close();
-    }
+  const db = new DatabaseHelper();
+  try {
+    await db.connect();
+    return await callback(db);
+  } finally {
+    await db.close();
+  }
 }
 
 /**
  * Fetch FAKTURASERIE_REFERANSE for a given behandling ID from BEHANDLINGSRESULTAT
  */
 export async function getFakturaserieReferanse(behandlingId: string | null | undefined): Promise<string | undefined> {
-    if (!behandlingId) throw new Error('behandlingId is required');
-    return withDatabase(async (db) => {
-        const result = await db.queryOne<{ FAKTURASERIE_REFERANSE: string }>(
-            `SELECT FAKTURASERIE_REFERANSE
-             FROM BEHANDLINGSRESULTAT
-             WHERE BEHANDLING_ID = :id`,
-            {id: behandlingId}
-        );
-        return result?.FAKTURASERIE_REFERANSE;
-    });
+  if (!behandlingId) throw new Error('behandlingId is required');
+  return withDatabase(async (db) => {
+    const result = await db.queryOne<{ FAKTURASERIE_REFERANSE: string }>(
+      `SELECT FAKTURASERIE_REFERANSE
+       FROM BEHANDLINGSRESULTAT
+       WHERE BEHANDLING_ID = :id`,
+      {id: behandlingId}
+    );
+    return result?.FAKTURASERIE_REFERANSE;
+  });
 }

--- a/helpers/mock-helper.ts
+++ b/helpers/mock-helper.ts
@@ -98,6 +98,83 @@ export async function findNewNavFormatSed(
   );
 }
 
+/**
+ * A journalpost stored in the SAF mock.
+ * Mirrors JournalpostModell in melosys-mock.
+ */
+export interface JournalpostInfo {
+  journalpostId: string;
+  tittel: string | null;
+  journalposttype: 'INNGAAENDE' | 'UTGAAENDE' | 'NOTAT' | null;
+  journalStatus: 'J' | 'MO' | 'M' | 'A' | null;
+  sakId: string | null;
+  eksternReferanseId: string | null;
+  kanal: string | null;
+  tilleggsoppltsninger: Array<{ nokkel: string | null; verdi: string | null }>;
+  avsenderMottaker: {
+    id?: string;
+    type?: string;
+    navn?: string;
+    land?: string;
+  };
+}
+
+/**
+ * Fetch all journalposter stored in the SAF mock.
+ *
+ * @param request - Playwright APIRequestContext
+ */
+export async function fetchStoredJournalposter(
+  request: APIRequestContext
+): Promise<JournalpostInfo[]> {
+  const response = await request.get('http://localhost:8083/testdata/verification/journalpost');
+  if (!response.ok()) {
+    throw new Error(`Failed to fetch journalposter: ${response.status()}`);
+  }
+  return response.json();
+}
+
+/**
+ * Poll for a new UTGAAENDE journalpost that was not present in a previous snapshot.
+ *
+ * Used to verify that OpprettUtgaaendeJournalpostService in melosys-eessi ran
+ * successfully after a SED was sent — i.e. the full Kafka sed-sendt loop completed.
+ *
+ * Usage:
+ *   // Before vedtak:
+ *   const jpBefore = await fetchStoredJournalposter(request);
+ *   // ... fatt vedtak ...
+ *   const jp = await findNewUtgaaendeJournalpost(request, jpBefore);
+ *
+ * @param request  - Playwright APIRequestContext
+ * @param before   - Snapshot taken BEFORE vedtak
+ * @param timeoutMs - Max polling time (default: 30s)
+ */
+export async function findNewUtgaaendeJournalpost(
+  request: APIRequestContext,
+  before: JournalpostInfo[],
+  timeoutMs = 30000
+): Promise<JournalpostInfo | null> {
+  const beforeIds = new Set(before.map((jp) => jp.journalpostId));
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const after = await fetchStoredJournalposter(request);
+    const newEessiJournalpost = after.filter(
+      (jp) =>
+        !beforeIds.has(jp.journalpostId) &&
+        jp.journalposttype === 'UTGAAENDE' &&
+        jp.kanal === 'EESSI'
+    );
+    if (newEessiJournalpost.length > 0) {
+      return newEessiJournalpost[0];
+    }
+    console.log(`⏳ Venter på UTGAAENDE EESSI-journalpost...`);
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  return null;
+}
+
 export interface MockClearResponse {
   message: string;
   journalpostCleared?: string | number;

--- a/pages/behandling/arbeid-flere-land-behandling.page.ts
+++ b/pages/behandling/arbeid-flere-land-behandling.page.ts
@@ -397,12 +397,16 @@ export class ArbeidFlereLandBehandlingPage extends BasePage {
    * @param arbeidsgiver - Arbeidsgiver å velge (default: 'Ståles Stål AS')
    * @param begrunnelse - Fritekst til begrunnelse (default: 'Lorem ipsum')
    * @param informasjon - Ytterligere informasjon (default: 'Dodatkowo')
+   * @param options - Valgfrie innstillinger
+   * @param options.skipFattVedtak - Hvis true, stoppes flyten før "Fatt vedtak"-steget.
+   *   Bruk dette når du trenger å gjøre egne handlinger (f.eks. velge EESSI-institusjon) før vedtaket fattes.
    */
   async fyllUtArbeidFlereLandBehandling(
     land: string = 'Norge',
     arbeidsgiver: string = 'Ståles Stål AS',
     begrunnelse: string = 'Lorem ipsum',
-    informasjon: string = 'Dodatkowo'
+    informasjon: string = 'Dodatkowo',
+    options: { skipFattVedtak?: boolean } = {}
   ): Promise<void> {
     // EU/EØS behandlinger har en tabbet UI med Inngang, Bosted, Virksomhet
     // "Bekreft og fortsett" navigerer automatisk til neste steg
@@ -460,8 +464,9 @@ export class ArbeidFlereLandBehandlingPage extends BasePage {
     await this.fyllInnFritekstTilBegrunnelse(begrunnelse);
     await this.fyllInnYtterligereInformasjon(informasjon);
 
-    // Steg 8: Fatt vedtak
-    await this.fattVedtak();
+    if (!options.skipFattVedtak) {
+      await this.fattVedtak();
+    }
   }
 
   // ============================================================

--- a/pages/shared/constants.ts
+++ b/pages/shared/constants.ts
@@ -75,4 +75,7 @@ export const EU_EOS_LAND = {
   NEDERLAND: 'Nederland',
   ESTLAND: 'Estland',
   NORGE: 'Norge',
+  // Ikke-EESSI-land som brukes i arbeid-i-flere-land-saker
+  FAROEYENE: 'Færøyene',
+  GRONLAND: 'Grønland',
 } as const;

--- a/pages/shared/constants.ts
+++ b/pages/shared/constants.ts
@@ -74,6 +74,7 @@ export const EU_EOS_LAND = {
   FRANKRIKE: 'Frankrike',
   NEDERLAND: 'Nederland',
   ESTLAND: 'Estland',
+  BELGIA: 'Belgia',
   NORGE: 'Norge',
   // Ikke-EESSI-land som brukes i arbeid-i-flere-land-saker
   FAROEYENE: 'Færøyene',

--- a/tests/eu-eos/eu-eos-papir-a1-til-ikke-eessi-land.spec.ts
+++ b/tests/eu-eos/eu-eos-papir-a1-til-ikke-eessi-land.spec.ts
@@ -50,6 +50,7 @@ test.describe('Papir-A1 til ikke-EESSI-land ved EOS-vedtak', () => {
     await hovedside.goto();
     await hovedside.klikkOpprettNySak();
     await opprettSak.fyllInnBrukerID(USER_ID_VALID);
+    await opprettSak.velgOpprettNySak();
     await opprettSak.velgSakstype('EU_EOS');
     await opprettSak.velgSakstema('MEDLEMSKAP_LOVVALG');
     await opprettSak.velgBehandlingstema('ARBEID_FLERE_LAND');

--- a/tests/eu-eos/eu-eos-papir-a1-til-ikke-eessi-land.spec.ts
+++ b/tests/eu-eos/eu-eos-papir-a1-til-ikke-eessi-land.spec.ts
@@ -1,0 +1,292 @@
+import { test, expect } from '../../fixtures';
+import { Page } from '@playwright/test';
+import { AuthHelper } from '../../helpers/auth-helper';
+import { HovedsidePage } from '../../pages/hovedside.page';
+import { OpprettNySakPage } from '../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import { EuEosBehandlingPage } from '../../pages/behandling/eu-eos-behandling.page';
+import { ArbeidFlereLandBehandlingPage } from '../../pages/behandling/arbeid-flere-land-behandling.page';
+import { USER_ID_VALID, EU_EOS_LAND } from '../../pages/shared/constants';
+import { waitForProcessInstances } from '../../helpers/api-helper';
+import { withDatabase } from '../../helpers/db-helper';
+import { APIRequestContext } from '@playwright/test';
+import { fetchStoredSedDocuments, findNewNavFormatSed, RinaDocumentInfo } from '../../helpers/mock-helper';
+
+/**
+ * Papir-A1 til ikke-EESSI-land (FO/GL) ved EOS-vedtak
+ *
+ * Disse testene verifiserer at når en sak inkluderer både EESSI-klare land og
+ * ikke-EESSI-land (Færøyene og/eller Grønland), så:
+ * - SED sendes til EESSI-klare land som normalt
+ * - Papir-A1 sendes til Færøyene/Grønland (SEND_BREV prosessinstans opprettet)
+ * - Ingen av delene hindrer den andre (IVERKSETT_VEDTAK_EOS STATUS = FERDIG)
+ *
+ * DB-verifikasjoner skjer via PROSESSINSTANS-tabellen:
+ * - IVERKSETT_VEDTAK_EOS med STATUS = FERDIG → vedtak gjennomført uten feil
+ * - SEND_BREV med trygdemyndighetLand = FO/GL → papir-A1 sendt til riktig land
+ *
+ * Testene dekker den manuelle testplanen fra 3-løsning.md:
+ * - Scenario 1: Hovedscenario — Færøyene + EU/EØS-land
+ * - Scenario 2: Færøyene + Grønland + EU/EØS-land
+ * - Scenario 3: Regresjon — kun EU/EØS-land (ingen FO/GL)
+ * - Scenario 4: Regresjon — kun ikke-EESSI-land (FO + GL)
+ */
+test.describe('Papir-A1 til ikke-EESSI-land ved EOS-vedtak', () => {
+
+  /**
+   * Hjelpefunksjon for å sette opp og navigere til en behandling.
+   * Returnerer behandlingssiden klar for stegvelgeren.
+   */
+  async function opprettOgNavigerTilBehandling(
+    page: Page,
+    land: string[]
+  ) {
+    const auth = new AuthHelper(page);
+    await auth.login();
+
+    const hovedside = new HovedsidePage(page);
+    const opprettSak = new OpprettNySakPage(page);
+    const euEosBehandling = new EuEosBehandlingPage(page);
+
+    await hovedside.goto();
+    await hovedside.klikkOpprettNySak();
+    await opprettSak.fyllInnBrukerID(USER_ID_VALID);
+    await opprettSak.velgSakstype('EU_EOS');
+    await opprettSak.velgSakstema('MEDLEMSKAP_LOVVALG');
+    await opprettSak.velgBehandlingstema('ARBEID_FLERE_LAND');
+
+    await euEosBehandling.fyllInnFraTilDato('01.01.2024', '31.12.2025');
+
+    // Velg første land og deretter øvrige
+    await euEosBehandling.velgLand(land[0]);
+    for (const ekstraLand of land.slice(1)) {
+      await euEosBehandling.velgAndreLand(ekstraLand);
+    }
+
+    await opprettSak.velgAarsak('SØKNAD');
+    await opprettSak.leggBehandlingIMine();
+    await opprettSak.klikkOpprettNyBehandling();
+
+    console.log('📝 Venter på prosessinstanser etter saksopprettelse...');
+    await waitForProcessInstances(page.request, 30);
+    await hovedside.goto();
+
+    await page.getByRole('link', { name: 'TRIVIELL KARAFFEL -' }).click();
+    await page.waitForLoadState('networkidle');
+
+    return new ArbeidFlereLandBehandlingPage(page);
+  }
+
+  /**
+   * Verifiserer DB-tilstand etter EOS-vedtak:
+   * 1. IVERKSETT_VEDTAK_EOS er FERDIG (ingen feil i prosessen)
+   * 2. SEND_BREV er opprettet for hvert forventet papirland (FO/GL)
+   * 3. Ingen SEND_BREV er opprettet for rene EESSI-vedtak
+   *
+   * @param forventetPapirland - Landkoder som skal ha fått papir-A1, f.eks. ['FO'] eller ['FO', 'GL']
+   */
+  async function verifiserProsessinstanserEtterVedtak(
+    forventetPapirland: string[]
+  ): Promise<void> {
+    await withDatabase(async (db) => {
+      // Hent siste IVERKSETT_VEDTAK_EOS (tester kjøres serielt, 5 min vindu er trygt)
+      const vedtak = await db.queryOne<{ BEHANDLING_ID: number; STATUS: string; SIST_FULLFORT_STEG: string }>(
+        `SELECT PI.BEHANDLING_ID, PI.STATUS, PI.SIST_FULLFORT_STEG
+         FROM PROSESSINSTANS PI
+         WHERE PI.PROSESS_TYPE = 'IVERKSETT_VEDTAK_EOS'
+           AND PI.REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE
+         ORDER BY PI.REGISTRERT_DATO DESC
+         FETCH FIRST 1 ROWS ONLY`,
+        {}
+      );
+
+      expect(vedtak, 'Fant ingen nylig IVERKSETT_VEDTAK_EOS prosessinstans').not.toBeNull();
+      expect(vedtak!.STATUS, `IVERKSETT_VEDTAK_EOS skal være FERDIG, men er: ${vedtak!.STATUS}`).toBe('FERDIG');
+      console.log(`✅ IVERKSETT_VEDTAK_EOS: FERDIG (behandlingId=${vedtak!.BEHANDLING_ID})`);
+
+      const behandlingId = vedtak!.BEHANDLING_ID;
+
+      // Hent papir-A1 SEND_BREV for denne behandlingen.
+      // SEND_VEDTAKSBREV_INNLAND oppretter alltid ett SEND_BREV (innlandsbrev) som IKKE
+      // har trygdemyndighetLand — vi filtrerer det ut og teller kun papir-A1 til utland.
+      const alleSendBrev = await db.query<{ DATA: string; STATUS: string }>(
+        `SELECT PI.DATA, PI.STATUS
+         FROM PROSESSINSTANS PI
+         WHERE PI.BEHANDLING_ID = :behandlingId
+           AND PI.PROSESS_TYPE = 'SEND_BREV'`,
+        { behandlingId }
+      );
+
+      // Papir-A1 til FO/GL er alltid av type ATTEST_A1 sendt til UTENLANDSK_TRYGDEMYNDIGHET.
+      // Innlandsbrev (INNVILGELSE_YRKESAKTIV_FLERE_LAND) sendes til BRUKER og inneholder ikke ATTEST_A1.
+      // NB: DATA-kolonnen er Java Properties-format der ':' escapes til '\:' i verdier.
+      const papirA1Brev = alleSendBrev.filter(row => {
+        const data = row.DATA || '';
+        return data.includes('ATTEST_A1') && data.includes('UTENLANDSK_TRYGDEMYNDIGHET');
+      });
+
+      if (forventetPapirland.length === 0) {
+        // Regresjonstest: ingen papir-A1 skal opprettes for rene EESSI-saker.
+        // papirA1Brev er allerede filtrert på ATTEST_A1 + UTENLANDSK_TRYGDEMYNDIGHET,
+        // så hele lista skal være tom — ikke bare FO/GL-innslag.
+        expect(
+          papirA1Brev.length,
+          `Forventet ingen papir-A1 SEND_BREV, men fant ${papirA1Brev.length}`
+        ).toBe(0);
+        console.log('✅ Ingen papir-A1 SEND_BREV (regresjonstest OK)');
+      } else {
+        expect(
+          papirA1Brev.length,
+          `Forventet ${forventetPapirland.length} papir-A1 SEND_BREV, men fant ${papirA1Brev.length}`
+        ).toBe(forventetPapirland.length);
+
+        for (const landkode of forventetPapirland) {
+          const brevForLand = papirA1Brev.find(row => {
+            const data = row.DATA || '';
+            // Properties.store() escaper ':' som '\:' i verdier — søk etter escaped form
+            return data.includes(`"trygdemyndighetLand"\\:"${landkode}"`);
+          });
+          if (!brevForLand) {
+            console.log(`DATA-verdier i papir-A1 SEND_BREV (søkte etter landkode="${landkode}"):\n${papirA1Brev.map(b => b.DATA).join('\n---\n')}`);
+          }
+          expect(brevForLand, `Forventet papir-A1 SEND_BREV med trygdemyndighetLand="${landkode}", men fant det ikke`).toBeTruthy();
+          expect(
+            brevForLand!.STATUS,
+            `SEND_BREV for ${landkode} skal være FERDIG, men er: ${brevForLand!.STATUS}`
+          ).toBe('FERDIG');
+          console.log(`✅ Papir-A1 SEND_BREV opprettet og FERDIG for land ${landkode}`);
+        }
+      }
+    });
+  }
+
+  /**
+   * Verifiserer at en A003 SED (LA_BUC_02) ble sendt til EESSI-mock etter vedtak.
+   * Brukes for scenariene som har EESSI-klare land (f.eks. Sverige).
+   *
+   * NB: For LA_BUC_02 (arbeid i flere land) er SED-typen A003, ikke A1.
+   * A1 attestasjonen sendes som papir-brev — ikke som SED til EESSI.
+   *
+   * @param request - Playwright APIRequestContext
+   * @param docsBefore - Snapshot av RINA-dokumenter tatt FØR vedtak
+   */
+  async function verifiserSedSendtTilEessi(
+    request: APIRequestContext,
+    docsBefore: RinaDocumentInfo[]
+  ): Promise<void> {
+    const sedContent = await findNewNavFormatSed(request, 'A003', docsBefore);
+    expect(sedContent, 'Forventet at A003 SED ble sendt til EESSI-mottaker, men ingen ny SED funnet i mock').toBeTruthy();
+    console.log(`✅ A003 SED sendt til EESSI (sed=${sedContent.sed}, sedVer=${sedContent.sedVer})`);
+  }
+
+  // ============================================================
+  // Scenario 1: Færøyene + EU/EØS-land
+  // ============================================================
+  test('Scenario 1: SED sendes til EESSI-land og papir til Færøyene', async ({ page, request }) => {
+    test.setTimeout(120000);
+
+    const behandling = await opprettOgNavigerTilBehandling(page, [
+      EU_EOS_LAND.SVERIGE,
+      EU_EOS_LAND.FAROEYENE,
+    ]);
+
+    await behandling.fyllUtArbeidFlereLandBehandling(
+      'Norge', 'Ståles Stål AS',
+      'Test: SED til Sverige, papir til Færøyene',
+      'E2E test scenario 1',
+      { skipFattVedtak: true }
+    );
+    await behandling.velgInstitusjonSomSkalMottaSed(EU_EOS_LAND.SVERIGE);
+
+    const docsBefore = await fetchStoredSedDocuments(request, 'A003');
+    await behandling.fattVedtak();
+
+    await waitForProcessInstances(page.request, 60);
+    await verifiserSedSendtTilEessi(request, docsBefore);
+    await verifiserProsessinstanserEtterVedtak(['FO']);
+    console.log('✅ Scenario 1: SED til Sverige og papir til Færøyene — verifisert');
+  });
+
+  // ============================================================
+  // Scenario 2: Færøyene + Grønland + EU/EØS-land
+  // ============================================================
+  test('Scenario 2: SED sendes til EESSI-land og papir til Færøyene og Grønland', async ({ page, request }) => {
+    test.setTimeout(120000);
+
+    const behandling = await opprettOgNavigerTilBehandling(page, [
+      EU_EOS_LAND.SVERIGE,
+      EU_EOS_LAND.FAROEYENE,
+      EU_EOS_LAND.GRONLAND,
+    ]);
+
+    await behandling.fyllUtArbeidFlereLandBehandling(
+      'Norge', 'Ståles Stål AS',
+      'Test: SED til Sverige, papir til FO og GL',
+      'E2E test scenario 2',
+      { skipFattVedtak: true }
+    );
+    await behandling.velgInstitusjonSomSkalMottaSed(EU_EOS_LAND.SVERIGE);
+
+    const docsBefore = await fetchStoredSedDocuments(request, 'A003');
+    await behandling.fattVedtak();
+
+    await waitForProcessInstances(page.request, 60);
+    await verifiserSedSendtTilEessi(request, docsBefore);
+    await verifiserProsessinstanserEtterVedtak(['FO', 'GL']);
+    console.log('✅ Scenario 2: SED til Sverige, papir til Færøyene og Grønland — verifisert');
+  });
+
+  // ============================================================
+  // Scenario 3: Regresjon — kun EU/EØS-land (ingen papir)
+  // ============================================================
+  test('Scenario 3 (regresjon): Kun EESSI-land — ingen papir-A1 til FO/GL', async ({ page, request }) => {
+    test.setTimeout(120000);
+
+    // Sverige + Norge — ARBEID_FLERE_LAND krever minst to land.
+    // Norge er hjemland (ingen EESSI-institusjon nødvendig), Sverige har institusjon i mock.
+    // Ingen FO/GL i listen → papir-A1-koden skal ikke trigges.
+    const behandling = await opprettOgNavigerTilBehandling(page, [
+      EU_EOS_LAND.SVERIGE,
+      EU_EOS_LAND.NORGE,
+    ]);
+
+    await behandling.fyllUtArbeidFlereLandBehandling(
+      'Norge', 'Ståles Stål AS',
+      'Test: Regresjon kun EESSI-land',
+      'E2E test scenario 3',
+      { skipFattVedtak: true }
+    );
+
+    await behandling.velgInstitusjonSomSkalMottaSed(EU_EOS_LAND.SVERIGE);
+
+    const docsBefore = await fetchStoredSedDocuments(request, 'A003');
+    await behandling.fattVedtak();
+
+    await waitForProcessInstances(page.request, 60);
+    await verifiserSedSendtTilEessi(request, docsBefore);
+    await verifiserProsessinstanserEtterVedtak([]);
+    console.log('✅ Scenario 3: SED til Sverige og ingen SEND_BREV for FO/GL — regresjon OK');
+  });
+
+  // ============================================================
+  // Scenario 4: Kun ikke-EESSI-land (kun papir)
+  // ============================================================
+  test('Scenario 4: Kun Færøyene + Grønland — papir-A1 sendes til begge', async ({ page }) => {
+    test.setTimeout(120000);
+
+    const behandling = await opprettOgNavigerTilBehandling(page, [
+      EU_EOS_LAND.FAROEYENE,
+      EU_EOS_LAND.GRONLAND,
+    ]);
+
+    // FO og GL har ingen EESSI-institusjoner — ingen institusjonsdropdown vises
+    await behandling.fyllUtArbeidFlereLandBehandling(
+      'Norge', 'Ståles Stål AS',
+      'Test: Regresjon kun FO og GL',
+      'E2E test scenario 4'
+    );
+
+    await waitForProcessInstances(page.request, 60);
+    await verifiserProsessinstanserEtterVedtak(['FO', 'GL']);
+    console.log('✅ Scenario 4: Kun FO/GL — SEND_BREV for begge land verifisert');
+  });
+});

--- a/tests/eu-eos/eu-eos-papir-a1-til-ikke-eessi-land.spec.ts
+++ b/tests/eu-eos/eu-eos-papir-a1-til-ikke-eessi-land.spec.ts
@@ -9,7 +9,10 @@ import { USER_ID_VALID, EU_EOS_LAND } from '../../pages/shared/constants';
 import { waitForProcessInstances } from '../../helpers/api-helper';
 import { withDatabase } from '../../helpers/db-helper';
 import { APIRequestContext } from '@playwright/test';
-import { fetchStoredSedDocuments, findNewNavFormatSed, RinaDocumentInfo } from '../../helpers/mock-helper';
+import {
+  fetchStoredSedDocuments, findNewNavFormatSed, RinaDocumentInfo,
+  fetchStoredJournalposter, findNewUtgaaendeJournalpost, JournalpostInfo,
+} from '../../helpers/mock-helper';
 
 /**
  * Papir-A1 til ikke-EESSI-land (FO/GL) ved EOS-vedtak
@@ -179,6 +182,38 @@ test.describe('Papir-A1 til ikke-EESSI-land ved EOS-vedtak', () => {
     console.log(`✅ A003 SED sendt til EESSI (sed=${sedContent.sed}, sedVer=${sedContent.sedVer})`);
   }
 
+  /**
+   * Verifiserer at en UTGAAENDE journalpost ble opprettet og ferdigstilt i SAF-mock
+   * etter at SED ble sendt. Bekrefter at hele Kafka-sløyfen fungerte:
+   * sendSed → EessiSedSendtProducer → SedSendtConsumer → OpprettUtgaaendeJournalpostService.
+   *
+   * avsenderMottaker.id settes til mottakerId fra SedHendelse — formatet er '<landkode>:<institusjonId>'
+   * (f.eks. 'SE:FK'). Vi verifiserer at prefixet matcher forventet mottakerland.
+   *
+   * @param request              - Playwright APIRequestContext
+   * @param jpBefore             - Snapshot av journalposter tatt FØR vedtak
+   * @param forventetMottakerLand - ISO-landkode for institusjonen som skal ha mottatt SED (f.eks. 'SE')
+   */
+  async function verifiserUtgaaendeJournalpostOpprettet(
+    request: APIRequestContext,
+    jpBefore: JournalpostInfo[],
+    forventetMottakerLand: string
+  ): Promise<void> {
+    const jp = await findNewUtgaaendeJournalpost(request, jpBefore);
+    expect(jp, 'Forventet UTGAAENDE EESSI-journalpost i SAF-mock etter SED ble sendt, men fant ingen ny med kanal=EESSI').not.toBeNull();
+    expect(jp!.journalStatus, `Journalpost skal være ferdigstilt (J), men er: ${jp!.journalStatus}`).toBe('J');
+    expect(jp!.kanal, 'Journalpost skal ha kanal=EESSI').toBe('EESSI');
+
+    const mottakerId = jp!.avsenderMottaker?.id ?? '';
+    const mottakerLand = mottakerId.split(':')[0];
+    expect(
+      mottakerLand,
+      `SED skal være sendt til ${forventetMottakerLand}, men avsenderMottaker.id='${mottakerId}' → land='${mottakerLand}'`
+    ).toBe(forventetMottakerLand);
+
+    console.log(`✅ UTGAAENDE EESSI-journalpost sendt til ${mottakerLand} (id=${jp!.journalpostId}, mottaker='${mottakerId}')`);
+  }
+
   // ============================================================
   // Scenario 1: Færøyene + EU/EØS-land
   // ============================================================
@@ -199,10 +234,12 @@ test.describe('Papir-A1 til ikke-EESSI-land ved EOS-vedtak', () => {
     await behandling.velgInstitusjonSomSkalMottaSed(EU_EOS_LAND.SVERIGE);
 
     const docsBefore = await fetchStoredSedDocuments(request, 'A003');
+    const jpBefore = await fetchStoredJournalposter(request);
     await behandling.fattVedtak();
 
     await waitForProcessInstances(page.request, 60);
     await verifiserSedSendtTilEessi(request, docsBefore);
+    await verifiserUtgaaendeJournalpostOpprettet(request, jpBefore, 'SE');
     await verifiserProsessinstanserEtterVedtak(['FO']);
     console.log('✅ Scenario 1: SED til Sverige og papir til Færøyene — verifisert');
   });
@@ -228,10 +265,12 @@ test.describe('Papir-A1 til ikke-EESSI-land ved EOS-vedtak', () => {
     await behandling.velgInstitusjonSomSkalMottaSed(EU_EOS_LAND.SVERIGE);
 
     const docsBefore = await fetchStoredSedDocuments(request, 'A003');
+    const jpBefore = await fetchStoredJournalposter(request);
     await behandling.fattVedtak();
 
     await waitForProcessInstances(page.request, 60);
     await verifiserSedSendtTilEessi(request, docsBefore);
+    await verifiserUtgaaendeJournalpostOpprettet(request, jpBefore, 'SE');
     await verifiserProsessinstanserEtterVedtak(['FO', 'GL']);
     console.log('✅ Scenario 2: SED til Sverige, papir til Færøyene og Grønland — verifisert');
   });
@@ -260,10 +299,12 @@ test.describe('Papir-A1 til ikke-EESSI-land ved EOS-vedtak', () => {
     await behandling.velgInstitusjonSomSkalMottaSed(EU_EOS_LAND.SVERIGE);
 
     const docsBefore = await fetchStoredSedDocuments(request, 'A003');
+    const jpBefore = await fetchStoredJournalposter(request);
     await behandling.fattVedtak();
 
     await waitForProcessInstances(page.request, 60);
     await verifiserSedSendtTilEessi(request, docsBefore);
+    await verifiserUtgaaendeJournalpostOpprettet(request, jpBefore, 'SE');
     await verifiserProsessinstanserEtterVedtak([]);
     console.log('✅ Scenario 3: SED til Sverige og ingen SEND_BREV for FO/GL — regresjon OK');
   });


### PR DESCRIPTION
Legger til 4 E2E-testscenarier som dekker EOS-vedtak der Færøyene (FO) og/eller Grønland (GL) er inkludert som arbeidsland.

Papir-A1 (SEND_BREV) skal opprettes for ikke-EESSI-land når EOS-vedtak fattes. Det fantes ingen automatisert dekning for disse scenariene.

[MELOSYS-7795](https://jira.adeo.no/browse/MELOSYS-7795)

- Ny testfil med 4 scenarier: FO+EU/EØS, FO+GL+EU/EØS, kun EU/EØS (regresjon), kun FO+GL
- Verifiserer PROSESSINSTANS-tabell: IVERKSETT_VEDTAK_EOS = FERDIG og SEND_BREV med riktig trygdemyndighetLand
- Utvidelse av `ArbeidFlereLandBehandlingPage` og konstanter

## Testing
- [x] E2E-tester kjører grønt i CI
