### PR TITLE
Fjern død verifiserPeriodeIDatabase og rett stale assertions-doks

### DIFF
--- a/pages/behandling/arbeid-flere-land-behandling.assertions.ts
+++ b/pages/behandling/arbeid-flere-land-behandling.assertions.ts
@@ -82,33 +82,6 @@ export class ArbeidFlereLandBehandlingAssertions {
   }
 
   /**
-   * Verifiser periode-datoer i databasen
-   *
-   * @param fnr - Brukerens personnummer
-   * @param fraOgMed - Forventet startdato (DD.MM.YYYY)
-   * @param tilOgMed - Forventet sluttdato (DD.MM.YYYY)
-   */
-  async verifiserPeriodeIDatabase(
-    _fnr: string,
-    fraOgMed: string,
-    tilOgMed: string
-  ): Promise<void> {
-    await withDatabase(async (db) => {
-      // Nyeste lovvalgsperiode (ren DB per fixture). Kolonnene heter FOM_DATO/TOM_DATO.
-      const result = await db.queryOne(
-        `SELECT TO_CHAR(FOM_DATO, 'DD.MM.YYYY') as FOM_DATO,
-                TO_CHAR(TOM_DATO, 'DD.MM.YYYY') as TOM_DATO
-         FROM LOVVALG_PERIODE ORDER BY ID DESC`
-      );
-
-      expect(result).not.toBeNull();
-      expect(result.FOM_DATO).toBe(fraOgMed);
-      expect(result.TOM_DATO).toBe(tilOgMed);
-      console.log(`✅ Verifisert periode i database: ${fraOgMed} - ${tilOgMed}`);
-    });
-  }
-
-  /**
    * Verifiser at vedtak ble fattet (VEDTAK-tabellen)
    *
    * @param fnr - Brukerens personnummer

--- a/pages/behandling/eu-eos-behandling.assertions.ts
+++ b/pages/behandling/eu-eos-behandling.assertions.ts
@@ -94,8 +94,10 @@ export class EuEosBehandlingAssertions {
   /**
    * Verifiser at lovvalgsperiode ble opprettet i databasen
    *
-   * @param fnr - Brukerens personnummer
-   * @param land - Forventet landkode (f.eks. 'DK' for Danmark)
+   * @param fnr - Brukerens personnummer (brukes ikke som filter — se merknad under)
+   * @param land - Forventet LOVVALGSLAND, dvs. landet hvis lovgivning gjelder.
+   *   For en norsk utsendt arbeidstaker er dette 'NO' (Norge beholder lovvalget),
+   *   IKKE destinasjonslandet (f.eks. 'DK'). Utelat når domene-verdien er usikker.
    */
   async verifiserLovvalgsperiodeIDatabase(_fnr: string, land?: string): Promise<void> {
     await withDatabase(async (db) => {
@@ -110,33 +112,6 @@ export class EuEosBehandlingAssertions {
         expect(result.LOVVALGSLAND).toBe(land);
       }
       console.log(`✅ Verifisert lovvalgsperiode i database: LOVVALGSLAND = ${result.LOVVALGSLAND}${land ? ` (forventet ${land})` : ''}`);
-    });
-  }
-
-  /**
-   * Verifiser periode-datoer i databasen
-   *
-   * @param fnr - Brukerens personnummer
-   * @param fraOgMed - Forventet startdato (DD.MM.YYYY)
-   * @param tilOgMed - Forventet sluttdato (DD.MM.YYYY)
-   */
-  async verifiserPeriodeIDatabase(
-    _fnr: string,
-    fraOgMed: string,
-    tilOgMed: string
-  ): Promise<void> {
-    await withDatabase(async (db) => {
-      // Nyeste lovvalgsperiode (ren DB per fixture). Kolonnene heter FOM_DATO/TOM_DATO.
-      const result = await db.queryOne(
-        `SELECT TO_CHAR(FOM_DATO, 'DD.MM.YYYY') as FOM_DATO,
-                TO_CHAR(TOM_DATO, 'DD.MM.YYYY') as TOM_DATO
-         FROM LOVVALG_PERIODE ORDER BY ID DESC`
-      );
-
-      expect(result).not.toBeNull();
-      expect(result.FOM_DATO).toBe(fraOgMed);
-      expect(result.TOM_DATO).toBe(tilOgMed);
-      console.log(`✅ Verifisert periode i database: ${fraOgMed} - ${tilOgMed}`);
     });
   }
 

--- a/tests/eu-eos/README.md
+++ b/tests/eu-eos/README.md
@@ -8,7 +8,7 @@ EU/EØS-saker håndterer tilfeller hvor arbeidstakere sendes ut til EU/EØS-land
 
 ## Testfiler
 
-### `eu-eos-fullfort-vedtak.spec.ts`
+### `eu-eos-12.1-utsent-arbeidstager-fullfort-vedtak.spec.ts`
 
 **Komplett arbeidsflyt test** som dekker:
 1. Opprett ny EU/EØS-sak (UTSENDT_ARBEIDSTAKER)
@@ -100,9 +100,14 @@ Verifiseringsmetoder for database og UI:
 - `verifiserIngenFeil()` - Ingen feil på siden
 - `verifiserBehandlingIDatabase(fnr)` - Verifiser behandling i DB
 - `verifiserLovvalgsperiodeIDatabase(fnr, land)` - Verifiser lovvalgsperiode i DB
-- `verifiserPeriodeIDatabase(fnr, fraOgMed, tilOgMed)` - Verifiser periode i DB
 - `verifiserVedtakIDatabase(fnr)` - Verifiser vedtak i DB
 - `verifiserKomplettBehandling(fnr, land)` - Komplett verifisering
+
+> **Merk:** `fnr`-argumentet brukes ikke som filter. Cleanup-fixturen tømmer Oracle-DB-en
+> før hver test, så assertion-metodene leser nyeste rad (høyest `id`) = testens behandling.
+> `land` = `LOVVALGSLAND` (landet hvis lovgivning gjelder), ikke destinasjonslandet — for en
+> norsk utsendt arbeidstaker er dette `'NO'`. Trenger du å assertere periode-datoer, gjør det
+> inline (se `eu-eos-12.1-iverksetting-mottaker-kjede.spec.ts`).
 
 ### `ArbeidFlereLandBehandlingPage`
 **Lokasjon:** `pages/behandling/arbeid-flere-land-behandling.page.ts`
@@ -137,9 +142,8 @@ Verifiseringsmetoder for "Arbeid i flere land" workflow:
 - `verifiserIngenFeil()` - Ingen feil på siden
 - `verifiserBehandlingIDatabase(fnr)` - Verifiser behandling (ARBEID_FLERE_LAND)
 - `verifiserLovvalgsperiodeIDatabase(fnr, land)` - Verifiser lovvalgsperiode
-- `verifiserPeriodeIDatabase(fnr, fraOgMed, tilOgMed)` - Verifiser periode
 - `verifiserVedtakIDatabase(fnr)` - Verifiser vedtak
-- `verifiserKomplettBehandling(fnr, land)` - Komplett verifisering
+- `verifiserKomplettBehandling(fnr, land)` - Komplett verifisering (jf. merknaden over om `fnr`/`land`)
 
 ## Konstanter
 
@@ -308,15 +312,17 @@ await behandling.fattVedtak();
 
 ## Database-verifisering
 
-Alle tester rydder automatisk data via cleanup-fixture. Du kan verifisere database-tilstand:
+Alle tester rydder automatisk data via cleanup-fixture, så assertion-metodene leser nyeste rad
+(`fnr` brukes ikke som filter). `land` = `LOVVALGSLAND` — for en norsk utsendt arbeidstaker er
+dette `'NO'`, ikke destinasjonslandet. Du kan verifisere database-tilstand:
 
 ```typescript
 await behandling.assertions.verifiserBehandlingIDatabase(USER_ID_VALID);
-await behandling.assertions.verifiserLovvalgsperiodeIDatabase(USER_ID_VALID, 'DK');
+await behandling.assertions.verifiserLovvalgsperiodeIDatabase(USER_ID_VALID, 'NO');
 await behandling.assertions.verifiserVedtakIDatabase(USER_ID_VALID);
 
-// Eller komplett verifisering
-await behandling.assertions.verifiserKomplettBehandling(USER_ID_VALID, 'DK');
+// Eller komplett verifisering (utelat land når domene-verdien er usikker)
+await behandling.assertions.verifiserKomplettBehandling(USER_ID_VALID);
 ```
 
 ## Kjøre tester


### PR DESCRIPTION
Rydder opp i DB-assertion-metodene for EU/EØS-behandling: sletter den eneste reelt døde metoden og retter villedende dokumentasjon. Ingen funksjonell endring i kjørende tester.

Metodene i `eu-eos-behandling.assertions.ts` og `arbeid-flere-land-behandling.assertions.ts` ble flagget som stale (antatt å treffe feil Oracle-skjema og kaste ORA-00942). Undersøkelse mot live Oracle viser at de allerede er skjema-korrekte (fikset i #260) og at `verifiserKomplettBehandling` er brukt av to grønne tester. Tabellene er `BEHANDLING`/`LOVVALG_PERIODE`/`VEDTAK_METADATA` (det finnes ingen `VEDTAK`-tabell), og det er ingen fnr-kolonne å joine på i `behandling→fagsak`-kjeden — så metodene leser korrekt nyeste rad etter cleanup-fixturen og ignorerer `_fnr`. Eneste reelt døde metode var `verifiserPeriodeIDatabase`.

- Sletter ubrukt `verifiserPeriodeIDatabase` fra begge assertions-filene (periode-datoer asserteres bedre inline av 12.1-testene)
- Presiserer i doks/README at `fnr` ikke brukes som filter, og at `land` = `LOVVALGSLAND` (`NO` for norsk utsendt arbeidstaker, ikke destinasjonslandet `DK`)
- Retter stale `eu-eos/README`: riktig spec-filnavn og fjerner det feilaktige `DK`-eksemplet

## Testing
- [x] `eu-eos-12.1-utsent-arbeidstager-fullfort-vedtak` kjørt grønn lokalt (verifiserer behandling/lovvalgsperiode/vedtak i DB, `LOVVALGSLAND = NO`)
- [x] `tsc --noEmit` — ingen nye typefeil i de endrede filene
- [x] `npm run check:tests` (vacuous-test-guardrail) OK