### PR TITLE
NOJIRA E2E-test for annullering av EU/EØS-sak (MEDL-avvisning)

### DIFF
--- a/helpers/mock-helper.ts
+++ b/helpers/mock-helper.ts
@@ -175,6 +175,45 @@ export async function findNewUtgaaendeJournalpost(
   return null;
 }
 
+/**
+ * A MEDL membership-exception period stored in the melosys-mock MEDL register.
+ * Mirrors MedlemskapsunntakForGet in melosys-mock.
+ *
+ * The `status` field is a PeriodestatusMedl code: 'GYLD' (gyldig/active),
+ * 'AVST' (avsluttet/withdrawn — set when melosys-api avviser a period) or 'UAVK'.
+ */
+export interface MedlPeriodeInfo {
+  unntakId: number;
+  status: string | null;
+  grunnlag: string | null;
+  lovvalg: string | null;
+  lovvalgsland: string | null;
+  fraOgMed: string | null;
+  tilOgMed: string | null;
+  medlem: boolean | null;
+}
+
+/**
+ * Fetch a single MEDL membership-exception period from the melosys-mock MEDL
+ * register by its periode id (the value stored in lovvalg_periode.medlperiode_id).
+ *
+ * Used to verify MEDL transitions end-to-end — e.g. that a period was avvist
+ * (status flips GYLD → AVST) when a sak is annullert.
+ *
+ * @param request   - Playwright APIRequestContext
+ * @param periodeId - The MEDL periode id (lovvalg_periode.medlperiode_id)
+ */
+export async function fetchMedlPeriode(
+  request: APIRequestContext,
+  periodeId: number
+): Promise<MedlPeriodeInfo> {
+  const response = await request.get(`http://localhost:8083/api/v1/medlemskapsunntak/${periodeId}`);
+  if (!response.ok()) {
+    throw new Error(`Failed to fetch MEDL periode ${periodeId}: ${response.status()}`);
+  }
+  return response.json();
+}
+
 export interface MockClearResponse {
   message: string;
   journalpostCleared?: string | number;

--- a/pages/behandling/annullering.assertions.ts
+++ b/pages/behandling/annullering.assertions.ts
@@ -1,0 +1,99 @@
+import {APIRequestContext, expect, Page} from '@playwright/test';
+import {withDatabase} from '../../helpers/db-helper';
+import {fetchMedlPeriode} from '../../helpers/mock-helper';
+
+/**
+ * Verifications for annullering of an EU/EØS (or trygdeavtale) sak.
+ *
+ * Encapsulates the database + MEDL-mock assertions that prove an annullering
+ * was iverksatt correctly. Mirrors the backend integration test
+ * `AnnuleringNyVurderingEøsOgTrygdeavtaleIT`, but verifies the outcome
+ * end-to-end through the real stack.
+ *
+ * @example
+ * const annullering = new AnnulleringPage(page);
+ * await annullering.annullerSak();
+ * await annullering.assertions.verifiserAnnulleringIverksatt(request, medlPeriodeId);
+ */
+export class AnnulleringAssertions {
+    constructor(private readonly page: Page) {
+    }
+
+    /**
+     * Verify (as a precondition, before annullering) that a MEDL-periode is
+     * active/valid in the MEDL register. Makes the later AVST-assertion a real
+     * before/after delta rather than a single-point check.
+     */
+    async verifiserMedlPeriodeGyldig(request: APIRequestContext, medlPeriodeId: number): Promise<void> {
+        const periode = await fetchMedlPeriode(request, medlPeriodeId);
+        expect(periode.status, `MEDL-periode ${medlPeriodeId} skal være GYLD før annullering`).toBe('GYLD');
+        console.log(`✅ MEDL-periode ${medlPeriodeId} er GYLD (aktiv) før annullering`);
+    }
+
+    /**
+     * Verify the full outcome of an annullert EU/EØS-sak (ANNULLER_SAK iverksatt):
+     *  - fagsak satt til ANNULLERT
+     *  - ny-vurderings-behandlingen avsluttet med behandlingsresultat ANNULLERT
+     *  - ny-vurderingens lovvalgsperiode slettet (slettLovvalgsperiode), den
+     *    opprinnelige perioden står igjen som INNVILGET
+     *  - MEDL-perioden avvist (status GYLD → AVST) — kjernen i MELOSYS-7668
+     *  - ANNULLER_SAK fullført uten feilede prosessinstanser
+     *
+     * @param request      - Playwright APIRequestContext (for MEDL-mock-oppslag)
+     * @param medlPeriodeId - MEDL-periode-id fra den opprinnelige lovvalgsperioden
+     */
+    async verifiserAnnulleringIverksatt(request: APIRequestContext, medlPeriodeId: number): Promise<void> {
+        await withDatabase(async (db) => {
+            // === Fagsak satt til ANNULLERT ===
+            const fagsak = await db.queryOne<{ SAKSNUMMER: string; STATUS: string }>(
+                `SELECT saksnummer, status FROM fagsak ORDER BY registrert_dato DESC FETCH FIRST 1 ROWS ONLY`, {});
+            expect(fagsak, 'Forventet en fagsak').not.toBeNull();
+            expect(fagsak!.STATUS, 'Fagsak skal være ANNULLERT').toBe('ANNULLERT');
+            console.log(`✅ Fagsak ${fagsak!.SAKSNUMMER} er ANNULLERT`);
+
+            // === Ny-vurderings-behandlingen avsluttet med resultat ANNULLERT ===
+            const nv = await db.queryOne<{ ID: number; STATUS: string }>(
+                `SELECT id, status FROM behandling WHERE beh_type = 'NY_VURDERING'
+                 ORDER BY id DESC FETCH FIRST 1 ROWS ONLY`, {});
+            expect(nv, 'Forventet en NY_VURDERING-behandling').not.toBeNull();
+            expect(nv!.STATUS, 'NV-behandlingen skal være AVSLUTTET').toBe('AVSLUTTET');
+
+            const nvResultat = await db.queryOne<{ RESULTAT_TYPE: string }>(
+                `SELECT resultat_type FROM behandlingsresultat WHERE behandling_id = :id`, {id: nv!.ID});
+            expect(nvResultat, 'Forventet et behandlingsresultat for NV').not.toBeNull();
+            expect(nvResultat!.RESULTAT_TYPE, 'NV-behandlingsresultat skal være ANNULLERT').toBe('ANNULLERT');
+            console.log(`✅ NV-behandling ${nv!.ID} avsluttet med resultat ANNULLERT`);
+
+            // === NV-lovvalgsperioden slettet; opprinnelig periode står igjen INNVILGET ===
+            const nvPerioder = await db.query(
+                `SELECT id FROM lovvalg_periode WHERE beh_resultat_id = :id`, {id: nv!.ID});
+            expect(nvPerioder, 'NV-lovvalgsperioden skal være slettet ved annullering').toHaveLength(0);
+
+            const gjenstaaende = await db.query<{ INNVILGELSE_RESULTAT: string; MEDLPERIODE_ID: number }>(
+                `SELECT innvilgelse_resultat, medlperiode_id FROM lovvalg_periode ORDER BY id`, {});
+            expect(gjenstaaende, 'Kun den opprinnelige lovvalgsperioden skal stå igjen').toHaveLength(1);
+            expect(gjenstaaende[0].INNVILGELSE_RESULTAT).toBe('INNVILGET');
+            expect(gjenstaaende[0].MEDLPERIODE_ID).toBe(medlPeriodeId);
+            console.log('✅ NV-lovvalgsperiode slettet; opprinnelig periode står igjen som INNVILGET');
+
+            // === Ingen feilede prosessinstanser + ANNULLER_SAK fullført ===
+            const feilede = await db.query<{ PROSESS_TYPE: string; STATUS: string }>(
+                `SELECT prosess_type, status FROM prosessinstans
+                 WHERE status = 'FEILET' AND registrert_dato > SYSDATE - INTERVAL '15' MINUTE`, {});
+            expect(feilede, `Forventet ingen feilede prosessinstanser, fant: ${JSON.stringify(feilede)}`).toHaveLength(0);
+
+            const annullerProsess = await db.queryOne<{ STATUS: string; SIST_FULLFORT_STEG: string }>(
+                `SELECT status, sist_fullfort_steg FROM prosessinstans
+                 WHERE prosess_type = 'ANNULLER_SAK' AND registrert_dato > SYSDATE - INTERVAL '15' MINUTE
+                 ORDER BY registrert_dato DESC FETCH FIRST 1 ROWS ONLY`, {});
+            expect(annullerProsess, 'Forventet en ANNULLER_SAK-prosessinstans').not.toBeNull();
+            expect(annullerProsess!.STATUS, 'ANNULLER_SAK skal være FERDIG').toBe('FERDIG');
+            console.log(`✅ ANNULLER_SAK FERDIG (sist steg: ${annullerProsess!.SIST_FULLFORT_STEG}), ingen feilede prosessinstanser`);
+        });
+
+        // === MEDL-perioden avvist (status GYLD → AVST) — MELOSYS-7668 ===
+        const periode = await fetchMedlPeriode(request, medlPeriodeId);
+        expect(periode.status, `MEDL-periode ${medlPeriodeId} skal være avvist (AVST) etter annullering`).toBe('AVST');
+        console.log(`✅ MEDL-periode ${medlPeriodeId} avvist (GYLD → AVST)`);
+    }
+}

--- a/pages/behandling/annullering.assertions.ts
+++ b/pages/behandling/annullering.assertions.ts
@@ -43,6 +43,10 @@ export class AnnulleringAssertions {
      * @param medlPeriodeId - MEDL-periode-id fra den opprinnelige lovvalgsperioden
      */
     async verifiserAnnulleringIverksatt(request: APIRequestContext, medlPeriodeId: number): Promise<void> {
+        // Databasen renses før hver test (cleanup-fixture), så "nyeste rad" / "eneste rad"
+        // = denne testens behandling. Derfor trengs ingen tidsfilter på prosessinstans-
+        // spørringene nedenfor (et SYSDATE-vindu ville bare vært sårbart for klokkeskew
+        // mellom api- og oracle-containeren).
         await withDatabase(async (db) => {
             // === Fagsak satt til ANNULLERT ===
             const fagsak = await db.queryOne<{ SAKSNUMMER: string; STATUS: string }>(
@@ -78,13 +82,12 @@ export class AnnulleringAssertions {
 
             // === Ingen feilede prosessinstanser + ANNULLER_SAK fullført ===
             const feilede = await db.query<{ PROSESS_TYPE: string; STATUS: string }>(
-                `SELECT prosess_type, status FROM prosessinstans
-                 WHERE status = 'FEILET' AND registrert_dato > SYSDATE - INTERVAL '15' MINUTE`, {});
+                `SELECT prosess_type, status FROM prosessinstans WHERE status = 'FEILET'`, {});
             expect(feilede, `Forventet ingen feilede prosessinstanser, fant: ${JSON.stringify(feilede)}`).toHaveLength(0);
 
             const annullerProsess = await db.queryOne<{ STATUS: string; SIST_FULLFORT_STEG: string }>(
                 `SELECT status, sist_fullfort_steg FROM prosessinstans
-                 WHERE prosess_type = 'ANNULLER_SAK' AND registrert_dato > SYSDATE - INTERVAL '15' MINUTE
+                 WHERE prosess_type = 'ANNULLER_SAK'
                  ORDER BY registrert_dato DESC FETCH FIRST 1 ROWS ONLY`, {});
             expect(annullerProsess, 'Forventet en ANNULLER_SAK-prosessinstans').not.toBeNull();
             expect(annullerProsess!.STATUS, 'ANNULLER_SAK skal være FERDIG').toBe('FERDIG');

--- a/pages/behandling/annullering.page.ts
+++ b/pages/behandling/annullering.page.ts
@@ -1,5 +1,6 @@
 import {Page} from '@playwright/test';
 import {BasePage} from '../shared/base.page';
+import {AnnulleringAssertions} from './annullering.assertions';
 
 /**
  * Page Object for annulling (cancelling) a behandling
@@ -12,8 +13,11 @@ import {BasePage} from '../shared/base.page';
  * @example
  * const annullering = new AnnulleringPage(page);
  * await annullering.annullerSak();
+ * await annullering.assertions.verifiserAnnulleringIverksatt(request, medlPeriodeId);
  */
 export class AnnulleringPage extends BasePage {
+    readonly assertions: AnnulleringAssertions;
+
     private readonly behandlingsmenyButton = this.page.getByRole('button', {name: 'Behandlingsmeny'});
     private readonly avsluttBehandlingButton = this.page.getByRole('button', {name: 'Avslutt behandling'});
     private readonly sakenErAnnullertButton = this.page.getByRole('button', {name: 'Saken er annullert'});
@@ -21,6 +25,7 @@ export class AnnulleringPage extends BasePage {
 
     constructor(page: Page) {
         super(page);
+        this.assertions = new AnnulleringAssertions(page);
     }
 
     async åpneBehandlingsmeny(): Promise<void> {

--- a/tests/eu-eos/eu-eos-nv-annuller-medl-avvis.spec.ts
+++ b/tests/eu-eos/eu-eos-nv-annuller-medl-avvis.spec.ts
@@ -1,0 +1,124 @@
+import {test} from '../../fixtures';
+import {AuthHelper} from '../../helpers/auth-helper';
+import {HovedsidePage} from '../../pages/hovedside.page';
+import {OpprettNySakPage} from '../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import {EuEosBehandlingPage} from '../../pages/behandling/eu-eos-behandling.page';
+import {AnnulleringPage} from '../../pages/behandling/annullering.page';
+import {USER_ID_VALID} from '../../pages/shared/constants';
+import {waitForProcessInstances} from '../../helpers/api-helper';
+import {withDatabase} from '../../helpers/db-helper';
+
+/**
+ * EU/EØS - Annullering av sak med sendt vedtak (MEDL-avvisning)
+ *
+ * Gap: nv-eos-annuller-medl-avvis (e2e-dekningshull, Tier 2). Ingen e2e dekket
+ * annullering av en EU/EØS-sak som allerede har et sendt vedtak. Bug-tett område:
+ * MELOSYS-7668 (en cron-jobb overskrev den avviste MEDL-perioden).
+ *
+ * Scenario:
+ * 1. Fullfør en førstegangs utsendt-sak → vedtak (A009, MEDL-periode opprettes GYLD)
+ * 2. Opprett en Nyvurdering
+ * 3. Annuller saken (Behandlingsmeny → Avslutt behandling → Saken er annullert)
+ * 4. Verifiser at annulleringen iverksettes korrekt:
+ *    - fagsak satt til ANNULLERT
+ *    - NV-behandlingen avsluttet med behandlingsresultat ANNULLERT
+ *    - NV-lovvalgsperioden slettet; opprinnelig periode står igjen INNVILGET
+ *    - MEDL-perioden avvist (status GYLD → AVST) ← kjernen i MELOSYS-7668
+ *    - ANNULLER_SAK fullført uten feilede prosessinstanser
+ *
+ * Assertionene speiler backend-integrasjonstesten
+ * `AnnuleringNyVurderingEøsOgTrygdeavtaleIT`, men verifiseres ende-til-ende
+ * gjennom hele stacken (UI → api → prosessflyt → MEDL-mock).
+ *
+ * NB om X008: backloggen antok at en annullering sender en X008 (tilbaketrekking)
+ * til utenlandsk institusjon. Det stemmer IKKE for denne flyten — ANNULLER_SAK-
+ * prosessen sender ingen SED (verifisert i kode + driftet flyt: 0 nye SED-er ved
+ * annullering). Utgående X008 sendes kun ved A012/A004-svar i en nyvurdering
+ * (`sendGodkjenningArbeidFlereLand`/`sendAvslagUtpekingSvar` → invaliderer en
+ * tidligere A004/A012), og innkommende X008→annullering er en egen mottaks-flyt.
+ * Derfor asserterer denne testen ikke X008 — det ville vært en falsk-grønn vakt.
+ */
+const FRA = '01.01.2024';
+const TIL = '31.12.2025';
+
+test.describe('EU/EØS - Annullering (MEDL-avvisning)', () => {
+    test('skal annullere sak med sendt vedtak og avvise MEDL-perioden', async ({page, request}) => {
+        test.setTimeout(240000);
+
+        const auth = new AuthHelper(page);
+        await auth.login();
+
+        const hovedside = new HovedsidePage(page);
+        const opprettSak = new OpprettNySakPage(page);
+        const behandling = new EuEosBehandlingPage(page);
+        const annullering = new AnnulleringPage(page);
+
+        // === DEL A: Førstegangs utsendt-sak → vedtak (A009, MEDL-periode opprettes) ===
+        console.log('📝 Del A: Oppretter førstegangs utsendt-sak...');
+        await hovedside.goto();
+        await hovedside.klikkOpprettNySak();
+        await opprettSak.fyllInnBrukerID(USER_ID_VALID);
+        await opprettSak.velgSakstype('EU_EOS');
+        await opprettSak.velgSakstema('MEDLEMSKAP_LOVVALG');
+        await opprettSak.velgBehandlingstema('UTSENDT_ARBEIDSTAKER');
+        await behandling.fyllInnFraTilDato(FRA, TIL);
+        await behandling.velgLand('Danmark');
+        await opprettSak.velgAarsak('SØKNAD');
+        await opprettSak.leggBehandlingIMine();
+        await opprettSak.klikkOpprettNyBehandling();
+
+        await waitForProcessInstances(page.request, 30);
+        await hovedside.goto();
+        await hovedside.åpneBehandling('TRIVIELL KARAFFEL -');
+        await page.waitForLoadState('networkidle');
+
+        console.log('📝 Del A: Fullfører førstegangs behandling til vedtak...');
+        await behandling.klikkBekreftOgFortsett();
+        await behandling.velgYrkesaktivEllerSelvstendigOgFortsett(true);
+        await behandling.velgArbeidsgiverOgFortsett('Ståles Stål AS');
+        await behandling.velgArbeidstype(true);
+        await behandling.svarJaOgFortsett();
+        await behandling.svarJaOgFortsett();
+        await behandling.innvilgeOgFattVedtak();
+
+        console.log('📝 Del A: Venter på iverksetting av førstegangsvedtak...');
+        await waitForProcessInstances(page.request, 60);
+
+        // Hent MEDL-periode-id-en som førstegangsvedtaket opprettet (eneste rad etter rensing).
+        const medlPeriodeId = await withDatabase(async (db) => {
+            const lp = await db.queryOne<{ MEDLPERIODE_ID: number }>(
+                `SELECT medlperiode_id FROM lovvalg_periode ORDER BY id DESC FETCH FIRST 1 ROWS ONLY`, {});
+            if (!lp?.MEDLPERIODE_ID) {
+                throw new Error('Fant ingen lovvalgsperiode med medlperiode_id etter førstegangsvedtak');
+            }
+            return lp.MEDLPERIODE_ID;
+        });
+        console.log(`📌 MEDL-periode opprettet: ${medlPeriodeId}`);
+        // Forutsetning: perioden er GYLD (aktiv) før annullering — gjør AVST-sjekken til en reell delta.
+        await annullering.assertions.verifiserMedlPeriodeGyldig(request, medlPeriodeId);
+
+        // === DEL B: Opprett Nyvurdering ===
+        console.log('📝 Del B: Oppretter nyvurdering...');
+        await hovedside.goto();
+        await hovedside.klikkOpprettNySak();
+        await opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD');
+        await waitForProcessInstances(page.request, 30);
+
+        // Åpne den NYE aktive behandlingen (åpneBehandling tar nyeste lenke, med reload-retry)
+        await hovedside.goto();
+        await hovedside.åpneBehandling('TRIVIELL KARAFFEL -');
+        await page.waitForLoadState('networkidle');
+
+        // === DEL C: Annuller saken ===
+        console.log('📝 Del C: Annullerer saken...');
+        await annullering.annullerSak();
+
+        console.log('📝 Del C: Venter på iverksetting av annullering (kaster ved feilede prosessinstanser)...');
+        await waitForProcessInstances(page.request, 60);
+
+        // === DEL D: Verifiser annulleringen ===
+        await annullering.assertions.verifiserAnnulleringIverksatt(request, medlPeriodeId);
+
+        console.log('✅ Annullering av EU/EØS-sak verifisert: fagsak ANNULLERT, MEDL-periode avvist');
+    });
+});


### PR DESCRIPTION
Legger til en e2e-test som dekker annullering av en EU/EØS-sak som allerede har et sendt vedtak, og verifiserer at MEDL-perioden avvises korrekt.

Annullering av EU/EØS-saker med sendt vedtak var udekket av e2e, og er et bug-tett område (MELOSYS-7668, der en cron overskrev den avviste MEDL-perioden). Dette er "del 2" av EU/EØS tilstandsovergang-gapene; "del 1" (NV, iverksetting, §2-8b, A003) er allerede i main. Testen speiler backend-integrasjonstesten `AnnuleringNyVurderingEøsOgTrygdeavtaleIT`, men verifiserer hele kjeden ende-til-ende gjennom UI, api, prosessflyt og MEDL-mock.

Flyt: førstegangs utsendt-sak → vedtak (A009, MEDL-periode opprettes GYLD) → nyvurdering → annuller. Verifiserer at fagsak settes til ANNULLERT, at NV-behandlingen avsluttes med behandlingsresultat ANNULLERT, at NV-lovvalgsperioden slettes mens den opprinnelige står igjen INNVILGET, at MEDL-perioden avvises (GYLD → AVST) og at ANNULLER_SAK fullføres uten feilede prosessinstanser.

- Ny test `tests/eu-eos/eu-eos-nv-annuller-medl-avvis.spec.ts`
- Ny verifiserings-POM `pages/behandling/annullering.assertions.ts` (wiret inn i `annullering.page.ts`, bakoverkompatibel)
- Ny `fetchMedlPeriode`-hjelper i `helpers/mock-helper.ts` for MEDL-mock-oppslag

## Notes
Backloggen antok at annullering sender en X008 (tilbaketrekking) og krever en mock-utvidelse. Det stemmer ikke for denne flyten: `ANNULLER_SAK` sender ingen SED (verifisert i kode + driftet flyt: 0 nye SED-er ved annullering). Utgående X008 sendes kun ved A012/A004-svar i en nyvurdering, og innkommende X008→annullering er en egen mottaks-flyt. X008 asserteres derfor bevisst ikke, og ingen mock-endring var nødvendig.

## Testing
- [x] Manuell e2e lokalt mot full stack (grønn 2x, ~52s)
- [x] Docker-logger rene under kjøring (ingen `@expect-docker-errors`-tag)
- [x] `npm run check:tests` (vacuous-test guardrail) OK
- [ ] E2E i GitHub Actions