### PR TITLE
NOJIRA Legg til E2E gap-tester (NV-eos, iverksetting, §2-8b, A003)

### DIFF
--- a/pages/behandling/eu-eos-behandling.page.ts
+++ b/pages/behandling/eu-eos-behandling.page.ts
@@ -508,6 +508,22 @@ export class EuEosBehandlingPage extends BasePage {
   }
 
   /**
+   * Velg obligatorisk "grunn for nytt vedtak" på vedtak-steget.
+   * For en nyvurdering (NV) er feltet påkrevd, og "Fatt vedtak" forblir
+   * deaktivert til en grunn er valgt.
+   *
+   * @param grunn - Grunn-kode (f.eks. 'FEIL_I_BEHANDLING')
+   */
+  async velgGrunnForNyttVedtak(grunn: string): Promise<void> {
+    const dropdown = this.page.getByRole('combobox', {
+      name: /Oppgi grunn for nytt vedtak/
+    });
+    await dropdown.waitFor({ state: 'visible', timeout: 10000 });
+    await dropdown.selectOption(grunn);
+    console.log(`✅ Valgte grunn for nytt vedtak: ${grunn}`);
+  }
+
+  /**
    * Klikk "Fatt vedtak" knapp for å fullføre behandlingen
    * EU/EØS fatter vedtak direkte uten egen vedtaksside
    *

--- a/tests/eu-eos/eu-eos-12.1-iverksetting-mottaker-kjede.spec.ts
+++ b/tests/eu-eos/eu-eos-12.1-iverksetting-mottaker-kjede.spec.ts
@@ -53,7 +53,8 @@ test.describe('EU/EØS 12.1 - Iverksetting mottaker-kjede (UTSENDT_ARBEIDSTAKER)
 
         await waitForProcessInstances(page.request, 30);
         await hovedside.goto();
-        await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).click();
+        // Robust mot async saksoversikt-lasting (reload-retry) i stedet for rå link-klikk
+        await hovedside.åpneBehandling('TRIVIELL KARAFFEL -');
         await page.waitForLoadState('networkidle');
 
         // Gå gjennom behandlingen frem til (men ikke inkludert) "Fatt vedtak"

--- a/tests/eu-eos/eu-eos-12.1-iverksetting-mottaker-kjede.spec.ts
+++ b/tests/eu-eos/eu-eos-12.1-iverksetting-mottaker-kjede.spec.ts
@@ -1,0 +1,147 @@
+import {test, expect} from '../../fixtures';
+import {AuthHelper} from '../../helpers/auth-helper';
+import {HovedsidePage} from '../../pages/hovedside.page';
+import {OpprettNySakPage} from '../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import {EuEosBehandlingPage} from '../../pages/behandling/eu-eos-behandling.page';
+import {USER_ID_VALID} from '../../pages/shared/constants';
+import {waitForProcessInstances} from '../../helpers/api-helper';
+import {withDatabase} from '../../helpers/db-helper';
+import {
+    fetchStoredSedDocuments, findNewNavFormatSed,
+    fetchStoredJournalposter, findNewUtgaaendeJournalpost,
+} from '../../helpers/mock-helper';
+
+/**
+ * EU/EØS 12.1 - Iverksetting / mottaker-kjede (UTSENDT_ARBEIDSTAKER)
+ *
+ * Gap: iverksetting-mottaker-kjede-brev-sed. Den eksisterende 12.1-testen stopper på
+ * "vedtak fattet" uten DB/SED/brev-assert. Denne verifiserer hele iverksettingskjeden
+ * for en utsendt arbeidstaker (PD-A1 / lovvalgsvedtak):
+ *  - IVERKSETT_VEDTAK_EOS fullfører (FERDIG, ingen feilede prosessinstanser)
+ *  - A009 lovvalgsvedtak-SED (LA_BUC_01) sendes til mottakerinstitusjon (Danmark)
+ *  - utgående EESSI-journalpost opprettes og ferdigstilles (hele Kafka-sløyfen)
+ *  - lovvalgsperioden overføres til MEDL (medlperiode_id satt)
+ *
+ * NB: Utsendt arbeidstaker (LA_BUC_01) sender A009, ikke A003 (som "arbeid i flere land"/LA_BUC_02).
+ */
+const FRA = '01.01.2024';
+const TIL = '31.12.2025';
+
+test.describe('EU/EØS 12.1 - Iverksetting mottaker-kjede (UTSENDT_ARBEIDSTAKER)', () => {
+    test('skal iverksette vedtak og verifisere MEDL-periode, A009 SED og utgående journalpost', async ({page, request}) => {
+        test.setTimeout(150000);
+
+        const auth = new AuthHelper(page);
+        await auth.login();
+
+        const hovedside = new HovedsidePage(page);
+        const opprettSak = new OpprettNySakPage(page);
+        const behandling = new EuEosBehandlingPage(page);
+
+        // Opprett utsendt-arbeidstaker-sak (Danmark)
+        await hovedside.goto();
+        await hovedside.klikkOpprettNySak();
+        await opprettSak.fyllInnBrukerID(USER_ID_VALID);
+        await opprettSak.velgSakstype('EU_EOS');
+        await opprettSak.velgSakstema('MEDLEMSKAP_LOVVALG');
+        await opprettSak.velgBehandlingstema('UTSENDT_ARBEIDSTAKER');
+        await behandling.fyllInnFraTilDato(FRA, TIL);
+        await behandling.velgLand('Danmark');
+        await opprettSak.velgAarsak('SØKNAD');
+        await opprettSak.leggBehandlingIMine();
+        await opprettSak.klikkOpprettNyBehandling();
+
+        await waitForProcessInstances(page.request, 30);
+        await hovedside.goto();
+        await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).click();
+        await page.waitForLoadState('networkidle');
+
+        // Gå gjennom behandlingen frem til (men ikke inkludert) "Fatt vedtak"
+        await behandling.klikkBekreftOgFortsett();
+        await behandling.velgYrkesaktivEllerSelvstendigOgFortsett(true);
+        await behandling.velgArbeidsgiverOgFortsett('Ståles Stål AS');
+        await behandling.velgArbeidstype(true);
+        await behandling.svarJaOgFortsett();
+        await behandling.svarJaOgFortsett();
+        await behandling.innvilgeSøknad();
+        await behandling.klikkBekreftOgFortsett();
+        await behandling.velgMottakerInstitusjon();
+
+        // Snapshot SED- og journalpost-tilstand FØR vedtak (iverksetting sender SED/oppretter JP)
+        const docsBefore = await fetchStoredSedDocuments(request, 'A009');
+        const jpBefore = await fetchStoredJournalposter(request);
+
+        await behandling.fattVedtak();
+
+        console.log('📝 Venter på iverksetting (kaster ved feilede prosessinstanser)...');
+        await waitForProcessInstances(page.request, 60);
+
+        // === 1. A009 lovvalgsvedtak-SED (LA_BUC_01) sendt til EESSI-mottaker ===
+        const sed = await findNewNavFormatSed(request, 'A009', docsBefore);
+        expect(sed.sed).toBe('A009');
+        expect(sed.sedVer).toBe('4');
+        console.log(`✅ A009 SED sendt til EESSI (sedVer=${sed.sedVer})`);
+
+        // === 2. Utgående EESSI-journalpost opprettet og ferdigstilt (mottaker Danmark) ===
+        const jp = await findNewUtgaaendeJournalpost(request, jpBefore);
+        expect(jp, 'Forventet UTGAAENDE EESSI-journalpost etter iverksetting').not.toBeNull();
+        expect(jp!.journalStatus, 'Journalpost skal være ferdigstilt (J)').toBe('J');
+        expect(jp!.kanal).toBe('EESSI');
+        expect((jp!.avsenderMottaker?.id ?? '').split(':')[0], 'SED skal være sendt til DK').toBe('DK');
+        console.log(`✅ Utgående EESSI-journalpost til DK (id=${jp!.journalpostId}, mottaker=${jp!.avsenderMottaker?.id})`);
+
+        // === 3. IVERKSETT_VEDTAK_EOS FERDIG + MEDL-periode overført ===
+        await withDatabase(async (db) => {
+            const iverksett = await db.queryOne<{ BEHANDLING_ID: number; STATUS: string; SIST_FULLFORT_STEG: string }>(
+                `SELECT PI.BEHANDLING_ID, PI.STATUS, PI.SIST_FULLFORT_STEG
+                 FROM PROSESSINSTANS PI
+                 WHERE PI.PROSESS_TYPE = 'IVERKSETT_VEDTAK_EOS'
+                   AND PI.REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE
+                 ORDER BY PI.REGISTRERT_DATO DESC
+                 FETCH FIRST 1 ROWS ONLY`,
+                {}
+            );
+            expect(iverksett, 'Forventet IVERKSETT_VEDTAK_EOS-prosessinstans').not.toBeNull();
+            expect(iverksett!.STATUS, 'IVERKSETT_VEDTAK_EOS skal være FERDIG').toBe('FERDIG');
+            console.log(`✅ IVERKSETT_VEDTAK_EOS FERDIG (behandlingId=${iverksett!.BEHANDLING_ID}, sist steg=${iverksett!.SIST_FULLFORT_STEG})`);
+
+            // Lovvalgsperiode skal være opprettet og overført til MEDL (medlperiode_id satt)
+            const periode = await db.queryOne<{ FOM: string; TOM: string; LOVVALGSLAND: string; MEDLPERIODE_ID: number | null }>(
+                `SELECT
+                   TO_CHAR(lp.fom_dato, 'DD.MM.YYYY') AS FOM,
+                   TO_CHAR(lp.tom_dato, 'DD.MM.YYYY') AS TOM,
+                   lp.lovvalgsland AS LOVVALGSLAND,
+                   lp.medlperiode_id AS MEDLPERIODE_ID
+                 FROM lovvalg_periode lp
+                 ORDER BY lp.id DESC
+                 FETCH FIRST 1 ROWS ONLY`,
+                {}
+            );
+            expect(periode, 'Forventet en lovvalgsperiode etter iverksetting').not.toBeNull();
+            expect(periode!.FOM).toBe(FRA);
+            expect(periode!.TOM).toBe(TIL);
+            expect(periode!.LOVVALGSLAND).toBe('NO');
+            expect(periode!.MEDLPERIODE_ID, 'Lovvalgsperioden skal være overført til MEDL (medlperiode_id satt)').not.toBeNull();
+            console.log(`✅ MEDL-periode opprettet: ${periode!.FOM} – ${periode!.TOM} (${periode!.LOVVALGSLAND}, medlperiode_id=${periode!.MEDLPERIODE_ID})`);
+
+            // Vedtaksbrev produsert via dokgen og sendt (INNVILGELSE_YRKESAKTIV → BRUKER)
+            const sendBrev = await db.query<{ DATA: string; STATUS: string }>(
+                `SELECT PI.DATA, PI.STATUS
+                 FROM PROSESSINSTANS PI
+                 WHERE PI.BEHANDLING_ID = :behandlingId
+                   AND PI.PROSESS_TYPE = 'SEND_BREV'`,
+                { behandlingId: iverksett!.BEHANDLING_ID }
+            );
+            const vedtaksbrev = sendBrev.find(b => (b.DATA || '').includes('INNVILGELSE_YRKESAKTIV'));
+            expect(vedtaksbrev, 'Forventet et innvilgelsesbrev (SEND_BREV) for vedtaket').toBeTruthy();
+            expect(vedtaksbrev!.STATUS, 'Vedtaksbrev skal være FERDIG').toBe('FERDIG');
+            console.log('✅ Vedtaksbrev (INNVILGELSE_YRKESAKTIV → BRUKER) produsert og FERDIG');
+
+            // Merk: "Skatteinnkrever-kopi" sendes ikke som en egen observerbar SEND_BREV-
+            // prosessinstans i lokal stack for denne flyten (kun innvilgelsesbrevet til BRUKER
+            // opprettes). Den asserteres derfor ikke her — vi unngår en falsk-grønn vakt.
+        });
+
+        console.log('✅ Iverksettingskjede for UTSENDT_ARBEIDSTAKER verifisert');
+    });
+});

--- a/tests/eu-eos/eu-eos-12.1-nyvurdering-medl-overforing.spec.ts
+++ b/tests/eu-eos/eu-eos-12.1-nyvurdering-medl-overforing.spec.ts
@@ -56,7 +56,8 @@ test.describe('EU/EØS - Nyvurdering (MEDL-overføring)', () => {
 
         await waitForProcessInstances(page.request, 30);
         await hovedside.goto();
-        await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).click();
+        // Robust mot async saksoversikt-lasting (reload-retry) i stedet for rå link-klikk
+        await hovedside.åpneBehandling('TRIVIELL KARAFFEL -');
         await page.waitForLoadState('networkidle');
 
         console.log('📝 Del A: Fullfører førstegangs behandling til vedtak...');
@@ -78,9 +79,9 @@ test.describe('EU/EØS - Nyvurdering (MEDL-overføring)', () => {
         await opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD');
         await waitForProcessInstances(page.request, 30);
 
-        // Åpne den NYE aktive behandlingen (første lenke = nyeste)
+        // Åpne den NYE aktive behandlingen (åpneBehandling tar første lenke = nyeste, med reload-retry)
         await hovedside.goto();
-        await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).first().click();
+        await hovedside.åpneBehandling('TRIVIELL KARAFFEL -');
         await page.waitForLoadState('networkidle');
 
         // === DEL C: Forkort lovvalgsperioden og fatt nytt vedtak ===

--- a/tests/eu-eos/eu-eos-12.1-nyvurdering-medl-overforing.spec.ts
+++ b/tests/eu-eos/eu-eos-12.1-nyvurdering-medl-overforing.spec.ts
@@ -1,0 +1,175 @@
+import {test, expect} from '../../fixtures';
+import {AuthHelper} from '../../helpers/auth-helper';
+import {HovedsidePage} from '../../pages/hovedside.page';
+import {OpprettNySakPage} from '../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import {EuEosBehandlingPage} from '../../pages/behandling/eu-eos-behandling.page';
+import {USER_ID_VALID} from '../../pages/shared/constants';
+import {waitForProcessInstances} from '../../helpers/api-helper';
+import {withDatabase} from '../../helpers/db-helper';
+
+/**
+ * Nyvurdering på EU/EØS utsendt arbeidstaker - MEDL-overføring
+ *
+ * Gap: nv-eos-utsendt-medl-overforing (toppen av e2e-dekningshullet, score 9).
+ * Ingen e2e dekker en Nyvurdering på en EU/EØS utsendt-sak. Bug-tett område:
+ * 7045/6125 (feil MEDL-overføring ved NV), 8034 (A011 mottak bruker utdatert
+ * lovvalgsperiode fra minnet → feilede prosessinstanser).
+ *
+ * Scenario:
+ * 1. Fullfør en førstegangs utsendt-sak → vedtak (periode 01.01.2024–31.12.2025, Danmark)
+ * 2. Opprett Nyvurdering på samme sak
+ * 3. Forkort lovvalgsperioden (til-dato 31.12.2025 → 30.06.2025)
+ * 4. Fatt nytt vedtak
+ * 5. Verifiser at:
+ *    - iverksettingen ikke gir feilede prosessinstanser (waitForProcessInstances kaster ved FAILED)
+ *    - nyeste IVERKSETT_VEDTAK_EOS er FERDIG (MEDL-overføring skjer som steg LAGRE_LOVVALGSPERIODE_MEDL her)
+ *    - nyeste lovvalgsperiode i DB reflekterer den FORKORTEDE perioden (ikke en utdatert periode)
+ */
+const FØRSTE_FRA = '01.01.2024';
+const FØRSTE_TIL = '31.12.2025';
+const NV_FORKORTET_TIL = '30.06.2025';
+
+test.describe('EU/EØS - Nyvurdering (MEDL-overføring)', () => {
+    test('skal forkorte lovvalgsperiode via nyvurdering og overføre ny periode til MEDL', async ({page}) => {
+        test.setTimeout(180000);
+
+        const auth = new AuthHelper(page);
+        await auth.login();
+
+        const hovedside = new HovedsidePage(page);
+        const opprettSak = new OpprettNySakPage(page);
+        const behandling = new EuEosBehandlingPage(page);
+
+        // === DEL A: Førstegangs utsendt-sak → vedtak ===
+        console.log('📝 Del A: Oppretter førstegangs utsendt-sak...');
+        await hovedside.goto();
+        await hovedside.klikkOpprettNySak();
+        await opprettSak.fyllInnBrukerID(USER_ID_VALID);
+        await opprettSak.velgSakstype('EU_EOS');
+        await opprettSak.velgSakstema('MEDLEMSKAP_LOVVALG');
+        await opprettSak.velgBehandlingstema('UTSENDT_ARBEIDSTAKER');
+        await behandling.fyllInnFraTilDato(FØRSTE_FRA, FØRSTE_TIL);
+        await behandling.velgLand('Danmark');
+        await opprettSak.velgAarsak('SØKNAD');
+        await opprettSak.leggBehandlingIMine();
+        await opprettSak.klikkOpprettNyBehandling();
+
+        await waitForProcessInstances(page.request, 30);
+        await hovedside.goto();
+        await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).click();
+        await page.waitForLoadState('networkidle');
+
+        console.log('📝 Del A: Fullfører førstegangs behandling til vedtak...');
+        await behandling.klikkBekreftOgFortsett();
+        await behandling.velgYrkesaktivEllerSelvstendigOgFortsett(true);
+        await behandling.velgArbeidsgiverOgFortsett('Ståles Stål AS');
+        await behandling.velgArbeidstype(true);
+        await behandling.svarJaOgFortsett();
+        await behandling.svarJaOgFortsett();
+        await behandling.innvilgeOgFattVedtak();
+
+        console.log('📝 Del A: Venter på iverksetting av førstegangsvedtak...');
+        await waitForProcessInstances(page.request, 30);
+
+        // === DEL B: Opprett Nyvurdering ===
+        console.log('📝 Del B: Oppretter nyvurdering...');
+        await hovedside.goto();
+        await hovedside.klikkOpprettNySak();
+        await opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD');
+        await waitForProcessInstances(page.request, 30);
+
+        // Åpne den NYE aktive behandlingen (første lenke = nyeste)
+        await hovedside.goto();
+        await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).first().click();
+        await page.waitForLoadState('networkidle');
+
+        // === DEL C: Forkort lovvalgsperioden og fatt nytt vedtak ===
+        console.log(`📝 Del C: Forkorter lovvalgsperioden (til-dato → ${NV_FORKORTET_TIL})...`);
+        // Forkort perioden via "Periode og land" → "Rediger" i opplysninger-panelet
+        // (i NV-behandlingen er ikke perioden et eget steg; den endres her).
+        await page.getByRole('button', { name: 'Periode og land' }).click();
+        const periodeOgLandPanel = page.getByRole('complementary').filter({ hasText: 'Periode og land' });
+        await periodeOgLandPanel.getByRole('button', { name: 'Rediger' }).first().click();
+        const tilField = periodeOgLandPanel.getByRole('textbox', { name: 'Til og med' });
+        await tilField.click();
+        await tilField.fill(NV_FORKORTET_TIL);
+        await tilField.press('Enter');
+        // Enter committer som regel lagringen; klikk "Lagre" kun hvis editoren fortsatt er åpen
+        const lagreBtn = periodeOgLandPanel.getByRole('button', { name: 'Lagre' });
+        if (await lagreBtn.isVisible().catch(() => false)) {
+            await lagreBtn.click();
+        }
+        // Vent til panelet viser den forkortede perioden (lagring fullført)
+        await expect(periodeOgLandPanel.getByText(`${FØRSTE_FRA} - ${NV_FORKORTET_TIL}`)).toBeVisible({ timeout: 10000 });
+        console.log(`✅ Lovvalgsperiode forkortet i UI: ${FØRSTE_FRA} - ${NV_FORKORTET_TIL}`);
+
+        // Gå gjennom stegene på nytt og fatt vedtak
+        await behandling.klikkBekreftOgFortsett();
+        await behandling.velgYrkesaktivEllerSelvstendigOgFortsett(true);
+        await behandling.velgArbeidsgiverOgFortsett('Ståles Stål AS');
+        await behandling.velgArbeidstype(true);
+        await behandling.svarJaOgFortsett();
+        await behandling.svarJaOgFortsett();
+
+        // Vedtak-steget for en NV krever obligatorisk "grunn for nytt vedtak"
+        await behandling.innvilgeSøknad();
+        await behandling.klikkBekreftOgFortsett();
+        await behandling.velgMottakerInstitusjon();
+        await behandling.velgGrunnForNyttVedtak('FEIL_I_BEHANDLING');
+        await behandling.fattVedtak();
+
+        // === DEL D: Verifiser MEDL-overføring + prosessinstans FERDIG ===
+        console.log('📝 Del D: Venter på iverksetting av NV-vedtak (kaster ved feilede prosessinstanser)...');
+        await waitForProcessInstances(page.request, 30);
+
+        await withDatabase(async (db) => {
+            // Ingen feilede prosessinstanser de siste 10 min (fanger 8034-klassen)
+            const feilede = await db.query<{ PROSESS_TYPE: string; STATUS: string }>(
+                `SELECT PI.PROSESS_TYPE, PI.STATUS
+                 FROM PROSESSINSTANS PI
+                 WHERE PI.STATUS = 'FEILET'
+                   AND PI.REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE`,
+                {}
+            );
+            expect(feilede, `Forventet ingen feilede prosessinstanser, fant: ${JSON.stringify(feilede)}`).toHaveLength(0);
+
+            // Nyeste IVERKSETT_VEDTAK_EOS skal være FERDIG (MEDL-overføring skjer som steg her)
+            const iverksett = await db.queryOne<{ STATUS: string; SIST_FULLFORT_STEG: string }>(
+                `SELECT PI.STATUS, PI.SIST_FULLFORT_STEG
+                 FROM PROSESSINSTANS PI
+                 WHERE PI.PROSESS_TYPE = 'IVERKSETT_VEDTAK_EOS'
+                   AND PI.REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE
+                 ORDER BY PI.REGISTRERT_DATO DESC
+                 FETCH FIRST 1 ROWS ONLY`,
+                {}
+            );
+            expect(iverksett, 'Forventet en IVERKSETT_VEDTAK_EOS-prosessinstans etter NV-vedtak').not.toBeNull();
+            expect(iverksett!.STATUS, 'NV-iverksetting skal være FERDIG').toBe('FERDIG');
+            console.log(`✅ IVERKSETT_VEDTAK_EOS FERDIG (sist fullført steg: ${iverksett!.SIST_FULLFORT_STEG})`);
+
+            // Nyeste lovvalgsperiode skal reflektere den FORKORTEDE perioden (ikke utdatert periode).
+            // Databasen renses før hver test, så nyeste rad (høyest id) = nyvurderingens periode.
+            const periode = await db.queryOne<{ FOM: string; TOM: string; LOVVALGSLAND: string; MEDLPERIODE_ID: number | null }>(
+                `SELECT
+                   TO_CHAR(lp.fom_dato, 'DD.MM.YYYY') AS FOM,
+                   TO_CHAR(lp.tom_dato, 'DD.MM.YYYY') AS TOM,
+                   lp.lovvalgsland AS LOVVALGSLAND,
+                   lp.medlperiode_id AS MEDLPERIODE_ID
+                 FROM lovvalg_periode lp
+                 ORDER BY lp.id DESC
+                 FETCH FIRST 1 ROWS ONLY`,
+                {}
+            );
+            expect(periode, 'Forventet en lovvalgsperiode etter NV').not.toBeNull();
+            // Lovvalgsland for utsendt norsk arbeidstaker er NO (Norge beholder lovvalget)
+            expect(periode!.LOVVALGSLAND).toBe('NO');
+            expect(periode!.FOM).toBe(FØRSTE_FRA);
+            expect(periode!.TOM, 'Lovvalgsperiode skal være forkortet av nyvurderingen (ikke utdatert periode)').toBe(NV_FORKORTET_TIL);
+            // MEDL-overføring: perioden skal være registrert i MEDL (medlperiode_id satt)
+            expect(periode!.MEDLPERIODE_ID, 'Lovvalgsperioden skal være overført til MEDL (medlperiode_id satt)').not.toBeNull();
+            console.log(`✅ MEDL-overført lovvalgsperiode forkortet: ${periode!.FOM} – ${periode!.TOM} (${periode!.LOVVALGSLAND}, medlperiode_id=${periode!.MEDLPERIODE_ID})`);
+        });
+
+        console.log('✅ NV på EU/EØS utsendt-sak fullført med korrekt MEDL-overføring');
+    });
+});

--- a/tests/eu-eos/eu-eos-13.1-arbeid-flere-land-selvstendig-fullfort-vedtak.spec.ts
+++ b/tests/eu-eos/eu-eos-13.1-arbeid-flere-land-selvstendig-fullfort-vedtak.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '../../fixtures';
+import { test, expect } from '../../fixtures';
 import { AuthHelper } from '../../helpers/auth-helper';
 import { HovedsidePage } from '../../pages/hovedside.page';
 import { OpprettNySakPage } from '../../pages/opprett-ny-sak/opprett-ny-sak.page';
@@ -6,6 +6,7 @@ import { EuEosBehandlingPage } from '../../pages/behandling/eu-eos-behandling.pa
 import { ArbeidFlereLandBehandlingPage } from '../../pages/behandling/arbeid-flere-land-behandling.page';
 import { USER_ID_VALID, EU_EOS_LAND } from '../../pages/shared/constants';
 import { waitForProcessInstances } from '../../helpers/api-helper';
+import { fetchStoredSedDocuments, findNewNavFormatSed } from '../../helpers/mock-helper';
 
 /**
  * EU/EØS 13.1 - Arbeid i flere land (Selvstendig næringsvirksomhet variant)
@@ -29,7 +30,7 @@ import { waitForProcessInstances } from '../../helpers/api-helper';
  * Denne testen dekker varianten med selvstendig næringsvirksomhet og SED-dokument popup.
  */
 test.describe('EU/EØS 13.1 - Arbeid i flere land (Selvstendig variant)', () => {
-  test('skal fullføre "Arbeid i flere land" med selvstendig næringsvirksomhet og SED-dokument', async ({ page }) => {
+  test('skal fullføre "Arbeid i flere land" med selvstendig næringsvirksomhet og SED-dokument', async ({ page, request }) => {
     // Øk test timeout til 120 sekunder (vedtak kan ta lang tid på CI)
     test.setTimeout(120000);
 
@@ -105,14 +106,34 @@ test.describe('EU/EØS 13.1 - Arbeid i flere land (Selvstendig variant)', () => 
     // Steg 8: Velg institusjon som skal motta SED
     await behandling.velgInstitusjonSomSkalMottaSed('Sverige');
 
+    // Snapshot A003-dokumenter før vedtak (SED sendes ved iverksetting av vedtak)
+    const docsBefore = await fetchStoredSedDocuments(request, 'A003');
+
     // Steg 9: Fatt vedtak
     await behandling.fattVedtak();
 
     console.log('✅ "Arbeid i flere land" (Selvstendig variant) arbeidsflyt fullført med POM');
 
-    // Database-verifisering (valgfri - kan kommenteres inn ved behov)
-    /*
-    await behandling.assertions.verifiserKomplettBehandling(USER_ID_VALID, 'NO');
-    */
+    // === Verifiser SED A003-innhold (lovvalgsvedtak til utland) ===
+    // Gap: a003-ut-innholds-assertion. A003 sendes implisitt av flere vedtak-tester,
+    // men ingen asserterer innholdet slik A001/A008 gjøres.
+    const sedContent = await findNewNavFormatSed(request, 'A003', docsBefore);
+    expect(sedContent.sed).toBe('A003');
+    expect(sedContent.sedVer).toBe('4');
+    expect(sedContent.sedGVer).toBe('4');
+
+    const medlemskap = sedContent.medlemskap as Record<string, any>;
+
+    // Artikkel: selvstendig næringsvirksomhet i flere land = art. 13(2)(a)
+    expect(medlemskap.relevantartikkelfor8832004eller9872009).toBe('13_2_a');
+
+    // Lovvalgsland og vedtaksperiode skal speile saken (NO, 19.11.2025–18.11.2026)
+    const vedtak = medlemskap.vedtak as Record<string, any>;
+    expect(vedtak.land).toBe('NO');
+    expect(vedtak.gjelderperiode?.startdato).toBe('2025-11-19');
+    expect(vedtak.gjelderperiode?.sluttdato).toBe('2026-11-18');
+    expect(vedtak.eropprinneligvedtak).toBe('ja');
+
+    console.log('✅ SED A003-innhold verifisert (art. 13(2)(a), lovvalgsland NO, periode 19.11.2025–18.11.2026)');
   });
 });

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-2-8b-student.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-2-8b-student.spec.ts
@@ -1,0 +1,92 @@
+import {test} from '../../../fixtures';
+import {AuthHelper} from '../../../helpers/auth-helper';
+import {HovedsidePage} from '../../../pages/hovedside.page';
+import {OpprettNySakPage} from '../../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import {MedlemskapPage} from '../../../pages/behandling/medlemskap.page';
+import {ArbeidsforholdPage} from '../../../pages/behandling/arbeidsforhold.page';
+import {LovvalgPage} from '../../../pages/behandling/lovvalg.page';
+import {ResultatPeriodePage} from '../../../pages/behandling/resultat-periode.page';
+import {TrygdeavgiftPage} from '../../../pages/trygdeavgift/trygdeavgift.page';
+import {VedtakPage} from '../../../pages/vedtak/vedtak.page';
+import {USER_ID_VALID} from '../../../pages/shared/constants';
+import {TestPeriods} from '../../../helpers/date-helper';
+
+/**
+ * Komplett saksflyt - FTRL § 2-8 første ledd bokstav b (student, frivillig medlemskap)
+ *
+ * Gap: ftrl-2-8b-student-full-flyt. § 2-8b fantes kun i deaktiverte discovery-notater
+ * (se docs/lovvalg/LOVVALG-2-8-B-DISCOVERY.md). Denne dekker full førstegangs vedtaksflyt
+ * med trygdeavgift.
+ *
+ * Mønster kopiert fra komplett-sak-2-8a.spec.ts. Forskjell mot § 2-8a:
+ * - bestemmelse FTRL_KAP2_2_8_FØRSTE_LEDD_B
+ * - 4 betingede lovvalgsspørsmål (§ 2-8a har 3): det ekstra er "Er søker student ...".
+ */
+test.describe('Komplett saksflyt - Utenfor avtaleland', () => {
+    test('skal fullføre komplett saksflyt med § 2-8 første ledd bokstav b (student)', async ({page, request}) => {
+        // Setup: Authentication
+        const auth = new AuthHelper(page);
+        await auth.login();
+
+        // Setup: Page Objects
+        const hovedside = new HovedsidePage(page);
+        const opprettSak = new OpprettNySakPage(page);
+        const medlemskap = new MedlemskapPage(page);
+        const arbeidsforhold = new ArbeidsforholdPage(page);
+        const lovvalg = new LovvalgPage(page);
+        const resultatPeriode = new ResultatPeriodePage(page);
+        const trygdeavgift = new TrygdeavgiftPage(page);
+        const vedtak = new VedtakPage(page);
+
+        // Step 1: Create new case
+        console.log('📝 Step 1: Creating new case...');
+        await hovedside.gotoOgOpprettNySak();
+        await opprettSak.opprettStandardSak(USER_ID_VALID);
+        await opprettSak.assertions.verifiserBehandlingOpprettet();
+
+        // Step 2: Navigate to behandling
+        console.log('📝 Step 2: Opening behandling...');
+        await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).click();
+
+        // Step 3: Fill Medlemskap (using dynamic dates to avoid year-boundary issues)
+        const period = TestPeriods.standardPeriod;
+        console.log(`📝 Step 3: Filling medlemskap information (${period.start} - ${period.end})...`);
+        await medlemskap.velgPeriode(period.start, period.end);
+        await medlemskap.velgLand('Afghanistan');
+        await medlemskap.velgTrygdedekning('FTRL_2_9_FØRSTE_LEDD_C_HELSE_PENSJON');
+        await medlemskap.klikkBekreftOgFortsett();
+
+        // Step 4: Select Arbeidsforhold
+        console.log('📝 Step 4: Selecting arbeidsforhold...');
+        await arbeidsforhold.fyllUtArbeidsforhold('Ståles Stål AS');
+
+        // Step 5: Answer Lovvalg questions (§ 2-8b: 4 betingede spørsmål)
+        console.log('📝 Step 5: Answering lovvalg questions (§ 2-8b student)...');
+        await lovvalg.velgBestemmelse('FTRL_KAP2_2_8_FØRSTE_LEDD_B');
+        await lovvalg.svarJaPaaFørsteSpørsmål();                                // Q1: ikke omfattet av annet lands lovgivning
+        await lovvalg.svarJaPaaSpørsmålIGruppe('Er søker student');            // Q2: student ved universitet/høgskole (kun § 2-8b)
+        await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker vært medlem i minst'); // Q3: medlem i minst tre av fem siste år
+        await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker nær tilknytning til'); // Q4: nær tilknytning til norsk samfunn
+        await lovvalg.klikkBekreftOgFortsett();
+
+        // Step 6: Select Resultat Periode - explicitly set INNVILGET to avoid default "Avslått"
+        console.log('📝 Step 6: Setting resultat periode to INNVILGET...');
+        await resultatPeriode.fyllUtResultatPeriode('INNVILGET');
+
+        // Step 7: Handle Trygdeavgift page
+        console.log('📝 Step 7: Handling trygdeavgift...');
+        await trygdeavgift.ventPåSideLastet();
+
+        await trygdeavgift.velgSkattepliktig(false);
+        await trygdeavgift.velgInntektskilde('INNTEKT_FRA_UTLANDET');
+        await trygdeavgift.velgBetalesAga(false);
+        await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
+        await trygdeavgift.klikkBekreftOgFortsett();
+
+        // Step 8: Fatt vedtak
+        console.log('📝 Step 8: Making decision...');
+        await vedtak.klikkFattVedtak();
+
+        console.log('✅ § 2-8b (student) workflow completed');
+    });
+});

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-2-8b-student.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-2-8b-student.spec.ts
@@ -44,9 +44,9 @@ test.describe('Komplett saksflyt - Utenfor avtaleland', () => {
         await opprettSak.opprettStandardSak(USER_ID_VALID);
         await opprettSak.assertions.verifiserBehandlingOpprettet();
 
-        // Step 2: Navigate to behandling
+        // Step 2: Navigate to behandling (robust mot async saksoversikt-lasting via reload-retry)
         console.log('📝 Step 2: Opening behandling...');
-        await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).click();
+        await hovedside.åpneBehandling('TRIVIELL KARAFFEL -');
 
         // Step 3: Fill Medlemskap (using dynamic dates to avoid year-boundary issues)
         const period = TestPeriods.standardPeriod;


### PR DESCRIPTION
Legger til fire E2E-tester fra dekningsgap-backloggen (Tier 0+1) som lukker den strukturelle gapfronten der "alle tester grønne" ikke betød "trygt å merge" — særlig nyvurdering og iverksetting for EU/EØS.

Produksjonsbugene i lovvalg/MEDL-overføring klynger seg rundt nyvurderings-overgangen (7045/6125/8034). Den viktigste nye testen verifiserer at en forkortet lovvalgsperiode faktisk overføres til MEDL (medlperiode_id) uten feilede prosessinstanser, og fanger dermed stale-periode-feilklassen.

- NV på EU/EØS utsendt arbeidstaker → forkort periode → vedtak → MEDL-overføring (det øverste reelle gapet)
- Iverksetting-mottaker-kjede for utsendt arbeidstaker (A009 SED, utgående EESSI-journalpost, MEDL-periode, vedtaksbrev)
- FTRL §2-8b student full vedtaksflyt
- Innholds-assertering av utgående A003 SED i art.13-flyten
- Ny POM-metode `EuEosBehandlingPage.velgGrunnForNyttVedtak`

## Testing
- [x] Alle fire grønne lokalt
- [x] Full E2E-suite grønn på CI (83 passed, 0 failed) — [run 27189409692](https://github.com/navikt/melosys-e2e-tests/actions/runs/27189409692)

## Notater
NV-testen krever RINA-mock-endepunktet `PUT /cpi/buc/{id}/sed/{id}` fra navikt/melosys-docker-compose#145. CI-kjøringen over brukte feature-tagget mock-image (`e2e-nv-eos-sed-update`). Før denne merges bør #145 merges og mock `:latest` re-releases, ellers feiler NV-testen (405) på ordinær CI mot `:latest`-mock.