### PR TITLE
NOJIRA E2E-test: motta svar (A002/A011) på anmodning om unntak

### DIFF
--- a/helpers/mock-helper.ts
+++ b/helpers/mock-helper.ts
@@ -99,6 +99,39 @@ export async function findNewNavFormatSed(
 }
 
 /**
+ * Find the newest NAV-format SED document (full RinaDocumentInfo, incl. caseId)
+ * that was not present in a previous snapshot.
+ *
+ * Like {@link findNewNavFormatSed}, but returns the whole document — needed when
+ * the caller must know the RINA case id (`caseId` === rinaSaksnummer) of the
+ * outgoing SED, e.g. to reply on the SAME BUC by injecting an inbound SED with
+ * that rinaSaksnummer (the A001 → A002/A011 anmodning-om-unntak svar flow).
+ */
+export async function findNewRinaSedDocument(
+  request: APIRequestContext,
+  sedType: string,
+  before: RinaDocumentInfo[],
+  timeoutMs = 30000
+): Promise<RinaDocumentInfo> {
+  const beforeKeys = new Set(before.map(d => `${d.caseId}:${d.documentId}`));
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const after = await fetchStoredSedDocuments(request, sedType);
+    const navFormatDocs = after.filter(d => {
+      if (beforeKeys.has(`${d.caseId}:${d.documentId}`)) return false;
+      const c = d.content as Record<string, any>;
+      return c.sed !== undefined && c.sedVer !== undefined;
+    });
+    if (navFormatDocs.length > 0) {
+      return navFormatDocs[navFormatDocs.length - 1];
+    }
+    await new Promise(resolve => setTimeout(resolve, 2000));
+  }
+  throw new Error(`Timed out waiting for NAV-format ${sedType} document (${timeoutMs}ms)`);
+}
+
+/**
  * A journalpost stored in the SAF mock.
  * Mirrors JournalpostModell in melosys-mock.
  */
@@ -210,6 +243,34 @@ export async function fetchMedlPeriode(
   const response = await request.get(`http://localhost:8083/api/v1/medlemskapsunntak/${periodeId}`);
   if (!response.ok()) {
     throw new Error(`Failed to fetch MEDL periode ${periodeId}: ${response.status()}`);
+  }
+  return response.json();
+}
+
+/**
+ * An oppgave stored in the melosys-mock Oppgave register.
+ * Mirrors the relevant fields of Oppgave in melosys-mock's OppgaveApi.
+ */
+export interface OppgaveInfo {
+  id: number;
+  oppgavetype: string | null;
+  status: string | null;
+  saksreferanse: string | null;
+  aktoerId: string | null;
+  behandlingstema: string | null;
+}
+
+/**
+ * Fetch all oppgaver stored in the melosys-mock Oppgave register.
+ *
+ * Used to assert oppgave transitions end-to-end — e.g. that exactly ONE
+ * behandlingsoppgave (oppgavetype BEH_SAK_MK) exists for a sak, guarding
+ * against the MELOSYS-6836 "to oppgaver" bug on svar-anmodning-om-unntak.
+ */
+export async function fetchOppgaver(request: APIRequestContext): Promise<OppgaveInfo[]> {
+  const response = await request.get('http://localhost:8083/testdata/verification/oppgave');
+  if (!response.ok()) {
+    throw new Error(`Failed to fetch oppgaver: ${response.status()}`);
   }
   return response.json();
 }

--- a/helpers/sed-helper.ts
+++ b/helpers/sed-helper.ts
@@ -67,6 +67,17 @@ export interface SedConfig {
    * (LA_BUC_03) which fails its "open LA_BUC_02" check, and the reply SED is never sent.
    */
   opprettBucIRina?: boolean;
+  /**
+   * Svar på anmodning om unntak (Article 16) — set on inbound A002/A011 replies.
+   * Routes via melosys-api's SvarAnmodningUnntakSedRuter to the
+   * ANMODNING_OM_UNNTAK_SVAR process on the existing anmodning-behandling.
+   *   beslutning: 'INNVILGELSE' (A002 godkjent) | 'AVSLAG' (A011) | 'DELVIS_INNVILGELSE'
+   */
+  svarAnmodningUnntak?: {
+    beslutning: 'INNVILGELSE' | 'DELVIS_INNVILGELSE' | 'AVSLAG';
+    begrunnelse?: string;
+    delvisInnvilgetPeriode?: { fom: string; tom: string };
+  };
 }
 
 /**

--- a/pages/eu-eos/unntak/svar-anmodning-unntak.assertions.ts
+++ b/pages/eu-eos/unntak/svar-anmodning-unntak.assertions.ts
@@ -1,0 +1,127 @@
+import { APIRequestContext, expect, Page } from '@playwright/test';
+import { withDatabase } from '../../../helpers/db-helper';
+import { fetchOppgaver } from '../../../helpers/mock-helper';
+
+/**
+ * Assertions for the EU/EØS "svar på anmodning om unntak" flow (Article 16):
+ * a sak has sent an A001 (anmodning om unntak) and then RECEIVES a reply SED —
+ * A002 (innvilgelse / approved) or A011 (avslag / rejected) — on the SAME
+ * LA_BUC_01. melosys-api routes the reply via SvarAnmodningUnntakSedRuter to the
+ * ANMODNING_OM_UNNTAK_SVAR process.
+ *
+ * Two outcomes (BestemBehandlingsmåteSvarAnmodningUnntak):
+ *  - A002 INNVILGELSE, no ytterligere info, behandling i ANMODNING_UNNTAK_SENDT
+ *    → vedtak fattes automatisk (FASTSATT_LOVVALGSLAND, DELVIS_AUTOMATISERT)
+ *  - A011 AVSLAG (eller A002 med ytterligere info) → behandling SVAR_ANMODNING_MOTTATT
+ *    (saksbehandler må vurdere manuelt)
+ *
+ * Bug-klyngen testen vokter mot: MELOSYS-6836 (to oppgaver), 7124 (kan ikke sende
+ * NV), 5415 (stegvelger åpnes ikke). Kjernen her er at svaret faktisk routes og
+ * avanserer behandlingen uten feilede prosessinstanser, og at det opprettes
+ * NØYAKTIG én behandlingsoppgave (ikke to — 6836).
+ *
+ * DB renses før hver test (cleanup-fixture), så nyeste/eneste rad = denne testens.
+ */
+export class SvarAnmodningUnntakAssertions {
+  constructor(private readonly page: Page) {}
+
+  /**
+   * Verify a received A002 (innvilgelse) auto-fattet vedtak for the anmodning-sak.
+   * Mirrors BestemBehandlingsmåteSvarAnmodningUnntak.vedtakFattesAutomatisk → fattVedtak.
+   */
+  async verifiserAutoVedtakVedInnvilgelse(request: APIRequestContext): Promise<void> {
+    await withDatabase(async (db) => {
+      const beh = await db.queryOne<{ ID: number; STATUS: string }>(
+        `SELECT id, status FROM behandling ORDER BY id DESC FETCH FIRST 1 ROWS ONLY`, {});
+      expect(beh, 'Forventet en behandling').not.toBeNull();
+      expect(beh!.STATUS, 'Behandling skal være AVSLUTTET etter auto-vedtak').toBe('AVSLUTTET');
+
+      const br = await db.queryOne<{ RESULTAT_TYPE: string; BEHANDLINGSMAATE: string }>(
+        `SELECT resultat_type, behandlingsmaate FROM behandlingsresultat WHERE behandling_id = :id`, { id: beh!.ID });
+      expect(br, 'Forventet et behandlingsresultat').not.toBeNull();
+      expect(br!.RESULTAT_TYPE, 'Resultattype skal være FASTSATT_LOVVALGSLAND').toBe('FASTSATT_LOVVALGSLAND');
+      expect(br!.BEHANDLINGSMAATE, 'Behandlingsmåte skal være DELVIS_AUTOMATISERT (auto-vedtak)').toBe('DELVIS_AUTOMATISERT');
+
+      const fagsak = await db.queryOne<{ STATUS: string }>(
+        `SELECT status FROM fagsak ORDER BY registrert_dato DESC FETCH FIRST 1 ROWS ONLY`, {});
+      expect(fagsak!.STATUS, 'Fagsak skal være LOVVALG_AVKLART').toBe('LOVVALG_AVKLART');
+
+      const lp = await db.queryOne<{ LOVVALGSLAND: string; INNVILGELSE_RESULTAT: string; MEDLPERIODE_ID: number }>(
+        `SELECT lovvalgsland, innvilgelse_resultat, medlperiode_id FROM lovvalg_periode
+         WHERE beh_resultat_id = :id ORDER BY id DESC FETCH FIRST 1 ROWS ONLY`, { id: beh!.ID });
+      expect(lp, 'Forventet en lovvalgsperiode').not.toBeNull();
+      expect(lp!.LOVVALGSLAND, 'Lovvalgsland skal være NO (Norge beholder lovvalg)').toBe('NO');
+      expect(lp!.INNVILGELSE_RESULTAT, 'Lovvalgsperioden skal være INNVILGET').toBe('INNVILGET');
+      expect(lp!.MEDLPERIODE_ID, 'medlperiode_id satt = MEDL-overføring').not.toBeNull();
+      console.log(`✅ A002 innvilgelse: behandling ${beh!.ID} AVSLUTTET, FASTSATT_LOVVALGSLAND/DELVIS_AUTOMATISERT, lovvalg NO/INNVILGET`);
+    });
+
+    await this.verifiserSvarProsessFerdigUtenFeil();
+    await this.verifiserNoyaktigEnBehandlingsoppgave(request);
+  }
+
+  /**
+   * Verify a received A011 (avslag) left the behandling in SVAR_ANMODNING_MOTTATT
+   * for manual ny vurdering (no auto-vedtak).
+   * Mirrors BestemBehandlingsmåteSvarAnmodningUnntak else-branch.
+   */
+  async verifiserManuellVurderingVedAvslag(request: APIRequestContext): Promise<void> {
+    await withDatabase(async (db) => {
+      const beh = await db.queryOne<{ ID: number; STATUS: string }>(
+        `SELECT id, status FROM behandling ORDER BY id DESC FETCH FIRST 1 ROWS ONLY`, {});
+      expect(beh, 'Forventet en behandling').not.toBeNull();
+      expect(beh!.STATUS, 'Behandling skal være SVAR_ANMODNING_MOTTATT (manuell vurdering)').toBe('SVAR_ANMODNING_MOTTATT');
+
+      // Ingen vedtak fattet: resultatet står fortsatt som ANMODNING_OM_UNNTAK
+      const br = await db.queryOne<{ RESULTAT_TYPE: string }>(
+        `SELECT resultat_type FROM behandlingsresultat WHERE behandling_id = :id`, { id: beh!.ID });
+      expect(br!.RESULTAT_TYPE, 'Ingen vedtak skal være fattet (resultat fortsatt ANMODNING_OM_UNNTAK)').toBe('ANMODNING_OM_UNNTAK');
+
+      // Svaret er registrert som AVSLAATT lovvalgsperiode (OpprettAnmodningsperiodeSvar + lagreLovvalgsperioder)
+      const lp = await db.queryOne<{ INNVILGELSE_RESULTAT: string }>(
+        `SELECT innvilgelse_resultat FROM lovvalg_periode
+         WHERE beh_resultat_id = :id ORDER BY id DESC FETCH FIRST 1 ROWS ONLY`, { id: beh!.ID });
+      expect(lp, 'Forventet en lovvalgsperiode fra svaret').not.toBeNull();
+      expect(lp!.INNVILGELSE_RESULTAT, 'Lovvalgsperioden fra avslaget skal være AVSLAATT').toBe('AVSLAATT');
+      console.log(`✅ A011 avslag: behandling ${beh!.ID} SVAR_ANMODNING_MOTTATT, lovvalgsperiode AVSLAATT, ingen auto-vedtak`);
+    });
+
+    await this.verifiserSvarProsessFerdigUtenFeil();
+    await this.verifiserNoyaktigEnBehandlingsoppgave(request);
+  }
+
+  /**
+   * Verify the ANMODNING_OM_UNNTAK_SVAR process ran to completion and that no
+   * prosessinstans feilet (the latter inherently catches the routing/lock bugs).
+   */
+  private async verifiserSvarProsessFerdigUtenFeil(): Promise<void> {
+    await withDatabase(async (db) => {
+      const svar = await db.queryOne<{ STATUS: string; SIST_FULLFORT_STEG: string }>(
+        `SELECT status, sist_fullfort_steg FROM prosessinstans
+         WHERE prosess_type = 'ANMODNING_OM_UNNTAK_SVAR' ORDER BY registrert_dato DESC FETCH FIRST 1 ROWS ONLY`, {});
+      expect(svar, 'Forventet en ANMODNING_OM_UNNTAK_SVAR-prosessinstans (svaret ble routet)').not.toBeNull();
+      expect(svar!.STATUS, 'ANMODNING_OM_UNNTAK_SVAR skal være FERDIG').toBe('FERDIG');
+
+      const feilede = await db.query<{ PROSESS_TYPE: string; STATUS: string }>(
+        `SELECT prosess_type, status FROM prosessinstans WHERE status = 'FEILET'`, {});
+      expect(feilede, `Forventet ingen feilede prosessinstanser, fant: ${JSON.stringify(feilede)}`).toHaveLength(0);
+      console.log(`✅ ANMODNING_OM_UNNTAK_SVAR FERDIG (steg: ${svar!.SIST_FULLFORT_STEG}), ingen feilede prosessinstanser`);
+    });
+  }
+
+  /**
+   * Guard against MELOSYS-6836 (to oppgaver): exactly ONE behandlingsoppgave
+   * (oppgavetype BEH_SAK_MK) skal finnes for saken etter at svaret er mottatt.
+   * (En egen JFR_UT-journalføringsoppgave for utgående A001 er en annen type og
+   * teller ikke med.)
+   */
+  private async verifiserNoyaktigEnBehandlingsoppgave(request: APIRequestContext): Promise<void> {
+    const oppgaver = await fetchOppgaver(request);
+    const behandlingsoppgaver = oppgaver.filter((o) => o.oppgavetype === 'BEH_SAK_MK');
+    expect(
+      behandlingsoppgaver.length,
+      `Skal være NØYAKTIG én behandlingsoppgave (MELOSYS-6836-vakt mot to oppgaver), fant: ${JSON.stringify(behandlingsoppgaver.map((o) => ({ id: o.id, status: o.status })))}`,
+    ).toBe(1);
+    console.log(`✅ Nøyaktig én behandlingsoppgave (BEH_SAK_MK), status=${behandlingsoppgaver[0].status} — ingen 6836-dobbel`);
+  }
+}

--- a/tests/eu-eos/unntak/eu-eos-anmodning-unntak-nyvurdering-svar.spec.ts
+++ b/tests/eu-eos/unntak/eu-eos-anmodning-unntak-nyvurdering-svar.spec.ts
@@ -1,0 +1,181 @@
+import { Page } from '@playwright/test';
+import { test, expect } from '../../../fixtures';
+import { AuthHelper } from '../../../helpers/auth-helper';
+import { HovedsidePage } from '../../../pages/hovedside.page';
+import { OpprettNySakPage } from '../../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import { EuEosBehandlingPage } from '../../../pages/behandling/eu-eos-behandling.page';
+import { AnmodningUnntakPage } from '../../../pages/eu-eos/unntak/anmodning-unntak.page';
+import { SvarAnmodningUnntakAssertions } from '../../../pages/eu-eos/unntak/svar-anmodning-unntak.assertions';
+import { waitForProcessInstances } from '../../../helpers/api-helper';
+import { UnleashHelper } from '../../../helpers/unleash-helper';
+import { fetchStoredSedDocuments, findNewRinaSedDocument } from '../../../helpers/mock-helper';
+import { SedHelper } from '../../../helpers/sed-helper';
+import { withDatabase } from '../../../helpers/db-helper';
+import {
+  USER_ID_VALID, SAKSTYPER, SAKSTEMA, BEHANDLINGSTEMA, AARSAK, EU_EOS_LAND,
+} from '../../../pages/shared/constants';
+
+/**
+ * EU/EØS Utsendt arbeidstaker - Anmodning om unntak (art.16): MOTTA SVAR → ny vurdering
+ *
+ * Dekker tilstands-/oppgaveovergangene når en anmodning-om-unntak-sak (A001 sendt)
+ * MOTTAR svar fra utlandet på den SAMME LA_BUC_01:
+ *   - A002 (innvilgelse) → melosys-api fatter vedtak automatisk
+ *     (FASTSATT_LOVVALGSLAND, DELVIS_AUTOMATISERT, MEDL-overføring)
+ *   - A011 (avslag)      → behandling SVAR_ANMODNING_MOTTATT (manuell ny vurdering)
+ *
+ * Svaret routes av SvarAnmodningUnntakSedRuter (korrelert via rinaSaksnummer) til
+ * prosessen ANMODNING_OM_UNNTAK_SVAR. Bug-klynge testen vokter mot: MELOSYS-6836
+ * (to oppgaver — asserterer NØYAKTIG én behandlingsoppgave), 7124 (kan ikke sende
+ * NV) og 5415 (stegvelger åpnes ikke) fanges av "ingen feilede prosessinstanser"
+ * + at svar-prosessen faktisk avanserer behandlingen.
+ *
+ * Mock-avhengighet (melosys-docker-compose): LagMelosysEessiMeldingController må
+ * støtte `svarAnmodningUnntak`, og eux-mocken må gi NUMERISK rinaSaksnummer
+ * (api sin SED-låsreferanse-regex er ^\d+_..._\d+).
+ */
+test.describe('EU/EØS Anmodning om unntak - motta svar (A002/A011)', () => {
+
+  /**
+   * Opprett EU/EØS utsendt-arbeidstaker-sak, send A001 anmodning om unntak,
+   * og returner rinaSaksnummer (= caseId på den utgående A001) slik at svaret
+   * kan injiseres på SAMME BUC.
+   */
+  async function opprettSakOgSendAnmodning(page: Page, request: any): Promise<string> {
+    const auth = new AuthHelper(page);
+    await auth.login();
+    const hovedside = new HovedsidePage(page);
+    const opprettSak = new OpprettNySakPage(page);
+    const behandling = new EuEosBehandlingPage(page);
+    const unntak = new AnmodningUnntakPage(page);
+
+    console.log('Steg 1: Oppretter EU/EØS utsendt-arbeidstaker-sak');
+    await hovedside.goto();
+    await hovedside.klikkOpprettNySak();
+    await opprettSak.fyllInnBrukerID(USER_ID_VALID);
+    await opprettSak.velgSakstype(SAKSTYPER.EU_EOS);
+    await opprettSak.velgSakstema(SAKSTEMA.MEDLEMSKAP_LOVVALG);
+    await opprettSak.velgBehandlingstema(BEHANDLINGSTEMA.UTSENDT_ARBEIDSTAKER);
+    await behandling.fyllInnFraTilDato('01.01.2026', '01.01.2027');
+    await behandling.velgLand(EU_EOS_LAND.DANMARK);
+    await opprettSak.velgAarsak(AARSAK.SØKNAD);
+    await opprettSak.leggBehandlingIMine();
+    await opprettSak.klikkOpprettNyBehandling();
+
+    console.log('Steg 2: Venter på prosessinstanser og navigerer til behandling');
+    await waitForProcessInstances(page.request, 30);
+    await hovedside.goto();
+    await hovedside.åpneSak('TRIVIELL KARAFFEL -');
+    await page.waitForLoadState('networkidle');
+    await behandling.klikkBekreftOgFortsett();
+
+    console.log('Steg 3: Velger yrkesaktiv (direkte til) og arbeidsgiver');
+    await behandling.velgYrkesaktiv();
+    await behandling.velgYrkesaktivDirekteTil();
+    await behandling.klikkBekreftOgFortsett();
+    await behandling.velgArbeidsgiverOgFortsett('Ståles Stål AS');
+
+    console.log('Steg 4: Fyller ut og sender A001 anmodning om unntak');
+    await unntak.fyllUtBrevSkjema({
+      artikkel: 'FO_883_2004_ART11_3A',
+      begrunnelse: 'KORTVARIG_PERIODE_RETUR_NORSK_AG',
+    });
+    const docsBefore = await fetchStoredSedDocuments(request, 'A001');
+    await unntak.klikkSendBrevene();
+    const a001 = await findNewRinaSedDocument(request, 'A001', docsBefore);
+    console.log(`Steg 5: A001 sendt, rinaSaksnummer=${a001.caseId}`);
+
+    // Vent til anmodning-prosessen er ferdig (behandling -> ANMODNING_UNNTAK_SENDT)
+    // slik at rinasak-koblingen er persistert og auto-vedtak-porten er åpen.
+    await ventPaaBehandlingStatus('ANMODNING_UNNTAK_SENDT');
+    return a001.caseId;
+  }
+
+  async function ventPaaBehandlingStatus(target: string, timeoutMs = 30000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    let siste = '';
+    while (Date.now() < deadline) {
+      siste = await withDatabase(async (db) => {
+        const r = await db.queryOne<{ STATUS: string }>(
+          `SELECT status FROM behandling ORDER BY id DESC FETCH FIRST 1 ROWS ONLY`, {});
+        return r?.STATUS ?? '';
+      });
+      if (siste === target) return;
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+    expect(siste, `Behandling nådde ikke status ${target} innen ${timeoutMs}ms`).toBe(target);
+  }
+
+  /** Vent på at ANMODNING_OM_UNNTAK_SVAR-prosessen er ferdig etter mottatt svar. */
+  async function ventPaaSvarProsessFerdig(timeoutMs = 30000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const status = await withDatabase(async (db) => {
+        const r = await db.queryOne<{ STATUS: string }>(
+          `SELECT status FROM prosessinstans WHERE prosess_type = 'ANMODNING_OM_UNNTAK_SVAR'
+           ORDER BY registrert_dato DESC FETCH FIRST 1 ROWS ONLY`, {});
+        return r?.STATUS ?? null;
+      });
+      if (status === 'FERDIG') return;
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+  }
+
+  test('mottar A002 (innvilgelse) - skal fatte vedtak automatisk', async ({ page, request }) => {
+    test.setTimeout(180000);
+    const unleash = new UnleashHelper(request);
+    await unleash.enableFeature('melosys.cdm-4-4');
+
+    const rinaSaksnummer = await opprettSakOgSendAnmodning(page, request);
+
+    console.log('Steg 6: Injiserer A002 (innvilgelse) på samme BUC');
+    const sedHelper = new SedHelper(request);
+    const resp = await sedHelper.sendSed({
+      sedType: 'A002',
+      bucType: 'LA_BUC_01',
+      rinaSaksnummer,
+      fnr: USER_ID_VALID,
+      landkode: 'DK',
+      svarAnmodningUnntak: { beslutning: 'INNVILGELSE', begrunnelse: 'Innvilget av utenlandsk myndighet' },
+    });
+    expect(resp.success, `A002-injeksjon feilet: ${resp.message}`).toBe(true);
+
+    console.log('Steg 7: Venter på at svaret routes og vedtak fattes automatisk');
+    await ventPaaSvarProsessFerdig();
+    await ventPaaBehandlingStatus('AVSLUTTET');
+    await waitForProcessInstances(request, 30);
+
+    console.log('Steg 8: Verifiserer auto-vedtak');
+    const svar = new SvarAnmodningUnntakAssertions(page);
+    await svar.verifiserAutoVedtakVedInnvilgelse(request);
+  });
+
+  test('mottar A011 (avslag) - skal kreve manuell ny vurdering', async ({ page, request }) => {
+    test.setTimeout(180000);
+    const unleash = new UnleashHelper(request);
+    await unleash.enableFeature('melosys.cdm-4-4');
+
+    const rinaSaksnummer = await opprettSakOgSendAnmodning(page, request);
+
+    console.log('Steg 6: Injiserer A011 (avslag) på samme BUC');
+    const sedHelper = new SedHelper(request);
+    const resp = await sedHelper.sendSed({
+      sedType: 'A011',
+      bucType: 'LA_BUC_01',
+      rinaSaksnummer,
+      fnr: USER_ID_VALID,
+      landkode: 'DK',
+      svarAnmodningUnntak: { beslutning: 'AVSLAG', begrunnelse: 'Avslått av utenlandsk myndighet' },
+    });
+    expect(resp.success, `A011-injeksjon feilet: ${resp.message}`).toBe(true);
+
+    console.log('Steg 7: Venter på at svaret routes (manuell vurdering)');
+    await ventPaaSvarProsessFerdig();
+    await ventPaaBehandlingStatus('SVAR_ANMODNING_MOTTATT');
+    await waitForProcessInstances(request, 30);
+
+    console.log('Steg 8: Verifiserer manuell vurdering kreves');
+    const svar = new SvarAnmodningUnntakAssertions(page);
+    await svar.verifiserManuellVurderingVedAvslag(request);
+  });
+});


### PR DESCRIPTION
Ny e2e-test for EU/EØS art.16-flyten (anmodning om unntak → **motta svar**), det siste store bug-tette EU/EØS tilstandsovergang-gapet (`eos-anmodning-unntak-nyvurdering-svar`, Tier 2).

## Flyt
EU/EØS utsendt-arbeidstaker → send A001 anmodning → MOTTA svar på samme LA_BUC_01 (korrelert via `rinaSaksnummer`) → `SvarAnmodningUnntakSedRuter` → prosess `ANMODNING_OM_UNNTAK_SVAR`:
- **A002 (innvilgelse)** → vedtak fattes automatisk: behandling `AVSLUTTET`, behandlingsresultat `FASTSATT_LOVVALGSLAND` / `DELVIS_AUTOMATISERT`, lovvalg_periode NO/INNVILGET med MEDL-overføring, fagsak `LOVVALG_AVKLART`.
- **A011 (avslag)** → behandling `SVAR_ANMODNING_MOTTATT` (manuell ny vurdering), lovvalg_periode `AVSLAATT`, ingen vedtak.

Begge: `ANMODNING_OM_UNNTAK_SVAR` FERDIG uten feilede prosessinstanser, og **nøyaktig én** `BEH_SAK_MK`-behandlingsoppgave (vakt mot MELOSYS-6836 «to oppgaver»).

## Filer
- `tests/eu-eos/unntak/eu-eos-anmodning-unntak-nyvurdering-svar.spec.ts` (2 tester)
- `pages/eu-eos/unntak/svar-anmodning-unntak.assertions.ts`
- `helpers/mock-helper.ts`: `findNewRinaSedDocument` (fanger caseId=rinaSaksnummer) + `fetchOppgaver`/`OppgaveInfo`
- `helpers/sed-helper.ts`: `svarAnmodningUnntak`-felt på `SedConfig`

## Avhengighet
Krever mock-endringene i **navikt/melosys-docker-compose#147** (svarAnmodningUnntak-passthrough + numerisk caseId — `mock-`-prefiks brøt melosys-api sin SED-låsreferanse-regex). #147 er merget og publisert til `mock:latest`.

Grønn lokalt 2x mot live stack; `npm run check:tests` OK; rene docker-logger.