### PR TITLE
NOJIRA Fiks flyttall-presisjon i fakturaserie-verifisering

### DIFF
--- a/helpers/fakturering-helper.ts
+++ b/helpers/fakturering-helper.ts
@@ -168,6 +168,24 @@ export class FaktureringHelper {
     return serier.reduce((sum, serie) => sum + this.totalBelop(serie, aar), 0);
   }
 
+  /**
+   * Hent og slå sammen flere fakturaserie-kjeder, deduplisert på referanse.
+   * Nødvendig når krediterings-serier lenkes til flere kjeder via erstattet_med.
+   */
+  async hentSammenslåttKjede(...referanser: string[]): Promise<Fakturaserie[]> {
+    const kjeder = await Promise.all(referanser.map(r => this.hentFakturaserieKjede(r)));
+    const sett = new Map<string, Fakturaserie>();
+    kjeder.flat().forEach(s => sett.set(s.fakturaserieReferanse, s));
+    return [...sett.values()];
+  }
+
+  /**
+   * Avrund beløp til 2 desimaler (unngår floating point epsilon-avvik)
+   */
+  avrundBelop(belop: number): number {
+    return parseFloat(belop.toFixed(2));
+  }
+
   // --- Convenience methods ---
 
   /**

--- a/helpers/fakturering-helper.ts
+++ b/helpers/fakturering-helper.ts
@@ -144,6 +144,30 @@ export class FaktureringHelper {
     return await response.json();
   }
 
+  /**
+   * Hent fakturaserie-kjede by referanse (inkluderer krediterings-serier via erstattet_med-kjeden)
+   *
+   * Bruker query-parameter-endepunktet som traverserer hele erstattet_med-kjeden,
+   * i motsetning til hentFakturaserie som kun returnerer én serie.
+   */
+  async hentFakturaserieKjede(referanse: string): Promise<Fakturaserie[]> {
+    const response = await this.callEndpoint('GET', `/fakturaserier?referanse=${referanse}`);
+
+    if (!response.ok()) {
+      const text = await response.text();
+      throw new Error(`Failed to get fakturaserie-kjede ${referanse}: ${response.status()} - ${text}`);
+    }
+
+    return await response.json();
+  }
+
+  /**
+   * Get total beløp for en hel fakturaserie-kjede (inkl. krediteringer), eventuelt filtrert på år
+   */
+  totalBelopKjede(serier: Fakturaserie[], aar?: number): number {
+    return serier.reduce((sum, serie) => sum + this.totalBelop(serie, aar), 0);
+  }
+
   // --- Convenience methods ---
 
   /**

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-arbeidsinntekt-nv-kansellering.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-arbeidsinntekt-nv-kansellering.spec.ts
@@ -94,7 +94,7 @@ test.describe('Komplett saksflyt - Flere land med pensjon-dekning og NV-kanselle
         await trygdeavgift.ventPåSideLastet();
         await trygdeavgift.velgSkattepliktig(false);
         await trygdeavgift.velgInntektskilde('ARBEIDSINNTEKT');
-        await trygdeavgift.fyllInnBruttoinntektMedApiVent('10000');
+        await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
         await trygdeavgift.klikkBekreftOgFortsett();
 
         // Step 8: Vedtak
@@ -168,15 +168,17 @@ test.describe('Komplett saksflyt - Flere land med pensjon-dekning og NV-kanselle
         }
 
         const faktureringHelper = new FaktureringHelper(request);
-        const opprinneligFakturaserie = await faktureringHelper.hentFakturaserie(opprinneligFakturaserieReferanse);
-        const arsavregningFakturaserie = await faktureringHelper.hentFakturaserie(arsavregningFakturaserieRef);
+        const opprinneligKjede = await faktureringHelper.hentFakturaserieKjede(opprinneligFakturaserieReferanse);
+        const arsavregningKjede = await faktureringHelper.hentFakturaserieKjede(arsavregningFakturaserieRef);
 
-        faktureringHelper.loggFakturaserie(opprinneligFakturaserie);
-        faktureringHelper.loggFakturaserie(arsavregningFakturaserie);
+        // Dedupliser serier som finnes i begge kjeder (kreditering kan lenkes til begge)
+        const sett = new Map<string, Fakturaserie>();
+        [...opprinneligKjede, ...arsavregningKjede].forEach(s => sett.set(s.fakturaserieReferanse, s));
+        const alleSerier = [...sett.values()];
 
-        const opprinneligTotal = faktureringHelper.totalBelop(opprinneligFakturaserie);
-        const arsavregningTotal = faktureringHelper.totalBelop(arsavregningFakturaserie);
-        const sum = opprinneligTotal + arsavregningTotal;
+        alleSerier.forEach(s => faktureringHelper.loggFakturaserie(s));
+
+        const sum = Math.round(faktureringHelper.totalBelopKjede(alleSerier) * 100) / 100;
 
         expect(sum, 'Sum av fakturaserier skal være 0').toBe(0);
     });

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-arbeidsinntekt-nv-kansellering.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-arbeidsinntekt-nv-kansellering.spec.ts
@@ -157,29 +157,26 @@ test.describe('Komplett saksflyt - Flere land med pensjon-dekning og NV-kanselle
 
         console.log('✅ Workflow completed successfully!');
 
-        //Verifiserer at annulering har avregnet innværende fakturalinjer
+        // Verifiserer at annulering har avregnet innværende fakturalinjer
+        // Nyvurderingen (behandlingId) annulleres uten vedtak, så den har ingen fakturaserie
 
         const opprinneligFakturaserieReferanse = await getFakturaserieReferanse(opprinneligBehandlingId);
-        const fakturaserieReferanse = await getFakturaserieReferanse(behandlingId);
         const arsavregningFakturaserieRef = await getFakturaserieReferanse(arsavregningBehandlingId);
 
-        if (opprinneligFakturaserieReferanse === undefined || fakturaserieReferanse === undefined || arsavregningFakturaserieRef === undefined) {
-            throw new Error(`Fakturaserie referanse er ikke satt. Opprinnelig: ${opprinneligFakturaserieReferanse} (behandlingId: ${opprinneligBehandlingId}), Ny: ${fakturaserieReferanse} (behandlingId: ${behandlingId})`);
+        if (opprinneligFakturaserieReferanse === undefined || arsavregningFakturaserieRef === undefined) {
+            throw new Error(`Fakturaserie referanse er ikke satt. Opprinnelig: ${opprinneligFakturaserieReferanse} (behandlingId: ${opprinneligBehandlingId}), Årsavregning: ${arsavregningFakturaserieRef} (behandlingId: ${arsavregningBehandlingId})`);
         }
 
         const faktureringHelper = new FaktureringHelper(request);
         const opprinneligFakturaserie = await faktureringHelper.hentFakturaserie(opprinneligFakturaserieReferanse);
-        const fakturaserie = await faktureringHelper.hentFakturaserie(fakturaserieReferanse);
         const arsavregningFakturaserie = await faktureringHelper.hentFakturaserie(arsavregningFakturaserieRef);
 
         faktureringHelper.loggFakturaserie(opprinneligFakturaserie);
-        faktureringHelper.loggFakturaserie(fakturaserie);
         faktureringHelper.loggFakturaserie(arsavregningFakturaserie);
 
         const opprinneligTotal = faktureringHelper.totalBelop(opprinneligFakturaserie);
         const arsavregningTotal = faktureringHelper.totalBelop(arsavregningFakturaserie);
-        const nyTotal = faktureringHelper.totalBelop(fakturaserie);
-        const sum = opprinneligTotal + arsavregningTotal + nyTotal;
+        const sum = opprinneligTotal + arsavregningTotal;
 
         expect(sum, 'Sum av fakturaserier skal være 0').toBe(0);
     });

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-arbeidsinntekt-nv-kansellering.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-arbeidsinntekt-nv-kansellering.spec.ts
@@ -168,17 +168,11 @@ test.describe('Komplett saksflyt - Flere land med pensjon-dekning og NV-kanselle
         }
 
         const faktureringHelper = new FaktureringHelper(request);
-        const opprinneligKjede = await faktureringHelper.hentFakturaserieKjede(opprinneligFakturaserieReferanse);
-        const arsavregningKjede = await faktureringHelper.hentFakturaserieKjede(arsavregningFakturaserieRef);
-
-        // Dedupliser serier som finnes i begge kjeder (kreditering kan lenkes til begge)
-        const sett = new Map<string, Fakturaserie>();
-        [...opprinneligKjede, ...arsavregningKjede].forEach(s => sett.set(s.fakturaserieReferanse, s));
-        const alleSerier = [...sett.values()];
+        const alleSerier = await faktureringHelper.hentSammenslåttKjede(opprinneligFakturaserieReferanse, arsavregningFakturaserieRef);
 
         alleSerier.forEach(s => faktureringHelper.loggFakturaserie(s));
 
-        const sum = Math.round(faktureringHelper.totalBelopKjede(alleSerier) * 100) / 100;
+        const sum = faktureringHelper.avrundBelop(faktureringHelper.totalBelopKjede(alleSerier));
 
         expect(sum, 'Sum av fakturaserier skal være 0').toBe(0);
     });

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-arbeidsinntekt.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-arbeidsinntekt.spec.ts
@@ -95,7 +95,7 @@ test.describe('Komplett saksflyt - Flere land med arbeidsinntekt', () => {
         await trygdeavgift.ventPåSideLastet();
         await trygdeavgift.velgSkattepliktig(false);
         await trygdeavgift.velgInntektskilde('ARBEIDSINNTEKT');
-        await trygdeavgift.fyllInnBruttoinntektMedApiVent('10000');
+        await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
         await trygdeavgift.klikkBekreftOgFortsett();
 
         // Step 8: Vedtak
@@ -153,20 +153,21 @@ test.describe('Komplett saksflyt - Flere land med arbeidsinntekt', () => {
         }
 
         const faktureringHelper = new FaktureringHelper(request);
-        const opprinneligFakturaserie = await faktureringHelper.hentFakturaserie(opprinneligFakturaserieReferanse);
-        const fakturaserie = await faktureringHelper.hentFakturaserie(fakturaserieReferanse);
+        const opprinneligKjede = await faktureringHelper.hentFakturaserieKjede(opprinneligFakturaserieReferanse);
+        const nyKjede = await faktureringHelper.hentFakturaserieKjede(fakturaserieReferanse);
 
-        faktureringHelper.loggFakturaserie(opprinneligFakturaserie);
-        faktureringHelper.loggFakturaserie(fakturaserie);
+        // Dedupliser serier som finnes i begge kjeder
+        const sett = new Map<string, Fakturaserie>();
+        [...opprinneligKjede, ...nyKjede].forEach(s => sett.set(s.fakturaserieReferanse, s));
+        const alleSerier = [...sett.values()];
+
+        alleSerier.forEach(s => faktureringHelper.loggFakturaserie(s));
 
         const avregningsÅr = getYearFromDate(period.end)
-        const opprinneligTotal = faktureringHelper.totalBelop(opprinneligFakturaserie, avregningsÅr);
-        const nyTotal = faktureringHelper.totalBelop(fakturaserie, avregningsÅr);
-        const sum = opprinneligTotal + nyTotal;
+        const sum = Math.round(faktureringHelper.totalBelopKjede(alleSerier, avregningsÅr) * 100) / 100;
 
-        console.log(`Opprinnelig serie 2026: ${opprinneligTotal} kr`);
-        console.log(`Ny serie 2026: ${nyTotal} kr`);
+        console.log(`Sum kjede for ${avregningsÅr}: ${sum} kr`);
 
-        expect(sum, 'Sum av fakturaserier for 2026 skal være 0').toBe(0);
+        expect(sum, `Sum av fakturaserier for ${avregningsÅr} skal være 0`).toBe(0);
     });
 });

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-arbeidsinntekt.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-arbeidsinntekt.spec.ts
@@ -153,18 +153,12 @@ test.describe('Komplett saksflyt - Flere land med arbeidsinntekt', () => {
         }
 
         const faktureringHelper = new FaktureringHelper(request);
-        const opprinneligKjede = await faktureringHelper.hentFakturaserieKjede(opprinneligFakturaserieReferanse);
-        const nyKjede = await faktureringHelper.hentFakturaserieKjede(fakturaserieReferanse);
-
-        // Dedupliser serier som finnes i begge kjeder
-        const sett = new Map<string, Fakturaserie>();
-        [...opprinneligKjede, ...nyKjede].forEach(s => sett.set(s.fakturaserieReferanse, s));
-        const alleSerier = [...sett.values()];
+        const alleSerier = await faktureringHelper.hentSammenslåttKjede(opprinneligFakturaserieReferanse, fakturaserieReferanse);
 
         alleSerier.forEach(s => faktureringHelper.loggFakturaserie(s));
 
         const avregningsÅr = getYearFromDate(period.end)
-        const sum = Math.round(faktureringHelper.totalBelopKjede(alleSerier, avregningsÅr) * 100) / 100;
+        const sum = faktureringHelper.avrundBelop(faktureringHelper.totalBelopKjede(alleSerier, avregningsÅr));
 
         console.log(`Sum kjede for ${avregningsÅr}: ${sum} kr`);
 

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-nv-annulering-lukker-åpne-årsavregninger.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-nv-annulering-lukker-åpne-årsavregninger.spec.ts
@@ -179,7 +179,7 @@ test.describe('Komplett saksflyt - NV annulering lukker åpne årsavregninger', 
         opprinneligKjede.forEach(s => faktureringHelper.loggFakturaserie(s));
 
         const avregningsÅr = getYearFromDate(period.end)
-        const sum = Math.round(faktureringHelper.totalBelopKjede(opprinneligKjede, avregningsÅr) * 100) / 100;
+        const sum = faktureringHelper.avrundBelop(faktureringHelper.totalBelopKjede(opprinneligKjede, avregningsÅr));
 
         console.log(`Sum kjede for ${avregningsÅr}: ${sum} kr`);
 

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-nv-annulering-lukker-åpne-årsavregninger.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-nv-annulering-lukker-åpne-årsavregninger.spec.ts
@@ -95,7 +95,7 @@ test.describe('Komplett saksflyt - NV annulering lukker åpne årsavregninger', 
         await trygdeavgift.ventPåSideLastet();
         await trygdeavgift.velgSkattepliktig(false);
         await trygdeavgift.velgInntektskilde('ARBEIDSINNTEKT');
-        await trygdeavgift.fyllInnBruttoinntektMedApiVent('10000');
+        await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
         await trygdeavgift.klikkBekreftOgFortsett();
 
         // Step 8: Vedtak
@@ -174,15 +174,15 @@ test.describe('Komplett saksflyt - NV annulering lukker åpne årsavregninger', 
         }
 
         const faktureringHelper = new FaktureringHelper(request);
-        const opprinneligFakturaserie = await faktureringHelper.hentFakturaserie(opprinneligFakturaserieReferanse);
+        const opprinneligKjede = await faktureringHelper.hentFakturaserieKjede(opprinneligFakturaserieReferanse);
 
-        faktureringHelper.loggFakturaserie(opprinneligFakturaserie);
+        opprinneligKjede.forEach(s => faktureringHelper.loggFakturaserie(s));
 
         const avregningsÅr = getYearFromDate(period.end)
-        const opprinneligTotal = faktureringHelper.totalBelop(opprinneligFakturaserie, avregningsÅr);
+        const sum = Math.round(faktureringHelper.totalBelopKjede(opprinneligKjede, avregningsÅr) * 100) / 100;
 
-        console.log(`Opprinnelig serie: ${opprinneligTotal} kr`);
+        console.log(`Sum kjede for ${avregningsÅr}: ${sum} kr`);
 
-        expect(opprinneligTotal, `Opprinnelig fakturaserie for ${avregningsÅr} skal være kansellert (0)`).toBe(0);
+        expect(sum, `Fakturaserie-kjede for ${avregningsÅr} skal summere til 0`).toBe(0);
     });
 });

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-nv-annulering-lukker-åpne-årsavregninger.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-nv-annulering-lukker-åpne-årsavregninger.spec.ts
@@ -164,30 +164,25 @@ test.describe('Komplett saksflyt - NV annulering lukker åpne årsavregninger', 
             ).toBe('FERDIGBEHANDLET');
         });
 
-        // Verifiserer at ny vurdering har avregnet innværende fakturalinjer
+        // Verifiserer at annulering har kansellert fakturalinjer
+        // Nyvurderingen (behandlingId) annulleres uten vedtak, så den har ingen fakturaserie
 
         const opprinneligFakturaserieReferanse = await getFakturaserieReferanse(opprinneligBehandlingId);
-        const fakturaserieReferanse = await getFakturaserieReferanse(behandlingId);
 
-        if (opprinneligFakturaserieReferanse === undefined || fakturaserieReferanse === undefined) {
-            throw new Error(`Fakturaserie referanse er ikke satt. Opprinnelig: ${opprinneligFakturaserieReferanse} (behandlingId: ${opprinneligBehandlingId}), Ny: ${fakturaserieReferanse} (behandlingId: ${behandlingId})`);
+        if (opprinneligFakturaserieReferanse === undefined) {
+            throw new Error(`Fakturaserie referanse er ikke satt for opprinnelig behandling ${opprinneligBehandlingId}`);
         }
 
         const faktureringHelper = new FaktureringHelper(request);
         const opprinneligFakturaserie = await faktureringHelper.hentFakturaserie(opprinneligFakturaserieReferanse);
-        const fakturaserie = await faktureringHelper.hentFakturaserie(fakturaserieReferanse);
 
         faktureringHelper.loggFakturaserie(opprinneligFakturaserie);
-        faktureringHelper.loggFakturaserie(fakturaserie);
 
         const avregningsÅr = getYearFromDate(period.end)
         const opprinneligTotal = faktureringHelper.totalBelop(opprinneligFakturaserie, avregningsÅr);
-        const nyTotal = faktureringHelper.totalBelop(fakturaserie, avregningsÅr);
-        const sum = opprinneligTotal + nyTotal;
 
         console.log(`Opprinnelig serie: ${opprinneligTotal} kr`);
-        console.log(`Ny serie: ${nyTotal} kr`);
 
-        expect(sum, `Sum av fakturaserier for ${avregningsÅr} skal være 0`).toBe(0);
+        expect(opprinneligTotal, `Opprinnelig fakturaserie for ${avregningsÅr} skal være kansellert (0)`).toBe(0);
     });
 });

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-nv-periode-endres-til-kun-tidligere-ar.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-nv-periode-endres-til-kun-tidligere-ar.spec.ts
@@ -171,18 +171,12 @@ test.describe('Komplett saksflyt - Flere land med arbeidsinntekt', () => {
         }
 
         const faktureringHelper = new FaktureringHelper(request);
-        const opprinneligKjede = await faktureringHelper.hentFakturaserieKjede(opprinneligFakturaserieReferanse);
-        const nyKjede = await faktureringHelper.hentFakturaserieKjede(fakturaserieReferanse);
-
-        // Dedupliser serier som finnes i begge kjeder
-        const sett = new Map<string, Fakturaserie>();
-        [...opprinneligKjede, ...nyKjede].forEach(s => sett.set(s.fakturaserieReferanse, s));
-        const alleSerier = [...sett.values()];
+        const alleSerier = await faktureringHelper.hentSammenslåttKjede(opprinneligFakturaserieReferanse, fakturaserieReferanse);
 
         alleSerier.forEach(s => faktureringHelper.loggFakturaserie(s));
 
         const avregningsÅr = getYearFromDate(period.end)
-        const sum = Math.round(faktureringHelper.totalBelopKjede(alleSerier, avregningsÅr) * 100) / 100;
+        const sum = faktureringHelper.avrundBelop(faktureringHelper.totalBelopKjede(alleSerier, avregningsÅr));
 
         console.log(`Sum kjede for ${avregningsÅr}: ${sum} kr`);
 

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-nv-periode-endres-til-kun-tidligere-ar.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-nv-periode-endres-til-kun-tidligere-ar.spec.ts
@@ -96,7 +96,7 @@ test.describe('Komplett saksflyt - Flere land med arbeidsinntekt', () => {
         await trygdeavgift.ventPåSideLastet();
         await trygdeavgift.velgSkattepliktig(false);
         await trygdeavgift.velgInntektskilde('ARBEIDSINNTEKT');
-        await trygdeavgift.fyllInnBruttoinntektMedApiVent('10000');
+        await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
         await trygdeavgift.klikkBekreftOgFortsett();
 
         // Step 8: Vedtak
@@ -171,19 +171,20 @@ test.describe('Komplett saksflyt - Flere land med arbeidsinntekt', () => {
         }
 
         const faktureringHelper = new FaktureringHelper(request);
-        const opprinneligFakturaserie = await faktureringHelper.hentFakturaserie(opprinneligFakturaserieReferanse);
-        const fakturaserie = await faktureringHelper.hentFakturaserie(fakturaserieReferanse);
+        const opprinneligKjede = await faktureringHelper.hentFakturaserieKjede(opprinneligFakturaserieReferanse);
+        const nyKjede = await faktureringHelper.hentFakturaserieKjede(fakturaserieReferanse);
 
-        faktureringHelper.loggFakturaserie(opprinneligFakturaserie);
-        faktureringHelper.loggFakturaserie(fakturaserie);
+        // Dedupliser serier som finnes i begge kjeder
+        const sett = new Map<string, Fakturaserie>();
+        [...opprinneligKjede, ...nyKjede].forEach(s => sett.set(s.fakturaserieReferanse, s));
+        const alleSerier = [...sett.values()];
+
+        alleSerier.forEach(s => faktureringHelper.loggFakturaserie(s));
 
         const avregningsÅr = getYearFromDate(period.end)
-        const opprinneligTotal = faktureringHelper.totalBelop(opprinneligFakturaserie, avregningsÅr);
-        const nyTotal = faktureringHelper.totalBelop(fakturaserie, avregningsÅr);
-        const sum = opprinneligTotal + nyTotal;
+        const sum = Math.round(faktureringHelper.totalBelopKjede(alleSerier, avregningsÅr) * 100) / 100;
 
-        console.log(`Opprinnelig serie: ${opprinneligTotal} kr`);
-        console.log(`Ny serie: ${nyTotal} kr`);
+        console.log(`Sum kjede for ${avregningsÅr}: ${sum} kr`);
 
         expect(sum, `Sum av fakturaserier for ${avregningsÅr} skal være 0`).toBe(0);
     });


### PR DESCRIPTION
Fikser to tester som feiler på CI med floating-point presisjonsfeil ved sammenligning av fakturaserie-summer mot 0.

Testene gjorde rå addisjon av positive og negative beløp og sammenlignet med `.toBe(0)`. Resultatet ble matematisk 0, men IEEE 754-aritmetikk ga `-9.09e-13` — Jest's `.toBe()` bruker `Object.is` og godtar ikke det. Cherry-pickes fra `feature/ftrl-trygdeavgift-25-prosent-regel-e2e` der fiksen allerede finnes.

- Ny `FaktureringHelper.avrundBelop()` (toFixed(2)) brukt på sum-sammenligninger
- Ny `FaktureringHelper.hentSammenslåttKjede()` for parallell henting og deduplisering av kjeder
- Justert testdata for 25%-regelen (bruttoinntekt over minstebeløp)
- Fjernet feilaktig fakturaserie-sjekk for annullerte nyvurderinger uten vedtak

## Testing
- [ ] E2E-tester på CI grønne