### PR TITLE
NOJIRA Legg til per-run Unleash-toggle-overstyring i e2e-tester

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,6 +32,16 @@ on:
         required: false
         type: boolean
         default: false
+      unleash_force_disable:
+        description: 'Comma-separated Unleash toggles to force OFF for the whole run (e.g. melosys.trygdeavgift.25-prosentregel)'
+        required: false
+        type: string
+        default: ''
+      unleash_force_enable:
+        description: 'Comma-separated Unleash toggles to force ON for the whole run'
+        required: false
+        type: string
+        default: ''
 
   repository_dispatch:
     types:
@@ -482,6 +492,8 @@ jobs:
           CI: true
           RETRIES_DISABLED: ${{ inputs.disable_retries == true }}
           RECORD_API: ${{ inputs.record_api == true && 'true' || '' }}
+          UNLEASH_FORCE_DISABLE: ${{ inputs.unleash_force_disable }}
+          UNLEASH_FORCE_ENABLE: ${{ inputs.unleash_force_enable }}
 
       - name: Set test status outputs
         id: test-status

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -426,6 +426,15 @@ jobs:
           echo "TEST_START_TIME=$TEST_START_TIME" >> $GITHUB_OUTPUT
           echo "⏰ Test start time: $TEST_START_TIME"
 
+          # Report Unleash toggle overrides for this run (visible confirmation)
+          if [ -n "${{ inputs.unleash_force_disable }}" ] || [ -n "${{ inputs.unleash_force_enable }}" ]; then
+            echo "🎚️  Unleash overrides for this run:"
+            [ -n "${{ inputs.unleash_force_disable }}" ] && echo "    OFF: ${{ inputs.unleash_force_disable }}"
+            [ -n "${{ inputs.unleash_force_enable }}" ] && echo "    ON:  ${{ inputs.unleash_force_enable }}"
+          else
+            echo "🎚️  Unleash overrides: none (defaults apply)"
+          fi
+
           # Build Playwright command with optional filters
           PLAYWRIGHT_CMD="npx playwright test --project=chromium"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,40 @@ test('my test with unleash', async ({ page, request }) => {
 - Unleash UI available at `http://localhost:4242` (admin/unleash4all)
 - See `tests/unleash-eksempel.spec.ts` for complete examples
 
+#### Pinning a toggle for an ENTIRE run (local + CI)
+
+Use this when you want to run the **whole suite** with a toggle forced on/off (e.g. validating that a backend branch doesn't break existing tests with a feature toggle disabled). The per-test `disableFeature()` above is for a single test; this pins it for every test.
+
+The cleanup fixture calls `UnleashHelper.resetToDefaults()` before/after each test, and that method honors two comma-separated env vars (also works for toggles not in the default list):
+
+- `UNLEASH_FORCE_DISABLE` — toggles forced **OFF** for the whole run
+- `UNLEASH_FORCE_ENABLE` — toggles forced **ON** for the whole run
+
+**Local:**
+```bash
+UNLEASH_FORCE_DISABLE=melosys.trygdeavgift.25-prosentregel npm test
+# or put the same line in .env.local (gitignored) and just run: npm test
+```
+
+**GitHub Actions** (the `E2E Tests` workflow is dispatch-only) — use the `unleash_force_disable` / `unleash_force_enable` inputs:
+```bash
+gh workflow run "E2E Tests" \
+  --ref <branch> \
+  -f environment=melosys-api:<image-tag> \
+  -f unleash_force_disable=melosys.trygdeavgift.25-prosentregel
+```
+> The new inputs/code must exist on the dispatched `--ref`, so push the branch first.
+
+**Confirming it took effect:**
+- Cleanup log (local + CI) prints `⚙️ Unleash override: ... force-disable=[...]` before each test
+- The `Run Playwright tests` step echoes `🎚️ Unleash overrides for this run: OFF: ...`
+- The summary report (test-summary.md / GitHub job summary) shows a `🎚️ Unleash Toggle Overrides` section under Docker Image Tags
+- Verify from a finished run: `gh run view <run-id> --log | grep -m1 "OFF: <toggle>"`
+
+> Caveat: trygdeavgift-beregning polls Unleash on an interval, so the very first test after a reset may briefly still see the old state; since the value only moves toward the pinned state for the whole run, it self-corrects for subsequent tests.
+
+See `docs/guides/UNLEASH-DEBUGGING.md` for more detail.
+
 ### Docker Services Architecture
 
 The test suite depends on a full Docker Compose stack (17 services). **Locally**, use `../melosys-docker-compose`. **CI** uses `docker-compose.yml` in this repo. Key services:

--- a/docs/guides/UNLEASH-DEBUGGING.md
+++ b/docs/guides/UNLEASH-DEBUGGING.md
@@ -394,6 +394,54 @@ test('skal vise årsavregning advarsel når toggle er aktivert', ...)
 test('skal ikke vise årsavregning når toggle er deaktivert', ...)
 ```
 
+## Pinning a toggle for an entire run (local + CI)
+
+For per-test control use `unleash.disableFeature()` / `enableFeature()` inside the test. When you instead want the **whole suite** to run with a toggle forced on/off — e.g. validating that a backend branch doesn't break existing behaviour with a feature toggle disabled — use the run-level overrides.
+
+`UnleashHelper.resetToDefaults()` (called by the cleanup fixture before/after every test) reads two comma-separated env vars and applies them on top of the default toggle list, including toggles that are not part of that list:
+
+- `UNLEASH_FORCE_DISABLE` — toggles forced **OFF** for the whole run
+- `UNLEASH_FORCE_ENABLE` — toggles forced **ON** for the whole run
+
+### Local
+
+```bash
+UNLEASH_FORCE_DISABLE=melosys.trygdeavgift.25-prosentregel npm test
+# or add the line to .env.local (gitignored) and just run: npm test
+```
+
+Multiple toggles are comma-separated, e.g. `UNLEASH_FORCE_DISABLE=toggle.a,toggle.b`.
+
+### GitHub Actions
+
+The `E2E Tests` workflow is dispatch-only and exposes matching inputs:
+
+```bash
+gh workflow run "E2E Tests" \
+  --ref <branch> \
+  -f environment=melosys-api:<image-tag> \
+  -f unleash_force_disable=melosys.trygdeavgift.25-prosentregel \
+  -f unleash_force_enable=
+```
+
+The inputs are wired to the `UNLEASH_FORCE_DISABLE` / `UNLEASH_FORCE_ENABLE` env on the Playwright step. Because `gh workflow run` reads the workflow file from the remote `--ref`, push the branch first.
+
+### Confirming the override took effect
+
+1. **Cleanup log** (local + CI), printed before each test:
+   ```
+   ⚙️  Unleash override: force-enable=[] force-disable=[melosys.trygdeavgift.25-prosentregel]
+   ```
+2. **Workflow step echo** at the top of `Run Playwright tests`:
+   ```
+   🎚️  Unleash overrides for this run:
+       OFF: melosys.trygdeavgift.25-prosentregel
+   ```
+3. **Summary report** (`test-summary.md` / GitHub job summary / PR comment) shows a `🎚️ Unleash Toggle Overrides` section under Docker Image Tags.
+4. **From a finished run:** `gh run view <run-id> --log | grep -m1 "OFF: <toggle>"`
+
+> Caveat: trygdeavgift-beregning polls Unleash on an interval, so the very first test after a reset can briefly still see the old state. Since the value only ever moves toward the pinned state for the whole run, it self-corrects for subsequent tests.
+
 ## Configuration
 
 ### Timeout Settings

--- a/helpers/unleash-helper.ts
+++ b/helpers/unleash-helper.ts
@@ -382,7 +382,9 @@ export class UnleashHelper {
     for (const name of forceEnable) effective.set(name, true);
     for (const name of forceDisable) effective.set(name, false);
 
-    if (!silent && (forceEnable.length || forceDisable.length)) {
+    // Always log overrides (even in silent cleanup mode) so it is visible in the
+    // run output - both locally and on CI - that toggles were pinned for this run.
+    if (forceEnable.length || forceDisable.length) {
       console.log(
         `   ⚙️  Unleash override: force-enable=[${forceEnable.join(', ')}] force-disable=[${forceDisable.join(', ')}]`
       );

--- a/helpers/unleash-helper.ts
+++ b/helpers/unleash-helper.ts
@@ -336,6 +336,12 @@ export class UnleashHelper {
    * Reset all toggles to their default state (from seed script)
    * Default state: all toggles enabled except 'melosys.arsavregning.uten.flyt'
    *
+   * Per-run overrides (applied on top of the defaults, and to toggles not in the
+   * default list) can be supplied via comma-separated env vars:
+   *   - UNLEASH_FORCE_DISABLE - force these toggles OFF for the whole run
+   *   - UNLEASH_FORCE_ENABLE  - force these toggles ON for the whole run
+   * Example: UNLEASH_FORCE_DISABLE=melosys.trygdeavgift.25-prosentregel
+   *
    * @param silent - If true, suppresses individual toggle logging (default: false)
    * @param skipFrontendCheck - If true, only waits for Admin API (faster, for cleanup before test)
    */
@@ -361,11 +367,32 @@ export class UnleashHelper {
       { name: 'melosys.send_popp_hendelse', enabled: true },
     ];
 
-    for (const toggle of defaultToggles) {
-      if (toggle.enabled) {
-        await this.enableFeature(toggle.name, silent, skipFrontendCheck);
+    // Per-run overrides via env vars (comma-separated toggle names).
+    // Lets a whole test run pin specific toggles without code changes, e.g.
+    //   UNLEASH_FORCE_DISABLE=melosys.trygdeavgift.25-prosentregel
+    // Overrides are applied on top of the defaults above and also apply to
+    // toggles that are not part of the default list (like the 25-prosentregel).
+    const parseList = (value?: string): string[] =>
+      (value || '').split(',').map(s => s.trim()).filter(Boolean);
+    const forceEnable = parseList(process.env.UNLEASH_FORCE_ENABLE);
+    const forceDisable = parseList(process.env.UNLEASH_FORCE_DISABLE);
+
+    const effective = new Map<string, boolean>();
+    for (const toggle of defaultToggles) effective.set(toggle.name, toggle.enabled);
+    for (const name of forceEnable) effective.set(name, true);
+    for (const name of forceDisable) effective.set(name, false);
+
+    if (!silent && (forceEnable.length || forceDisable.length)) {
+      console.log(
+        `   ⚙️  Unleash override: force-enable=[${forceEnable.join(', ')}] force-disable=[${forceDisable.join(', ')}]`
+      );
+    }
+
+    for (const [name, enabled] of effective) {
+      if (enabled) {
+        await this.enableFeature(name, silent, skipFrontendCheck);
       } else {
-        await this.disableFeature(toggle.name, silent, skipFrontendCheck);
+        await this.disableFeature(name, silent, skipFrontendCheck);
       }
     }
   }

--- a/lib/summary-generator.test.ts
+++ b/lib/summary-generator.test.ts
@@ -757,6 +757,63 @@ describe('Summary Generator', () => {
 
   });
 
+  describe('Unleash Toggle Overrides', () => {
+
+    test('should render forced-off toggles', () => {
+      const data: TestSummaryData = {
+        status: 'passed',
+        duration: 10000,
+        tests: [createTest({ status: 'passed' })],
+        unleashOverrides: { forceDisable: ['melosys.trygdeavgift.25-prosentregel'] }
+      };
+
+      const result = generateMarkdownSummary(data);
+
+      assert(result.includes('## 🎚️ Unleash Toggle Overrides'));
+      assert(result.includes('❌ **OFF:** `melosys.trygdeavgift.25-prosentregel`'));
+    });
+
+    test('should render forced-on toggles', () => {
+      const data: TestSummaryData = {
+        status: 'passed',
+        duration: 10000,
+        tests: [createTest({ status: 'passed' })],
+        unleashOverrides: { forceEnable: ['melosys.some.toggle'] }
+      };
+
+      const result = generateMarkdownSummary(data);
+
+      assert(result.includes('## 🎚️ Unleash Toggle Overrides'));
+      assert(result.includes('✅ **ON:** `melosys.some.toggle`'));
+    });
+
+    test('should omit section when no overrides are set', () => {
+      const data: TestSummaryData = {
+        status: 'passed',
+        duration: 10000,
+        tests: [createTest({ status: 'passed' })]
+      };
+
+      const result = generateMarkdownSummary(data);
+
+      assert(!result.includes('Unleash Toggle Overrides'));
+    });
+
+    test('should omit section when override lists are empty', () => {
+      const data: TestSummaryData = {
+        status: 'passed',
+        duration: 10000,
+        tests: [createTest({ status: 'passed' })],
+        unleashOverrides: { forceDisable: [], forceEnable: [] }
+      };
+
+      const result = generateMarkdownSummary(data);
+
+      assert(!result.includes('Unleash Toggle Overrides'));
+    });
+
+  });
+
 });
 
 /**

--- a/lib/summary-generator.ts
+++ b/lib/summary-generator.ts
@@ -96,6 +96,19 @@ export function generateMarkdownSummary(
     }
   }
 
+  // Display Unleash toggle overrides if any toggles were pinned for this run
+  const overrides = data.unleashOverrides;
+  if (overrides && ((overrides.forceDisable?.length ?? 0) > 0 || (overrides.forceEnable?.length ?? 0) > 0)) {
+    md += `## 🎚️ Unleash Toggle Overrides\n\n`;
+    for (const name of overrides.forceDisable ?? []) {
+      md += `- ❌ **OFF:** \`${name}\`\n`;
+    }
+    for (const name of overrides.forceEnable ?? []) {
+      md += `- ✅ **ON:** \`${name}\`\n`;
+    }
+    md += '\n';
+  }
+
   md += `## Overall Results\n\n`;
   md += `- ✅ Passed: ${passed}\n`;
   md += `- ❌ Failed: ${failed}\n`;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -44,6 +44,10 @@ export interface TestSummaryData {
   tests: TestData[];
   tags?: Record<string, string>; // Docker image tags used in the test run
   retriesDisabled?: boolean; // When true, flaky tests are treated as failures
+  unleashOverrides?: {
+    forceDisable?: string[]; // Toggles forced OFF for the whole run
+    forceEnable?: string[]; // Toggles forced ON for the whole run
+  };
 }
 
 /**

--- a/reporters/test-summary.ts
+++ b/reporters/test-summary.ts
@@ -148,13 +148,26 @@ class TestSummaryReporter implements Reporter {
       }
     }
 
+    // Collect Unleash toggle overrides pinned for this run (UNLEASH_FORCE_DISABLE/ENABLE)
+    const parseToggleList = (value?: string): string[] =>
+      (value || '').split(',').map(s => s.trim()).filter(Boolean);
+    const forceDisable = parseToggleList(process.env.UNLEASH_FORCE_DISABLE);
+    const forceEnable = parseToggleList(process.env.UNLEASH_FORCE_ENABLE);
+    const hasOverrides = forceDisable.length > 0 || forceEnable.length > 0;
+
     const summaryData: TestSummaryData = {
       status: ciStatus,
       startTime: result.startTime,
       duration: result.duration,
       tests: testData,
       tags: Object.keys(tags).length > 0 ? tags : undefined,
-      retriesDisabled: retriesDisabled || undefined
+      retriesDisabled: retriesDisabled || undefined,
+      unleashOverrides: hasOverrides
+        ? {
+            forceDisable: forceDisable.length > 0 ? forceDisable : undefined,
+            forceEnable: forceEnable.length > 0 ? forceEnable : undefined,
+          }
+        : undefined
     };
 
     // Generate summary using shared module


### PR DESCRIPTION
Legger til en mekanisme for å pinne Unleash-toggles for en hel e2e-kjøring via env-variabler og workflow-inputs, med synlig logging av hvilke toggles som er overstyrt.

Vi trenger å kjøre hele e2e-suiten med `melosys.trygdeavgift.25-prosentregel` slått av for å verifisere at melosys-api `feature/7588` ikke bryter eksisterende oppførsel. Toggelen lå ikke i default-listen i `resetToDefaults()` og ble derfor aldri nullstilt, så den kunne ikke pinnes for hele kjøringen — verken lokalt eller i GitHub Actions. Denne mekanismen gjør det mulig begge steder uten å endre testkode.

- `UNLEASH_FORCE_DISABLE` / `UNLEASH_FORCE_ENABLE` (kommaseparerte toggle-navn) overstyrer i `resetToDefaults()`, også for toggles utenfor default-listen
- Nye `workflow_dispatch`-inputs `unleash_force_disable` / `unleash_force_enable`, koblet til Playwright-stegets env
- Synlig logging: override-linje i cleanup (også i silent-modus) + eget echo øverst i Playwright-steget

## Testing
- [x] Typecheck av `unleash-helper.ts` (`tsc --noEmit`, ingen nye feil)
- [ ] Manuell lokal kjøring med `UNLEASH_FORCE_DISABLE=melosys.trygdeavgift.25-prosentregel`
- [ ] E2E-kjøring via workflow_dispatch med `environment=melosys-api:<7588-tag>` og toggle av