### PR TITLE
NOJIRA E2E-test for inngående A003 (Norge utpekt) → A012-svar

### DIFF
--- a/helpers/sed-helper.ts
+++ b/helpers/sed-helper.ts
@@ -58,6 +58,15 @@ export interface SedConfig {
   sedType?: string;
   /** SED version (default: 1) */
   sedVersjon?: string;
+  /**
+   * When true, the mock also registers an OPEN BUC (of bucType) in the RINA store for the
+   * generated rinaSaksnummer, with the foreign sender as participant. Required for inbound
+   * SEDs that melosys-api must answer on the EXISTING BUC — e.g. an inbound A003 where Norway
+   * is designated (Norge utpekt) and replies with an outbound A012. Without it the direct
+   * mottak path leaves no BUC in RINA, melosys-api falls back to the file-based default BUC
+   * (LA_BUC_03) which fails its "open LA_BUC_02" check, and the reply SED is never sent.
+   */
+  opprettBucIRina?: boolean;
 }
 
 /**

--- a/pages/behandling/eu-eos-utpeking.assertions.ts
+++ b/pages/behandling/eu-eos-utpeking.assertions.ts
@@ -1,0 +1,116 @@
+import { APIRequestContext, expect, Page } from '@playwright/test';
+import { withDatabase } from '../../helpers/db-helper';
+import {
+  fetchMedlPeriode,
+  findNewNavFormatSed,
+  findNewUtgaaendeJournalpost,
+  JournalpostInfo,
+  RinaDocumentInfo,
+} from '../../helpers/mock-helper';
+
+/**
+ * Verifikasjoner for en godkjent "Norge utpekt"-utpeking (BESLUTNING_LOVVALG_NORGE).
+ *
+ * Beviser ende-til-ende at Norge, etter en innkommende A003 som peker ut Norge,
+ * svarer med en utgående A012 OG fastsetter et (foreløpig) norsk lovvalg med en
+ * tilhørende MEDL-periode.
+ *
+ * @example
+ * // FØR vedtak (snapshot):
+ * const sedFør = await fetchStoredSedDocuments(request, 'A012');
+ * const jpFør = await fetchStoredJournalposter(request);
+ * // ... godkjenn utpeking + fatt vedtak ...
+ * await utpeking.assertions.verifiserA012Sendt(request, sedFør, jpFør);
+ * await utpeking.assertions.verifiserGodkjentUtpekingIverksatt(request);
+ */
+export class EuEosUtpekingAssertions {
+  constructor(private readonly page: Page) {}
+
+  /**
+   * Verifiser at Norge sendte en utgående A012 (godkjenning av lovvalgsbeslutning)
+   * på den eksisterende bucen, og at en utgående EESSI-journalpost ble opprettet.
+   *
+   * @param request   - Playwright APIRequestContext
+   * @param sedFør    - Snapshot av A012-dokumenter tatt FØR vedtak
+   * @param jpFør     - Snapshot av journalposter tatt FØR vedtak
+   */
+  async verifiserA012Sendt(
+    request: APIRequestContext,
+    sedFør: RinaDocumentInfo[],
+    jpFør: JournalpostInfo[]
+  ): Promise<void> {
+    const a012 = await findNewNavFormatSed(request, 'A012', sedFør, 30000);
+    expect(a012.sed, 'Utgående svar-SED skal være A012 (godkjenning av lovvalgsbeslutning)').toBe('A012');
+    console.log('✅ A012 sendt (NAV-format) på eksisterende BUC');
+
+    const journalpost = await findNewUtgaaendeJournalpost(request, jpFør, 30000);
+    expect(journalpost, 'Forventet en UTGAAENDE EESSI-journalpost for A012-svaret').not.toBeNull();
+    console.log(`✅ UTGAAENDE EESSI-journalpost opprettet for A012: ${journalpost!.journalpostId}`);
+  }
+
+  /**
+   * Verifiser at den godkjente utpekingen ble iverksatt:
+   *  - behandlingsresultat: FASTSATT_LOVVALGSLAND, utfall_utpeking GODKJENT, fastsatt av NO
+   *  - lovvalgsperiode: Norge (NO), art.13(1)(a), INNVILGET, knyttet til en MEDL-periode
+   *  - MEDL-periode opprettet i registeret med foreløpig norsk lovvalg
+   *    (status UAVK, lovvalg FORL, lovvalgsland NOR) — speiler at vedtaket er en
+   *    MIDLERTIDIG_LOVVALGSBESLUTNING
+   *  - IVERKSETT_VEDTAK_EOS fullført uten feilede prosessinstanser
+   *
+   * @param request - Playwright APIRequestContext (for MEDL-mock-oppslag)
+   */
+  async verifiserGodkjentUtpekingIverksatt(request: APIRequestContext): Promise<void> {
+    // Databasen renses før hver test (cleanup-fixture), så "nyeste rad" = denne testens
+    // behandling. Derfor trengs ingen tidsfilter på spørringene under.
+    const medlPeriodeId = await withDatabase(async (db) => {
+      // === Behandlingsresultat: godkjent utpeking, norsk lovvalg fastsatt ===
+      const br = await db.queryOne<{
+        RESULTAT_TYPE: string; UTFALL_UTPEKING: string; FASTSATT_AV_LAND: string;
+      }>(
+        `SELECT resultat_type, utfall_utpeking, fastsatt_av_land FROM behandlingsresultat
+         ORDER BY behandling_id DESC FETCH FIRST 1 ROWS ONLY`, {});
+      expect(br, 'Forventet et behandlingsresultat').not.toBeNull();
+      expect(br!.RESULTAT_TYPE, 'Resultattype skal være FASTSATT_LOVVALGSLAND').toBe('FASTSATT_LOVVALGSLAND');
+      expect(br!.UTFALL_UTPEKING, 'Utfall av utpeking skal være GODKJENT').toBe('GODKJENT');
+      expect(br!.FASTSATT_AV_LAND, 'Lovvalget skal være fastsatt av Norge').toBe('NO');
+      console.log('✅ Behandlingsresultat: FASTSATT_LOVVALGSLAND / utpeking GODKJENT / fastsatt av NO');
+
+      // === Lovvalgsperiode: Norge, art.13(1)(a), innvilget, knyttet til MEDL ===
+      const lp = await db.queryOne<{
+        LOVVALGSLAND: string; LOVVALG_BESTEMMELSE: string; INNVILGELSE_RESULTAT: string; MEDLPERIODE_ID: number;
+      }>(
+        `SELECT lovvalgsland, lovvalg_bestemmelse, innvilgelse_resultat, medlperiode_id
+         FROM lovvalg_periode ORDER BY id DESC FETCH FIRST 1 ROWS ONLY`, {});
+      expect(lp, 'Forventet en lovvalgsperiode').not.toBeNull();
+      expect(lp!.LOVVALGSLAND, 'Lovvalgsperioden skal peke på Norge').toBe('NO');
+      expect(lp!.LOVVALG_BESTEMMELSE, 'Lovvalgsbestemmelse skal være art.13(1)(a)').toBe('FO_883_2004_ART13_1A');
+      expect(lp!.INNVILGELSE_RESULTAT, 'Lovvalgsperioden skal være INNVILGET').toBe('INNVILGET');
+      expect(lp!.MEDLPERIODE_ID, 'Lovvalgsperioden skal være knyttet til en MEDL-periode').toBeTruthy();
+      console.log(`✅ Lovvalgsperiode: NO / art.13(1)(a) / INNVILGET / MEDL-periode ${lp!.MEDLPERIODE_ID}`);
+
+      // === Ingen feilede prosessinstanser + IVERKSETT_VEDTAK_EOS fullført ===
+      const feilede = await db.query<{ PROSESS_TYPE: string }>(
+        `SELECT prosess_type FROM prosessinstans WHERE status = 'FEILET'`, {});
+      expect(feilede, `Forventet ingen feilede prosessinstanser, fant: ${JSON.stringify(feilede)}`).toHaveLength(0);
+
+      const iverksett = await db.queryOne<{ STATUS: string }>(
+        `SELECT status FROM prosessinstans WHERE prosess_type = 'IVERKSETT_VEDTAK_EOS'
+         ORDER BY registrert_dato DESC FETCH FIRST 1 ROWS ONLY`, {});
+      expect(iverksett, 'Forventet en IVERKSETT_VEDTAK_EOS-prosessinstans').not.toBeNull();
+      expect(iverksett!.STATUS, 'IVERKSETT_VEDTAK_EOS skal være FERDIG').toBe('FERDIG');
+      console.log('✅ IVERKSETT_VEDTAK_EOS FERDIG, ingen feilede prosessinstanser');
+
+      return lp!.MEDLPERIODE_ID;
+    });
+
+    // === MEDL-periode i registeret: foreløpig norsk medlemskap opprettet ===
+    const medl = await fetchMedlPeriode(request, medlPeriodeId);
+    expect(medl.medlem, 'MEDL-periode skal markere personen som medlem').toBe(true);
+    expect(medl.lovvalgsland, 'MEDL-periode skal ha norsk lovvalgsland (NOR)').toBe('NOR');
+    // Foreløpig lovvalg (FORL) + uavklart status (UAVK) speiler at vedtaket er en
+    // MIDLERTIDIG_LOVVALGSBESLUTNING — ikke et endelig (GYLD) medlemskap.
+    expect(medl.lovvalg, 'MEDL-periode skal ha foreløpig lovvalg (FORL)').toBe('FORL');
+    expect(medl.status, 'MEDL-periode skal være uavklart (UAVK) ved foreløpig lovvalgsbeslutning').toBe('UAVK');
+    console.log(`✅ MEDL-periode ${medlPeriodeId}: medlem=true, NOR, foreløpig (FORL/UAVK)`);
+  }
+}

--- a/pages/behandling/eu-eos-utpeking.page.ts
+++ b/pages/behandling/eu-eos-utpeking.page.ts
@@ -1,0 +1,137 @@
+import { Page, expect } from '@playwright/test';
+import { BasePage } from '../shared/base.page';
+import { EuEosUtpekingAssertions } from './eu-eos-utpeking.assertions';
+
+/**
+ * Page Object for the EU/EØS "vurder utpeking"-behandling (behandlingstema
+ * BESLUTNING_LOVVALG_NORGE).
+ *
+ * Denne behandlingen opprettes når en innkommende A003 peker ut Norge som
+ * kompetent land ("Norge utpekt"). Saksbehandler går gjennom 4 steg:
+ *   1. Inngang     – "Kontroller inngangsvilkår" (vilkårene er allerede oppfylt)
+ *   2. Virksomhet  – velg virksomhet(er) personen jobber for
+ *   3. Vurdering   – "Vurder lovvalgsbeslutningen (A003)": Godkjenn / Ikke godkjenn.
+ *                    Grunnlag (lovvalgsbestemmelse) og lovvalgsperiode er
+ *                    forhåndsutfylt fra SED-en.
+ *   4. Vedtak      – "Omfattet av norsk trygdelovgivning": fritekstbegrunnelse +
+ *                    Fatt vedtak. Ved godkjenning sender melosys-api en utgående
+ *                    A012 (godkjenning av lovvalgsbeslutning) på den eksisterende
+ *                    bucen.
+ *
+ * Steg-overgangene bruker BasePage.clickStepButtonWithRetry (heading-change-retry)
+ * for å være robust mot CI-flaking i stegvelger-wizarden.
+ *
+ * @example
+ * const utpeking = new EuEosUtpekingPage(page);
+ * await utpeking.godkjennUtpekingOgFattVedtak();
+ * await utpeking.assertions.verifiserA012Sendt(request, sedFør, jpFør);
+ * await utpeking.assertions.verifiserGodkjentUtpekingIverksatt(request);
+ */
+export class EuEosUtpekingPage extends BasePage {
+  readonly assertions: EuEosUtpekingAssertions;
+
+  private readonly bekreftOgFortsettButton = this.page.getByRole('button', { name: 'Bekreft og fortsett' });
+  private readonly fattVedtakButton = this.page.getByRole('button', { name: 'Fatt vedtak' });
+  private readonly godkjennRadio = this.page.getByRole('radio', { name: 'Godkjenn', exact: true });
+  private readonly ikkeGodkjennRadio = this.page.getByRole('radio', { name: 'Ikke godkjenn' });
+  private readonly begrunnelseField = this.page.getByRole('textbox', { name: 'Fritekstfelt til begrunnelse' });
+
+  private readonly inngangHeading = this.page.getByRole('heading', { name: 'Kontroller inngangsvilkår' });
+  private readonly virksomhetHeading = this.page.getByRole('heading', { name: 'Virksomhet' });
+  private readonly vurderingHeading = this.page.getByRole('heading', { name: 'Vurder lovvalgsbeslutningen (A003)' });
+  private readonly vedtakHeading = this.page.getByRole('heading', { name: 'Omfattet av norsk trygdelovgivning' });
+
+  constructor(page: Page) {
+    super(page);
+    this.assertions = new EuEosUtpekingAssertions(page);
+  }
+
+  /**
+   * Steg 1 (Inngang): bekreft at inngangsvilkårene er oppfylt.
+   */
+  async bekreftInngang(): Promise<void> {
+    await this.inngangHeading.waitFor({ state: 'visible', timeout: 30000 });
+    await this.clickStepButtonWithRetry(this.bekreftOgFortsettButton, {
+      verifyHeadingChange: true,
+      waitForContent: this.virksomhetHeading,
+    });
+    console.log('✅ Inngang bekreftet');
+  }
+
+  /**
+   * Steg 2 (Virksomhet): velg virksomhet. "Bekreft og fortsett" er deaktivert
+   * til minst én virksomhet er valgt.
+   *
+   * @param navn - Navn på virksomhet (default: 'Ståles Stål AS')
+   */
+  async velgVirksomhetOgFortsett(navn: string = 'Ståles Stål AS'): Promise<void> {
+    const checkbox = this.page.getByRole('checkbox', { name: navn });
+    await checkbox.waitFor({ state: 'visible', timeout: 30000 });
+    await checkbox.check();
+    await expect(this.bekreftOgFortsettButton).toBeEnabled({ timeout: 15000 });
+    await this.clickStepButtonWithRetry(this.bekreftOgFortsettButton, {
+      verifyHeadingChange: true,
+      waitForContent: this.vurderingHeading,
+    });
+    console.log(`✅ Valgte virksomhet: ${navn}`);
+  }
+
+  /**
+   * Steg 3 (Vurdering): godkjenn lovvalgsbeslutningen. Grunnlag
+   * (lovvalgsbestemmelse) og lovvalgsperiode er forhåndsutfylt fra SED-en, så
+   * det eneste valget er Godkjenn / Ikke godkjenn. "Bekreft og fortsett" er
+   * deaktivert til et valg er gjort.
+   */
+  async godkjennUtpekingOgFortsett(): Promise<void> {
+    await this.godkjennRadio.waitFor({ state: 'visible', timeout: 30000 });
+    await this.godkjennRadio.check();
+    await expect(this.bekreftOgFortsettButton).toBeEnabled({ timeout: 15000 });
+    await this.clickStepButtonWithRetry(this.bekreftOgFortsettButton, {
+      verifyHeadingChange: true,
+      waitForContent: this.vedtakHeading,
+    });
+    console.log('✅ Godkjente utpekingen');
+  }
+
+  /**
+   * Steg 4 (Vedtak): fyll inn fritekstbegrunnelse og fatt vedtak. Venter på det
+   * kritiske vedtaks-API-kallet (POST /api/saksflyt/vedtak/{id}/fatt).
+   *
+   * @param begrunnelse - Påkrevd fritekstbegrunnelse for vedtaket
+   */
+  async fyllBegrunnelseOgFattVedtak(begrunnelse: string): Promise<void> {
+    await this.begrunnelseField.waitFor({ state: 'visible', timeout: 30000 });
+    await this.begrunnelseField.click();
+    await this.begrunnelseField.fill(begrunnelse);
+    await this.begrunnelseField.press('Tab');
+
+    await this.page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+    await this.fattVedtakButton.waitFor({ state: 'visible', timeout: 10000 });
+
+    const responsePromise = this.page.waitForResponse(
+      response => response.url().includes('/api/saksflyt/vedtak/') &&
+                  response.url().includes('/fatt') &&
+                  response.request().method() === 'POST' &&
+                  (response.status() === 200 || response.status() === 204),
+      { timeout: 60000 }
+    );
+    await this.fattVedtakButton.click();
+    const response = await responsePromise;
+    console.log(`✅ Vedtak fattet (godkjent utpeking) → ${response.status()}`);
+  }
+
+  /**
+   * Kjør hele "godkjent utpeking → vedtak"-flyten med standardverdier.
+   *
+   * @param opts.virksomhet  - Virksomhet å velge (default: 'Ståles Stål AS')
+   * @param opts.begrunnelse - Fritekstbegrunnelse for vedtaket
+   */
+  async godkjennUtpekingOgFattVedtak(opts?: { virksomhet?: string; begrunnelse?: string }): Promise<void> {
+    await this.bekreftInngang();
+    await this.velgVirksomhetOgFortsett(opts?.virksomhet);
+    await this.godkjennUtpekingOgFortsett();
+    await this.fyllBegrunnelseOgFattVedtak(
+      opts?.begrunnelse ?? 'Norge godkjenner utpekingen. Personen har bostedsadresse i Norge i perioden.'
+    );
+  }
+}

--- a/tests/eu-eos/eu-eos-inngaaende-a003-norge-utpekt-a012.spec.ts
+++ b/tests/eu-eos/eu-eos-inngaaende-a003-norge-utpekt-a012.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '../../fixtures';
+import { AuthHelper } from '../../helpers/auth-helper';
+import { SedHelper } from '../../helpers/sed-helper';
+import { HovedsidePage } from '../../pages/hovedside.page';
+import { EuEosUtpekingPage } from '../../pages/behandling/eu-eos-utpeking.page';
+import { waitForProcessInstances } from '../../helpers/api-helper';
+import { fetchStoredJournalposter, fetchStoredSedDocuments } from '../../helpers/mock-helper';
+import { BRUKERNAVN_VALID } from '../../pages/shared/constants';
+
+/**
+ * EU/EØS - Inngående A003 (Norge utpekt) → utgående A012
+ *
+ * Gap: eos-inngaaende-a003-norge-utpekt-a012 (Tier 1, e2e-dekningshull). Et
+ * sed-mottak-smoke dekker at en inngående A003 oppretter en fagsak, men INGEN
+ * e2e fullførte utpeking-behandlingen (GODKJENN_UTPEKING_NORGE) til vedtak og
+ * verifiserte Norges utgående A012-svar. Identifisering er bug-følsom
+ * (MELOSYS-7743: feil person matchet).
+ *
+ * Scenario:
+ * 1. Injiser en inngående A003 som peker ut Norge (lovvalgsland=NO). Dette
+ *    oppretter en behandling med tema BESLUTNING_LOVVALG_NORGE for testpersonen.
+ * 2. Åpne behandlingen og fullfør "vurder utpeking"-flyten (Inngang →
+ *    Virksomhet → Vurdering[Godkjenn] → Vedtak).
+ * 3. Fatt vedtak (Norge godkjenner utpekingen).
+ * 4. Verifiser ende-til-ende:
+ *    - en utgående A012 (godkjenning av lovvalgsbeslutning) sendes på den
+ *      eksisterende bucen, med tilhørende UTGAAENDE EESSI-journalpost
+ *    - behandlingsresultatet er FASTSATT_LOVVALGSLAND / utpeking GODKJENT (NO)
+ *    - en lovvalgsperiode til Norge (art.13(1)(a), INNVILGET) opprettes, knyttet
+ *      til en MEDL-periode
+ *    - MEDL-perioden er et foreløpig norsk medlemskap (lovvalg FORL / status UAVK)
+ *      — speiler at vedtaket er en MIDLERTIDIG_LOVVALGSBESLUTNING
+ *    - IVERKSETT_VEDTAK_EOS fullført uten feilede prosessinstanser
+ *
+ * Mock-forutsetning (opprettBucIRina=true): den direkte mottak-stien går utenom
+ * melosys-eessi og oppretter derfor ingen BUC i RINA-store. Uten en BUC faller
+ * melosys-api tilbake på den fil-baserte default-BUCen (LA_BUC_03), som ikke
+ * matcher "åpen LA_BUC_02"-sjekken i SendVedtakUtland, og A012 ville aldri blitt
+ * sendt. Flagget registrerer den utenlandsk-initierte, åpne LA_BUC_02-en som
+ * Norge svarer på — slik en ekte innkommende A003 ville ha kommet inn på.
+ */
+test.describe('EU/EØS - Inngående A003 (Norge utpekt)', () => {
+  test('skal godkjenne utpeking av Norge og svare utland med A012', async ({ page, request }) => {
+    test.setTimeout(240000);
+
+    // === DEL A: Inngående A003 som peker ut Norge oppretter utpeking-behandling ===
+    console.log('📝 Del A: Injiserer inngående A003 (Norge utpekt)...');
+    const sed = new SedHelper(request);
+    const result = await sed.sendSed({
+      sedType: 'A003',
+      bucType: 'LA_BUC_02',
+      lovvalgsland: 'NO',
+      artikkel: '13_1_a',
+      opprettBucIRina: true,
+    });
+    expect(result.success, `Send A003 feilet: ${result.message}`).toBe(true);
+    await waitForProcessInstances(request, 60);
+
+    const auth = new AuthHelper(page);
+    await auth.login();
+    const hovedside = new HovedsidePage(page);
+    const utpeking = new EuEosUtpekingPage(page);
+
+    // Åpne den nyopprettede utpeking-behandlingen for testpersonen.
+    await hovedside.goto();
+    await hovedside.åpneBehandling(`${BRUKERNAVN_VALID} -`);
+    await page.waitForLoadState('networkidle').catch(() => {});
+
+    // Snapshot SED- og journalpost-tilstand FØR vedtak (for å verifisere A012-delta).
+    const sedFør = await fetchStoredSedDocuments(request, 'A012');
+    const jpFør = await fetchStoredJournalposter(request);
+
+    // === DEL B: Godkjenn utpeking og fatt vedtak ===
+    console.log('📝 Del B: Godkjenner utpeking og fatter vedtak...');
+    await utpeking.godkjennUtpekingOgFattVedtak();
+
+    console.log('📝 Del B: Venter på iverksetting (sender A012, kaster ved feilede prosessinstanser)...');
+    await waitForProcessInstances(request, 90);
+
+    // === DEL C: Verifiser A012 sendt + norsk lovvalg/MEDL iverksatt ===
+    await utpeking.assertions.verifiserA012Sendt(request, sedFør, jpFør);
+    await utpeking.assertions.verifiserGodkjentUtpekingIverksatt(request);
+
+    console.log('✅ Inngående A003 (Norge utpekt) → A012 verifisert ende-til-ende');
+  });
+});


### PR DESCRIPTION
## Hva
Lukker Tier 1-gapet `eos-inngaaende-a003-norge-utpekt-a012`. En inngående A003 som peker ut Norge oppretter en `BESLUTNING_LOVVALG_NORGE`-behandling (dekket av sed-mottak-smoke), men **ingen** e2e fullførte utpekingen til vedtak og verifiserte Norges utgående **A012**-svar. Identifisering er bug-følsom (MELOSYS-7743).

## Flyt
1. Injiser inngående A003 (`lovvalgsland=NO`) → utpeking-behandling for testpersonen.
2. Åpne behandlingen, godkjenn utpekingen: **Inngang → Virksomhet → Vurdering (Godkjenn) → Vedtak**.
3. Fatt vedtak (Norge godkjenner).

## Verifiserer ende-til-ende
- utgående **A012** (NAV-format) sendt på eksisterende BUC + **UTGAAENDE** EESSI-journalpost
- behandlingsresultat `FASTSATT_LOVVALGSLAND` / utpeking `GODKJENT` / fastsatt av `NO`
- lovvalgsperiode `NO` / `art.13(1)(a)` / `INNVILGET`, knyttet til en MEDL-periode
- MEDL-periode foreløpig (`lovvalg=FORL`, `status=UAVK`) — speiler at vedtaket er en `MIDLERTIDIG_LOVVALGSBESLUTNING`
- `IVERKSETT_VEDTAK_EOS` fullført uten feilede prosessinstanser

Korrekt **ingen X008** (førstegangs-utpeking, ikke en NV).

## Nye filer
- `tests/eu-eos/eu-eos-inngaaende-a003-norge-utpekt-a012.spec.ts`
- `pages/behandling/eu-eos-utpeking.page.ts` + `.assertions.ts`
- felt `opprettBucIRina` i `helpers/sed-helper.ts`

## ⚠️ Avhengighet (CI)
Krever mock-utvidelsen i **navikt/melosys-docker-compose#146** (`opprettBucIRina` registrerer en åpen LA_BUC_02 i RINA-store så A012 kan sendes på eksisterende BUC). Uten den faller mocken tilbake på en LA_BUC_03-default og A012 sendes aldri. Merge #146 (→ `melosys-mock:latest`) før CI kjøres her, eller kjør CI med `MELOSYS_MOCK_TAG=<tag>` fra et bygget image.

Grønn lokalt mot mock bygget fra #146; guardrail `npm run check:tests` OK; eksisterende sed-mottak direkte-inject-test fortsatt grønn.