### PR TITLE
Slack-varsling til #melosys-ci når E2E-tester feiler

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1075,13 +1075,13 @@ jobs:
               [.tests[] | select(.status == "failed" and (.isKnownError | not)) | .title]
               | .[0:5]
               | map("• " + .)
-              | join("%0A")
+              | join("\n")
             ' "$SUMMARY_JSON")
             if [ -n "$FAILED_LIST" ] && [ "$FAILED_LIST" != "" ]; then
-              RESULTS_BLOCK="${RESULTS_BLOCK}%0A%0A*Feilede tester:*%0A${FAILED_LIST}"
+              RESULTS_BLOCK="${RESULTS_BLOCK}\n\n*Feilede tester:*\n${FAILED_LIST}"
               if [ "$FAILED" -gt 5 ]; then
                 EXTRA=$((FAILED - 5))
-                RESULTS_BLOCK="${RESULTS_BLOCK}%0A_... og ${EXTRA} til_"
+                RESULTS_BLOCK="${RESULTS_BLOCK}\n_... og ${EXTRA} til_"
               fi
             fi
 
@@ -1090,10 +1090,10 @@ jobs:
               [.tests[] | select(.status == "passed" and .totalAttempts > 1) | .title]
               | .[0:3]
               | map("• " + .)
-              | join("%0A")
+              | join("\n")
             ' "$SUMMARY_JSON")
             if [ -n "$FLAKY_LIST" ] && [ "$FLAKY_LIST" != "" ]; then
-              RESULTS_BLOCK="${RESULTS_BLOCK}%0A%0A*Flaky (passed etter retry):*%0A${FLAKY_LIST}"
+              RESULTS_BLOCK="${RESULTS_BLOCK}\n\n*Flaky (passed etter retry):*\n${FLAKY_LIST}"
             fi
           else
             RESULTS_BLOCK="_Testresultater ikke tilgjengelig (test-summary.json mangler)._"
@@ -1103,11 +1103,11 @@ jobs:
           COMMIT_URL="https://github.com/navikt/${SOURCE_REPO}/commit/${COMMIT_SHA}"
           REPO_URL="https://github.com/navikt/${SOURCE_REPO}"
 
-          MESSAGE="${MENTION} E2E-tester feilet etter image-push fra ${SOURCE_REPO}.%0A%0A"
-          MESSAGE="${MESSAGE}*Repo:* <${REPO_URL}|${SOURCE_REPO}>%0A"
-          MESSAGE="${MESSAGE}*Commit:* <${COMMIT_URL}|\`${SHORT_SHA}\`> — ${COMMIT_MSG}%0A"
-          MESSAGE="${MESSAGE}*Image tag:* \`${IMAGE_TAG}\`%0A%0A"
-          MESSAGE="${MESSAGE}${RESULTS_BLOCK}%0A%0A"
+          MESSAGE="${MENTION} E2E-tester feilet etter image-push fra ${SOURCE_REPO}.\n\n"
+          MESSAGE="${MESSAGE}*Repo:* <${REPO_URL}|${SOURCE_REPO}>\n"
+          MESSAGE="${MESSAGE}*Commit:* <${COMMIT_URL}|\`${SHORT_SHA}\`> — ${COMMIT_MSG}\n"
+          MESSAGE="${MESSAGE}*Image tag:* \`${IMAGE_TAG}\`\n\n"
+          MESSAGE="${MESSAGE}${RESULTS_BLOCK}\n\n"
           MESSAGE="${MESSAGE}*Workflow run:* <${RUN_URL}|#${{ github.run_id }}>"
 
           {

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: boolean
         default: false
+      test_slack_notification:
+        description: '🧪 TEST: Feil umiddelbart for å trigge Slack-varsel (MIDLERTIDIG — fjernes før merge)'
+        required: false
+        type: boolean
+        default: false
 
   repository_dispatch:
     types:
@@ -56,6 +61,12 @@ jobs:
     timeout-minutes: 60
 
     steps:
+      - name: 🧪 Test Slack notification (MIDLERTIDIG — fjernes før merge)
+        if: inputs.test_slack_notification == true
+        run: |
+          echo "🧪 Testmodus aktivert — feiler umiddelbart for å trigge notify-slack"
+          exit 1
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -994,7 +1005,7 @@ jobs:
     name: Notify #melosys-ci on failure
     runs-on: ubuntu-latest
     needs: e2e-tests
-    if: failure() && github.event_name == 'repository_dispatch'
+    if: failure() && (github.event_name == 'repository_dispatch' || inputs.test_slack_notification == true)
     env:
       SLACK_USER_MAPPING: ${{ secrets.SLACK_USER_MAPPING }}
     steps:
@@ -1010,11 +1021,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          ACTOR='${{ github.event.client_payload.actor }}'
-          SOURCE_REPO='${{ github.event.client_payload.repository }}'
-          COMMIT_SHA='${{ github.event.client_payload.commit_sha }}'
-          COMMIT_MSG='${{ github.event.client_payload.commit_message }}'
-          IMAGE_TAG='${{ github.event.client_payload.image_tag }}'
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            ACTOR='${{ github.event.client_payload.actor }}'
+            SOURCE_REPO='${{ github.event.client_payload.repository }}'
+            COMMIT_SHA='${{ github.event.client_payload.commit_sha }}'
+            COMMIT_MSG='${{ github.event.client_payload.commit_message }}'
+            IMAGE_TAG='${{ github.event.client_payload.image_tag }}'
+          else
+            # Testmodus (workflow_dispatch) — bruk github-context som fallback
+            ACTOR='${{ github.actor }}'
+            SOURCE_REPO='melosys-e2e-tests (TEST)'
+            COMMIT_SHA='${{ github.sha }}'
+            COMMIT_MSG='🧪 Test av Slack-varsling — ignorer'
+            IMAGE_TAG='test'
+          fi
           SHORT_SHA="${COMMIT_SHA:0:7}"
 
           # Mention: Slack-ID (U...) gir ekte ping, handle (rune.lind) gir synlig tekst.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -989,3 +989,127 @@ jobs:
         run: |
           docker compose down -v
           docker network rm melosys.docker-internal || true
+
+  notify-slack:
+    name: Notify #melosys-ci on failure
+    runs-on: ubuntu-latest
+    needs: e2e-tests
+    if: failure() && github.event_name == 'repository_dispatch'
+    steps:
+      - name: Checkout slack-users mapping
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/slack-users.json
+          sparse-checkout-cone-mode: false
+
+      - name: Download test-summary artifact
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: test-summary
+          path: test-summary
+
+      - name: Build Slack context
+        id: ctx
+        run: |
+          set -euo pipefail
+
+          ACTOR='${{ github.event.client_payload.actor }}'
+          SOURCE_REPO='${{ github.event.client_payload.repository }}'
+          COMMIT_SHA='${{ github.event.client_payload.commit_sha }}'
+          COMMIT_MSG='${{ github.event.client_payload.commit_message }}'
+          IMAGE_TAG='${{ github.event.client_payload.image_tag }}'
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+
+          # Mention: Slack-ID (U...) gir ekte ping, handle (rune.lind) gir synlig tekst
+          MAPPING_FILE=".github/slack-users.json"
+          SLACK_VAL=""
+          if [ -n "$ACTOR" ] && [ -f "$MAPPING_FILE" ]; then
+            SLACK_VAL=$(jq -r --arg a "$ACTOR" '.[$a] // ""' "$MAPPING_FILE")
+          fi
+          if [[ "$SLACK_VAL" =~ ^U[A-Z0-9]+$ ]]; then
+            MENTION="<@${SLACK_VAL}>"
+          elif [ -n "$SLACK_VAL" ]; then
+            MENTION="@${SLACK_VAL}"
+          elif [ -n "$ACTOR" ]; then
+            MENTION="@${ACTOR}"
+          else
+            MENTION=""
+          fi
+
+          # Testresultater fra test-summary.json
+          RESULTS_BLOCK=""
+          SUMMARY_JSON="test-summary/test-summary.json"
+          if [ -f "$SUMMARY_JSON" ]; then
+            PASSED=$(jq '[.tests[] | select(.status == "passed" and .totalAttempts == 1)] | length' "$SUMMARY_JSON")
+            FAILED=$(jq '[.tests[] | select(.status == "failed" and (.isKnownError | not))] | length' "$SUMMARY_JSON")
+            FLAKY=$(jq '[.tests[] | select(.status == "passed" and .totalAttempts > 1)] | length' "$SUMMARY_JSON")
+            SKIPPED=$(jq '[.tests[] | select(.status == "skipped")] | length' "$SUMMARY_JSON")
+            KNOWN_FAILED=$(jq '[.tests[] | select(.status == "failed" and .isKnownError)] | length' "$SUMMARY_JSON")
+            TOTAL=$(jq '.tests | length' "$SUMMARY_JSON")
+
+            RESULTS_BLOCK="*Resultater:* ✅ ${PASSED} passed · ❌ ${FAILED} failed · 🔄 ${FLAKY} flaky · ⏭️ ${SKIPPED} skipped"
+            if [ "$KNOWN_FAILED" -gt 0 ]; then
+              RESULTS_BLOCK="${RESULTS_BLOCK} · ⚠️ ${KNOWN_FAILED} known-error"
+            fi
+            RESULTS_BLOCK="${RESULTS_BLOCK} (av ${TOTAL} totalt)"
+
+            # Liste opp feilede tester (ikke known-errors), maks 5
+            FAILED_LIST=$(jq -r '
+              [.tests[] | select(.status == "failed" and (.isKnownError | not)) | .title]
+              | .[0:5]
+              | map("• " + .)
+              | join("%0A")
+            ' "$SUMMARY_JSON")
+            if [ -n "$FAILED_LIST" ] && [ "$FAILED_LIST" != "" ]; then
+              RESULTS_BLOCK="${RESULTS_BLOCK}%0A%0A*Feilede tester:*%0A${FAILED_LIST}"
+              if [ "$FAILED" -gt 5 ]; then
+                EXTRA=$((FAILED - 5))
+                RESULTS_BLOCK="${RESULTS_BLOCK}%0A_... og ${EXTRA} til_"
+              fi
+            fi
+
+            # Flaky-tester (passed etter retry), maks 3
+            FLAKY_LIST=$(jq -r '
+              [.tests[] | select(.status == "passed" and .totalAttempts > 1) | .title]
+              | .[0:3]
+              | map("• " + .)
+              | join("%0A")
+            ' "$SUMMARY_JSON")
+            if [ -n "$FLAKY_LIST" ] && [ "$FLAKY_LIST" != "" ]; then
+              RESULTS_BLOCK="${RESULTS_BLOCK}%0A%0A*Flaky (passed etter retry):*%0A${FLAKY_LIST}"
+            fi
+          else
+            RESULTS_BLOCK="_Testresultater ikke tilgjengelig (test-summary.json mangler)._"
+          fi
+
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          COMMIT_URL="https://github.com/navikt/${SOURCE_REPO}/commit/${COMMIT_SHA}"
+          REPO_URL="https://github.com/navikt/${SOURCE_REPO}"
+
+          MESSAGE="${MENTION} E2E-tester feilet etter image-push fra ${SOURCE_REPO}.%0A%0A"
+          MESSAGE="${MESSAGE}*Repo:* <${REPO_URL}|${SOURCE_REPO}>%0A"
+          MESSAGE="${MESSAGE}*Commit:* <${COMMIT_URL}|\`${SHORT_SHA}\`> — ${COMMIT_MSG}%0A"
+          MESSAGE="${MESSAGE}*Image tag:* \`${IMAGE_TAG}\`%0A%0A"
+          MESSAGE="${MESSAGE}${RESULTS_BLOCK}%0A%0A"
+          MESSAGE="${MESSAGE}*Workflow run:* <${RUN_URL}|#${{ github.run_id }}>"
+
+          {
+            echo 'SLACK_MESSAGE<<SLACK_EOF'
+            printf '%b' "$MESSAGE"
+            echo
+            echo 'SLACK_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: Github Actions
+          SLACK_ICON: https://github.com/github.png?size=48
+          SLACK_COLOR: danger
+          SLACK_TITLE: "E2E-tester feilet"
+          SLACK_FOOTER: "melosys-e2e-tests"
+          SLACK_MESSAGE: ${{ steps.ctx.outputs.SLACK_MESSAGE }}
+          MSG_MINIMAL: "true"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,11 +32,6 @@ on:
         required: false
         type: boolean
         default: false
-      test_slack_notification:
-        description: '🧪 TEST: Feil umiddelbart for å trigge Slack-varsel (MIDLERTIDIG — fjernes før merge)'
-        required: false
-        type: boolean
-        default: false
 
   repository_dispatch:
     types:
@@ -61,12 +56,6 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - name: 🧪 Test Slack notification (MIDLERTIDIG — fjernes før merge)
-        if: inputs.test_slack_notification == true
-        run: |
-          echo "🧪 Testmodus aktivert — feiler umiddelbart for å trigge notify-slack"
-          exit 1
-
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -1005,7 +994,7 @@ jobs:
     name: Notify #melosys-ci on failure
     runs-on: ubuntu-latest
     needs: e2e-tests
-    if: failure() && (github.event_name == 'repository_dispatch' || inputs.test_slack_notification == true)
+    if: failure() && github.event_name == 'repository_dispatch'
     env:
       SLACK_USER_MAPPING: ${{ secrets.SLACK_USER_MAPPING }}
     steps:
@@ -1021,20 +1010,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            ACTOR='${{ github.event.client_payload.actor }}'
-            SOURCE_REPO='${{ github.event.client_payload.repository }}'
-            COMMIT_SHA='${{ github.event.client_payload.commit_sha }}'
-            COMMIT_MSG='${{ github.event.client_payload.commit_message }}'
-            IMAGE_TAG='${{ github.event.client_payload.image_tag }}'
-          else
-            # Testmodus (workflow_dispatch) — bruk github-context som fallback
-            ACTOR='${{ github.actor }}'
-            SOURCE_REPO='melosys-e2e-tests (TEST)'
-            COMMIT_SHA='${{ github.sha }}'
-            COMMIT_MSG='🧪 Test av Slack-varsling — ignorer'
-            IMAGE_TAG='test'
-          fi
+          ACTOR='${{ github.event.client_payload.actor }}'
+          SOURCE_REPO='${{ github.event.client_payload.repository }}'
+          COMMIT_SHA='${{ github.event.client_payload.commit_sha }}'
+          COMMIT_MSG='${{ github.event.client_payload.commit_message }}'
+          IMAGE_TAG='${{ github.event.client_payload.image_tag }}'
           SHORT_SHA="${COMMIT_SHA:0:7}"
 
           # Mention: Slack-ID (U...) gir ekte ping, handle (rune.lind) gir synlig tekst.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -995,14 +995,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: e2e-tests
     if: failure() && github.event_name == 'repository_dispatch'
+    env:
+      SLACK_USER_MAPPING: ${{ secrets.SLACK_USER_MAPPING }}
     steps:
-      - name: Checkout slack-users mapping
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            .github/slack-users.json
-          sparse-checkout-cone-mode: false
-
       - name: Download test-summary artifact
         uses: actions/download-artifact@v4
         continue-on-error: true
@@ -1022,11 +1017,11 @@ jobs:
           IMAGE_TAG='${{ github.event.client_payload.image_tag }}'
           SHORT_SHA="${COMMIT_SHA:0:7}"
 
-          # Mention: Slack-ID (U...) gir ekte ping, handle (rune.lind) gir synlig tekst
-          MAPPING_FILE=".github/slack-users.json"
+          # Mention: Slack-ID (U...) gir ekte ping, handle (rune.lind) gir synlig tekst.
+          # Mapping kommer fra org-secret SLACK_USER_MAPPING (JSON-streng).
           SLACK_VAL=""
-          if [ -n "$ACTOR" ] && [ -f "$MAPPING_FILE" ]; then
-            SLACK_VAL=$(jq -r --arg a "$ACTOR" '.[$a] // ""' "$MAPPING_FILE")
+          if [ -n "$ACTOR" ] && [ -n "${SLACK_USER_MAPPING:-}" ]; then
+            SLACK_VAL=$(printf '%s' "$SLACK_USER_MAPPING" | jq -r --arg a "$ACTOR" '.[$a] // ""')
           fi
           if [[ "$SLACK_VAL" =~ ^U[A-Z0-9]+$ ]]; then
             MENTION="<@${SLACK_VAL}>"

--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,6 @@ auth-state.json
 *.key
 secrets.json
 
-# Local-only Slack-mapping (ikke i public repo)
-.github/slack-users.json
-
 # Environment variables
 .env.local
 .env.*.local

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ auth-state.json
 *.key
 secrets.json
 
+# Local-only Slack-mapping (ikke i public repo)
+.github/slack-users.json
+
 # Environment variables
 .env.local
 .env.*.local


### PR DESCRIPTION
Legger til automatisk Slack-varsling til #melosys-ci når E2E-tester feiler etter at et annet repo har pushet et nytt image. Meldingen tagger utvikler som trigget kjøringen, og inkluderer resultater, liste over feilede tester og lenker til commit og workflow run.

E2E-feil etter merge blir i dag stille ignorert til noen manuelt sjekker CI, noe som forsinker feilretting og gjør det lett å glemme flaky/regresjoner mellom repoer. Direkte varsling til utvikler som pushet image lar oss raskt vurdere om feilen er reell, og kanalvarselet holder teamet oppdatert. Vi bruker samme `SLACK_WEBHOOK`-pattern som melosys-api sine deploy-workflows.

- Ny `notify-slack`-jobb i `.github/workflows/e2e-tests.yml` som kjører kun ved `repository_dispatch` og `failure()`
- Laster ned `test-summary`-artifactet og parser `test-summary.json` for passed/failed/flaky/skipped/known-error og testnavn
- `.github/slack-users.json` med mapping fra GitHub-brukernavn til Slack-handle for aktive teammedlemmer
- Mention-logikk: Slack user ID (`U[A-Z0-9]+`) gir ekte ping via `<@ID>`, handle gir synlig tekst `@rune.lind`, ingen mapping faller tilbake til GitHub-brukernavn

## Testing
- [x] YAML og JSON validert
- [x] jq-uttrykk testet mot eksisterende `test-summary.json`
- [x] Verifisere ekte melding i #melosys-ci — krever at `SLACK_WEBHOOK` secret er satt, og en reell failure etter merge

## Notes
- **Krever ny repo secret:** `SLACK_WEBHOOK` må settes til webhook som peker til #melosys-ci. Samme navn som brukes i andre melosys-repoer — kan gjenbrukes hvis webhooken allerede peker til riktig kanal.
- **Slack-handles vs IDer:** Filen bruker handles (f.eks. `rune.lind`) for synlig navn uten at vi må samle inn Slack user IDer først. Oppgrader til Slack user ID (f.eks. `U01ABC123`) i `slack-users.json` for ekte ping.