### PR TITLE
8128 E2E: år i beskrivelse og nøkkelord på årsavregningsoppgave

### DIFF
--- a/helpers/mock-helper.ts
+++ b/helpers/mock-helper.ts
@@ -277,6 +277,37 @@ export async function fetchOppgaver(request: APIRequestContext): Promise<Oppgave
   return response.json();
 }
 
+/**
+ * An oppgave as returned by the melosys-mock Oppgave API v2.
+ * Same oppgave-ids as v1; v2 additionally exposes the nokkelord list
+ * (MELOSYS-8128 — «Årsavregning <år>» settes via PATCH /api/v2/oppgaver/{id}).
+ */
+export interface OppgaveV2Info {
+  id: number;
+  versjon: number;
+  status: string | null;
+  beskrivelse: string | null;
+  nokkelord: string[];
+}
+
+/**
+ * Fetch a single oppgave from the melosys-mock Oppgave API v2.
+ *
+ * Used to assert nøkkelord set by melosys-api via PATCH /api/v2/oppgaver/{id}
+ * (MELOSYS-8128). Requires a mock image with the v2 endpoints
+ * (melosys-docker-compose branch 8128-oppgave-v2-nokkelord-mock or newer).
+ */
+export async function fetchOppgaveV2(
+  request: APIRequestContext,
+  oppgaveId: number
+): Promise<OppgaveV2Info> {
+  const response = await request.get(`http://localhost:8083/api/v2/oppgaver/${oppgaveId}`);
+  if (!response.ok()) {
+    throw new Error(`Failed to fetch oppgave ${oppgaveId} from Oppgave API v2: ${response.status()}`);
+  }
+  return response.json();
+}
+
 export interface MockClearResponse {
   message: string;
   journalpostCleared?: string | number;

--- a/helpers/mock-helper.ts
+++ b/helpers/mock-helper.ts
@@ -258,6 +258,8 @@ export interface OppgaveInfo {
   saksreferanse: string | null;
   aktoerId: string | null;
   behandlingstema: string | null;
+  tema: string | null;
+  beskrivelse: string | null;
 }
 
 /**

--- a/helpers/skattehendelse-helper.ts
+++ b/helpers/skattehendelse-helper.ts
@@ -1,0 +1,44 @@
+import { execSync } from 'node:child_process';
+
+/**
+ * Skattehendelse slik melosys-api sin SkattehendelserConsumer forventer den
+ * (JSON-deserialisert via objectMapper).
+ *
+ * @see melosys-api/domain/.../avgift/aarsavregning/Skattehendelse.kt
+ */
+export interface Skattehendelse {
+  /** Skatteåret hendelsen gjelder, f.eks. '2025' */
+  gjelderPeriode: string;
+  /** Fnr eller aktørId — api slår opp aktørId via PDL */
+  identifikator: string;
+  hendelsetype: string;
+}
+
+/**
+ * Publish a skattehendelse directly to the Kafka topic melosys-api consumes
+ * (teammelosys.skattehendelser.v1-local, local-mock profile).
+ *
+ * Uses kafka-console-producer inside the kafka container, so it works both
+ * locally and on CI without adding a Kafka client dependency to the test repo.
+ *
+ * Requires the 'melosys.skattehendelse.consumer' toggle to be enabled
+ * (default ON) for melosys-api to act on the event.
+ *
+ * @example
+ * publishSkattehendelse({
+ *   gjelderPeriode: String(FORRIGE_AAR),
+ *   identifikator: USER_ID_VALID,
+ *   hendelsetype: 'NY',
+ * });
+ */
+export function publishSkattehendelse(hendelse: Skattehendelse): void {
+  const json = JSON.stringify(hendelse);
+  console.log(`📨 Publishing skattehendelse to Kafka: ${json}`);
+  execSync(
+    'docker exec -i kafka kafka-console-producer' +
+      ' --bootstrap-server kafka.melosys.docker-internal:9092' +
+      ' --topic teammelosys.skattehendelser.v1-local',
+    { input: `${json}\n`, encoding: 'utf-8' }
+  );
+  console.log('✅ Skattehendelse published');
+}

--- a/helpers/unleash-helper.ts
+++ b/helpers/unleash-helper.ts
@@ -365,6 +365,7 @@ export class UnleashHelper {
         enabled: true,
       },
       { name: 'melosys.send_popp_hendelse', enabled: true },
+      { name: 'melosys.oppgave_nokkelord', enabled: true },
     ];
 
     // Per-run overrides via env vars (comma-separated toggle names).

--- a/specs/aarsavregning-oppgave-nokkelord.md
+++ b/specs/aarsavregning-oppgave-nokkelord.md
@@ -1,0 +1,77 @@
+---
+jira: MELOSYS-8128
+epic: MELOSYS-6579 — Automatisk opprette årsavregningsbehandlinger på ikke skattepliktige
+status: draft
+test: tests/utenfor-avtaleland/workflows/arsavregning-oppgave-aar-i-beskrivelse.spec.ts
+toggles:
+  melosys.oppgave_nokkelord: on   # gate for nøkkelord-funksjonaliteten; PÅ i default-lista
+tags: [årsavregning, oppgave, gosys, nøkkelord, oppgave-api-v2, ftrl]
+---
+
+# Skatteår som nøkkelord på årsavregningsoppgave
+
+## Forretningsregel
+
+Bygger på [MELOSYS-8123](aarsavregning-oppgave-skatteaar-i-beskrivelse.md) (skatteår i
+beskrivelsesfeltet): i tillegg til beskrivelsen skal skatteåret settes som **nøkkelord** på
+årsavregningsoppgaven, slik at saksbehandler kan filtrere/sortere på nøkkelord i Gosys.
+Nøkkelordet har eksakt format `Årsavregning <år>` (f.eks. «Årsavregning 2025») og settes via
+Oppgave-API v2 (`PATCH /api/v2/oppgaver/{id}`) rett etter at oppgaven er opprettet — og
+re-settes etter oppdatering/rebuild av oppgaven. Feil i nøkkelord-kallet skal aldri blokkere
+selve oppgaveopprettelsen. Funksjonaliteten er gated bak Unleash-togglen
+`melosys.oppgave_nokkelord`.
+
+## Scenario
+
+```gherkin
+Scenario: Årsavregningsoppgave får skatteår som nøkkelord
+  Gitt at togglen melosys.oppgave_nokkelord er PÅ
+   Når Melosys automatisk oppretter en årsavregningsoppgave for skatteår X
+    # (uansett trigger: skattehendelse, ikke-skattepliktig-jobb eller saksbehandlingsflyt)
+   Så har oppgaven nøkkelordet «Årsavregning X» i Oppgave-API v2
+    Og beskrivelsesfeltet inneholder fortsatt skatteår X (8123 uendret)
+
+Scenario: Nøkkelordet overlever oppdatering av oppgaven
+  Gitt en årsavregningsoppgave med nøkkelordet «Årsavregning X»
+   Når oppgaven oppdateres/rebuildes (v1-PUT erstatter hele oppgaven)
+   Så re-settes nøkkelordet «Årsavregning X» av Melosys etterpå
+```
+
+## Akseptansekriterier
+
+- [ ] Årsavregningsoppgaver opprettet av alle tre automatiske triggere (8123-scenarioene) har
+      nøkkelordet `Årsavregning <skatteår>` i Oppgave-API v2
+- [ ] Nøkkelordet finnes fortsatt etter at tilhørende prosessinstanser (som kan oppdatere
+      oppgaven) er ferdige
+- [ ] 8123-assertions (skatteår i beskrivelse, tema, oppgavetype, gjelderfelt) er uendret grønne
+
+---
+
+## Teknisk binding
+*(for testagenten — domeneleseren kan stoppe over linjen)*
+
+Implementert som **utvidelse av 8123-testene** i samme spec-fil — ikke egne tester. Alle tre
+tester får nøkkelord-assertions i tillegg til beskrivelse-assertions.
+
+**Backend:** melosys-api branch `8128-nokkelord-arsavregningsoppgave` (stacked på 8123).
+OppgaveService setter nøkkelordet i et **separat kall** (`PATCH /api/v2/oppgaver/{id}`) rett
+ETTER opprettelse/oppdatering → assertions må **polle** (`expect.poll`, 30 s), ikke
+enkelt-sjekke.
+
+**Mock:** krever mock-image med Oppgave-API v2 (melosys-docker-compose branch
+`8128-oppgave-v2-nokkelord-mock`): `GET/PATCH /api/v2/oppgaver/{id}` — samme oppgave-id-er som
+v1; PATCH erstatter hele nokkelord-listen; **v1-PUT nullstiller nokkelord** (det er dette som
+gjør re-sjekken etter prosess-fullføring til en reell regresjonsvakt).
+
+**Assertions** (helper `verifiserNokkelordPaaOppgave` i testfila):
+1. `verifiserAarsavregningsoppgaveMedSkatteaar` (8123) returnerer nå oppgave-id
+2. `expect.poll` på `fetchOppgaveV2(request, oppgaveId).nokkelord` (`helpers/mock-helper.ts`,
+   `GET http://localhost:8083/api/v2/oppgaver/{id}`) → `toContain('Årsavregning ${FORRIGE_AAR}')`
+3. Etter siste `waitForProcessInstances`: samme poll én gang til (nøkkelord overlever
+   oppdatering/rebuild)
+
+**Toggle:** `melosys.oppgave_nokkelord` er lagt inn i default-lista i
+`helpers/unleash-helper.ts` (`resetToDefaults`) som **PÅ** — alle tester kjører dermed med
+nøkkelord-funksjonaliteten aktiv, og cleanup-fixturen holder staten deterministisk.
+
+**Hjelpere:** `helpers/mock-helper.ts` (`fetchOppgaveV2`, `OppgaveV2Info` — nye)

--- a/specs/aarsavregning-oppgave-nokkelord.md
+++ b/specs/aarsavregning-oppgave-nokkelord.md
@@ -60,9 +60,10 @@ enkelt-sjekke.
 
 **Mock:** krever mock-image med Oppgave-API v2 (melosys-docker-compose PR #148):
 `GET/PATCH /api/v2/oppgaver/{id}` — samme oppgave-id-er som v1; PATCH erstatter hele
-nokkelord-listen. Re-sjekken etter prosess-fullføring asserter at nøkkelordet finnes etter
-oppdatering/rebuild av oppgaven (v1-PUT) — invarianten holder uavhengig av om mocken bevarer
-nokkelord ved v1-PUT (mock-oppførsel fra #148-review) eller backend re-setter det.
+nokkelord-listen; **v1-PUT nullstiller nokkelord** (asserted semantikk i mocken med egen
+test, jf. #148 — om ekte v1-PUT nullstiller er ukjent og verifiseres i Q, men backend har
+re-assert-vern i oppdaterOppgave uansett). Det er nullstillingen som gjør re-sjekken etter
+prosess-fullføring til en reell regresjonsvakt for re-assert-vernet.
 
 **Assertions** (helper `verifiserNokkelordPaaOppgave` i testfila):
 1. `verifiserAarsavregningsoppgaveMedSkatteaar` (8123) returnerer nå oppgave-id

--- a/specs/aarsavregning-oppgave-nokkelord.md
+++ b/specs/aarsavregning-oppgave-nokkelord.md
@@ -58,10 +58,11 @@ OppgaveService setter nøkkelordet i et **separat kall** (`PATCH /api/v2/oppgave
 ETTER opprettelse/oppdatering → assertions må **polle** (`expect.poll`, 30 s), ikke
 enkelt-sjekke.
 
-**Mock:** krever mock-image med Oppgave-API v2 (melosys-docker-compose branch
-`8128-oppgave-v2-nokkelord-mock`): `GET/PATCH /api/v2/oppgaver/{id}` — samme oppgave-id-er som
-v1; PATCH erstatter hele nokkelord-listen; **v1-PUT nullstiller nokkelord** (det er dette som
-gjør re-sjekken etter prosess-fullføring til en reell regresjonsvakt).
+**Mock:** krever mock-image med Oppgave-API v2 (melosys-docker-compose PR #148):
+`GET/PATCH /api/v2/oppgaver/{id}` — samme oppgave-id-er som v1; PATCH erstatter hele
+nokkelord-listen. Re-sjekken etter prosess-fullføring asserter at nøkkelordet finnes etter
+oppdatering/rebuild av oppgaven (v1-PUT) — invarianten holder uavhengig av om mocken bevarer
+nokkelord ved v1-PUT (mock-oppførsel fra #148-review) eller backend re-setter det.
 
 **Assertions** (helper `verifiserNokkelordPaaOppgave` i testfila):
 1. `verifiserAarsavregningsoppgaveMedSkatteaar` (8123) returnerer nå oppgave-id

--- a/specs/aarsavregning-oppgave-nokkelord.md
+++ b/specs/aarsavregning-oppgave-nokkelord.md
@@ -1,7 +1,7 @@
 ---
 jira: MELOSYS-8128
 epic: MELOSYS-6579 — Automatisk opprette årsavregningsbehandlinger på ikke skattepliktige
-status: draft
+status: verified
 test: tests/utenfor-avtaleland/workflows/arsavregning-oppgave-aar-i-beskrivelse.spec.ts
 toggles:
   melosys.oppgave_nokkelord: on   # gate for nøkkelord-funksjonaliteten; PÅ i default-lista

--- a/specs/aarsavregning-oppgave-skatteaar-i-beskrivelse.md
+++ b/specs/aarsavregning-oppgave-skatteaar-i-beskrivelse.md
@@ -1,7 +1,7 @@
 ---
 jira: MELOSYS-8123
 epic: MELOSYS-6579 — Automatisk opprette årsavregningsbehandlinger på ikke skattepliktige
-status: implemented
+status: verified
 test: tests/utenfor-avtaleland/workflows/arsavregning-oppgave-aar-i-beskrivelse.spec.ts
 toggles: {}        # default-state; per-trigger-koreografi av melosys.faktureringskomponenten.ikke-tidligere-perioder er testmekanikk (se binding)
 tags: [årsavregning, oppgave, gosys, skattehendelse, ikke-skattepliktig, ftrl]

--- a/specs/aarsavregning-oppgave-skatteaar-i-beskrivelse.md
+++ b/specs/aarsavregning-oppgave-skatteaar-i-beskrivelse.md
@@ -1,0 +1,148 @@
+---
+jira: MELOSYS-8123
+epic: MELOSYS-6579 — Automatisk opprette årsavregningsbehandlinger på ikke skattepliktige
+status: implemented
+test: tests/utenfor-avtaleland/workflows/arsavregning-oppgave-aar-i-beskrivelse.spec.ts
+toggles: {}        # default-state; per-trigger-koreografi av melosys.faktureringskomponenten.ikke-tidligere-perioder er testmekanikk (se binding)
+tags: [årsavregning, oppgave, gosys, skattehendelse, ikke-skattepliktig, ftrl]
+---
+
+# Skatteår i beskrivelse på årsavregningsoppgave
+
+## Forretningsregel
+
+Når Melosys automatisk oppretter en årsavregningsbehandling, skal saksbehandler kunne identifisere *hvilket skatteår* behandlingen gjelder direkte fra oppgaveoversikten i Gosys — uten å måtte åpne selve behandlingen. Årsavregningsoppgaver har i dag oppgavetype «Behandle årsavregning» (`BEH_ARSAVREG`) med tema Trygdeavgift, men beskrivelsesfeltet settes alltid tomt ([Oppgaver i Gosys](https://confluence.adeo.no/spaces/TEESSI/pages/478253092), [MELOSYS-6525](https://jira.adeo.no/browse/MELOSYS-6525), [MELOSYS-7614](https://jira.adeo.no/browse/MELOSYS-7614)). Regelen som innføres er: beskrivelsesfeltet skal inneholde skatteåret behandlingen gjelder for, satt automatisk ved opprettelse.
+
+## Scenario
+
+```gherkin
+# Trigger 1 — skattehendelse fra Skatteetaten
+Scenario: Årsavregningsoppgave fra skattehendelse får skatteår i beskrivelse
+  Gitt at Melosys mottar en skattehendelse for skatteår X
+    Og skatteår X ikke allerede har en årsavregningsbehandling på saken
+   Når Melosys automatisk oppretter en årsavregningsbehandling for skatteår X
+   Så er skatteår X angitt i beskrivelsesfeltet i den tilknyttede årsavregningsoppgaven i Gosys
+    Og oppgaven har ellers riktig tema, oppgavetype og gjelderfelt
+
+# Trigger 2 — periodisk jobb for ikke-skattepliktige
+Scenario: Årsavregningsoppgave fra ikke-skattepliktig-jobb får skatteår i beskrivelse
+  Gitt at Melosys kjører den periodiske jobben for ikke-skattepliktige for skatteår X
+    Og det finnes saker som kvalifiserer til automatisk årsavregning for skatteår X
+   Når Melosys automatisk oppretter en årsavregningsbehandling for skatteår X
+   Så er skatteår X angitt i beskrivelsesfeltet i den tilknyttede årsavregningsoppgaven i Gosys
+    Og oppgaven har ellers riktig tema, oppgavetype og gjelderfelt
+
+# Trigger 3 — saksbehandlingsflyt ved endring tilbake i tid
+Scenario: Årsavregningsoppgave fra saksbehandlingsflyt for tidligere år X får skatteår i beskrivelse
+  Gitt at en saksbehandler gjennomfører en endring som berører et tidligere år X
+    Og Melosys automatisk oppretter en årsavregningsbehandling for år X som følge av endringen
+   Når årsavregningsbehandlingen og tilhørende oppgave opprettes
+   Så er år X angitt i beskrivelsesfeltet i den tilknyttede årsavregningsoppgaven i Gosys
+    Og oppgaven har ellers riktig tema, oppgavetype og gjelderfelt
+```
+
+## Akseptansekriterier (det fagperson signerer av på)
+
+- [ ] Gitt at Melosys i kontekst av lytting på skattemeldinger automatisk oppretter en årsavregningsbehandling for skatteår X — så er skatteår X satt i beskrivelsesfeltet i den tilknyttede årsavregningsoppgaven
+- [ ] Gitt at Melosys automatisk oppretter en årsavregningsbehandling i kontekst av jobben «ikke skattepliktige» for skatteår X — så er skatteår X satt i beskrivelsesfeltet i den tilknyttede årsavregningsoppgaven
+- [ ] Gitt at Melosys i kontekst av en saksbehandlingsflyt automatisk oppretter en årsavregningsbehandling for tidligere år X — så er år X satt i beskrivelsesfeltet i den tilknyttede årsavregningsoppgaven
+- [ ] **Avklaring påkrevd — bekreft med fagperson (Yvonne Jacobs):** Hvilket format skal skatteåret ha i beskrivelsesfeltet? Kun årstallet (`2024`), eller en lesbar etikett (`Skatteår 2024`)? Jira-saken spesifiserer kun «X».
+
+## Kjente avgrensninger (ikke dekket her)
+
+- **Manuelt opprettede årsavregningsbehandlinger:** Saken dekker kun automatisk opprettelse. Skal beskrivelsesfeltet også settes ved manuell opprettelse, er det en separat avklaring.
+- **Oppdatering av eksisterende oppgaver:** Saken sier ingenting om å retroaktivt fylle inn beskrivelse på årsavregningsoppgaver som allerede er opprettet uten år.
+- **Innhentingsbrev ved automatisk opprettelse:** Tilgrensende flyt er spesifisert i [MELOSYS-8122](https://nav.atlassian.net/browse/MELOSYS-8122) og dekkes ikke her.
+- **Duplikatsikring ved automatisk opprettelse:** Håndteres i [MELOSYS-7592](https://jira.adeo.no/browse/MELOSYS-7592) og er en forutsetning, ikke en del av denne speken.
+
+---
+
+## Teknisk binding
+*(for testagenten — domeneleseren kan stoppe over linjen)*
+
+> **Verbatim-regel:** verdier merket `(verbatim)` er flyt-spesifikke `selectOption`-argumenter
+> og skal brukes **ordrett**. Ikke "korriger" dem mot eksempelverdier i POM-ens JSDoc — samme
+> dropdown bruker ulike koder i ulike flyter.
+
+> **Status-merknad:** Funksjonaliteten (år i beskrivelse) er **ikke implementert i melosys-api
+> ennå** (MELOSYS-8123 er i «Utvikle og teste»). Beskrivelse-assertions forventes røde til
+> feature-branchen lander; resten av flyten (oppgaveopprettelse, tema, oppgavetype) er grønn i dag.
+
+**Skatteår X i testene:** `FORRIGE_AAR` (konstant i `pages/shared/constants.ts`, `inneværende år − 1`).
+Beskrivelse-assertion er format-robust inntil avklaringen fra fagperson: assert at beskrivelsen
+**inneholder** `String(FORRIGE_AAR)` (dekker både `2025` og `Skatteår 2025`).
+
+### Felles forutsetning (alle tre triggere)
+
+Vedtatt FTRL-sak med trygdeavgift som betales til NAV (ikke-skattepliktig), avgiftsperiode i
+forrige år — samme oppskrift som `tests/utenfor-avtaleland/workflows/arsavregning-ikke-skattepliktig.spec.ts`:
+
+- bruker: `USER_ID_VALID` (`30056928150`, "TRIVIELL KARAFFEL"; aktørId i mock: `1111111111111`)
+- `OpprettNySakPage.opprettStandardSak(USER_ID_VALID)` (FTRL / MEDLEMSKAP_LOVVALG / YRKESAKTIV / SØKNAD)
+- `MedlemskapPage`: `velgPeriode('01.01.${FORRIGE_AAR}', '31.12.${FORRIGE_AAR}')` (`TestPeriods.previousYearPeriod`) ·
+  `velgLand('Afghanistan')` · `velgTrygdedekning('FTRL_2_9_FØRSTE_LEDD_C_HELSE_PENSJON')` **(verbatim)**
+- `ArbeidsforholdPage.fyllUtArbeidsforhold('Ståles Stål AS')`
+- `LovvalgPage`: `velgBestemmelse('FTRL_KAP2_2_8_FØRSTE_LEDD_A')` **(verbatim)** · `svarJaPaaFørsteSpørsmål()` ·
+  Ja på "Har søker vært medlem i minst" og "Har søker nær tilknytning til" · `klikkBekreftOgFortsett()`
+- `ResultatPeriodePage.fyllUtResultatPeriode('INNVILGET')`
+- `TrygdeavgiftPage`: `ventPåSideLastet()` · `velgSkattepliktig(false)` · `velgInntektskilde('INNTEKT_FRA_UTLANDET')` **(verbatim)** ·
+  `velgBetalesAga(false)` · `fyllInnBruttoinntektMedApiVent('100000')` · `klikkBekreftOgFortsett()`
+- `VedtakPage.klikkFattVedtak()` · `waitForProcessInstances(page.request, 30)`
+
+**Toggle-koreografi** (`UnleashHelper`, toggle `melosys.faktureringskomponenten.ikke-tidligere-perioder`):
+- **Trigger 1 og 2:** toggle **AV** under saksopprettelse/vedtak (forrige-års-UI-et krever det, og
+  fakturering må akseptere serien), **PÅ** igjen *etter* vedtaket, før selve triggeren utløses
+  (hindrer også at trigger 3 auto-oppretter årsavregningen i samme vedtak).
+- **Trigger 3 (= NV-mønsteret):** toggle **AV** under førstegangsvedtaket for *inneværende* år →
+  faktura-rader settes `BESTILT` (`withFaktureringDatabase`) → toggle **PÅ** → **ny vurdering**
+  som endrer perioden til kun forrige år → `fattVedtakForNyVurdering('FEIL_I_BEHANDLING')` →
+  `OppretteÅrsavregningVedEndring` (NV-grenen, `årMedEndringer = {forrige år}`) auto-oppretter
+  årsavregningen. Samme oppskrift som `komplett-sak-nv-periode-endres-til-kun-tidligere-ar.spec.ts`.
+  NV-spesifikke verdier: lovvalg `FTRL_KAP2_2_1` **(verbatim)** · situasjon
+  `MIDLERTIDIG_ARBEID_2_1_FJERDE_LEDD` **(verbatim)** · Ja på "Er søkers arbeidsoppdrag i",
+  "Plikter arbeidsgiver å betale", "Har søker lovlig opphold i" · resultat/trygdeavgift beholdes
+  (`klikkBekreftOgFortsett()`).
+
+**Endringslogg (teknisk binding)**
+- 2026-06-10: Trigger 3 var opprinnelig bundet som *førstegangsvedtak* for rent tidligere år med
+  toggle PÅ. Lokal kjøring viste to problemer: (a) Trygdeavgift-steget rendres ikke for rene
+  tidligere-års-perioder med togglen PÅ; (b) faktureringskomponenten avviser deterministisk
+  tidligere-års-fakturaserier for førstegangsbehandlinger («Startdato kan ikke være fra tidligere
+  år») — én grønn kjøring skyldtes toggle-propagerings-race mellom api og fakturering. Re-bundet
+  til ny vurdering-mønsteret over (prod-realistisk «endring som berører tidligere år»).
+  Domenelaget uendret.
+
+### Trigger-utløsning
+
+1. **Skattehendelse:** publiser rå JSON til Kafka-topic `teammelosys.skattehendelser.v1-local`
+   (api kjører `local-mock`-profil; `SkattehendelserConsumer` deserialiserer via objectMapper):
+   ```
+   {"gjelderPeriode":"${FORRIGE_AAR}","identifikator":"${USER_ID_VALID}","hendelsetype":"NY"}
+   ```
+   via `docker exec -i kafka kafka-console-producer --bootstrap-server kafka.melosys.docker-internal:9092 --topic teammelosys.skattehendelser.v1-local`
+   (helper: `publishSkattehendelse` i `helpers/skattehendelse-helper.ts`). `identifikator` kan være
+   fnr — api slår opp aktørId via PDL. Krever toggle `melosys.skattehendelse.consumer` PÅ (default).
+2. **Ikke-skattepliktig-jobb:** `AdminApiHelper.finnIkkeSkattepliktigeSaker(request, '${FORRIGE_AAR}-01-01', '${FORRIGE_AAR}-12-31', true)`
+   + `waitForIkkeSkattepliktigeSakerJob(request, 60, 1000)`; assert `antallProsessert === 1`.
+3. **Saksbehandlingsflyt:** ingen ekstra handling — vedtaket i felles-forutsetningen er selve triggeren.
+
+### Assertions (binder «Så»-linjene)
+
+Oppgaveregisteret verifiseres via melosys-mock: `fetchOppgaver(request)`
+(`helpers/mock-helper.ts`, `GET http://localhost:8083/testdata/verification/oppgave` — returnerer
+full `Oppgave` inkl. `beskrivelse` og `tema`; `OppgaveInfo`-interfacet utvides med disse feltene).
+Opprettelsen er asynkron (Kafka-consume / jobb / prosessinstans) → bruk `expect.poll` (timeout 30 s)
+til nøyaktig **én** oppgave med `oppgavetype === 'BEH_ARSAVREG'` finnes, deretter:
+
+- `beskrivelse` inneholder `String(FORRIGE_AAR)` ← **selve akseptansekriteriet**
+- `oppgavetype === 'BEH_ARSAVREG'` (← «riktig oppgavetype»)
+- `tema === 'TRY'` (← «riktig tema»)
+- `behandlingstema === 'ab0484'` (UTENFOR_AVTALAND_YRKESAKTIV — FTRL/YRKESAKTIV-mapping i `OppgaveGosysMapping`)
+- `aktoerId === '1111111111111'` (← «riktig gjelderfelt» for testbrukeren)
+
+Avslutt hver test med `waitForProcessInstances(page.request, 30)` slik at cleanup-fixturen ikke
+treffer aktive prosessinstanser.
+
+**Page Objects:** `HovedsidePage`, `OpprettNySakPage`, `MedlemskapPage`, `ArbeidsforholdPage`, `LovvalgPage`, `ResultatPeriodePage`, `TrygdeavgiftPage`, `VedtakPage`
+**Konstanter:** `pages/shared/constants.ts` (`USER_ID_VALID`, `FORRIGE_AAR`)
+**Hjelpere:** `helpers/api-helper.ts` (`AdminApiHelper`, `waitForProcessInstances`), `helpers/mock-helper.ts` (`fetchOppgaver`), `helpers/skattehendelse-helper.ts` (`publishSkattehendelse`, ny), `helpers/date-helper.ts` (`TestPeriods`, `TestPeriodsISO`), `helpers/unleash-helper.ts`

--- a/tests/utenfor-avtaleland/workflows/arsavregning-oppgave-aar-i-beskrivelse.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/arsavregning-oppgave-aar-i-beskrivelse.spec.ts
@@ -195,9 +195,10 @@ test.describe('Årsavregningsoppgave — skatteår i beskrivelse (MELOSYS-8123)'
         await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
         await waitForProcessInstances(page.request, 30);
 
-        // Nøkkelordet skal finnes også etter at alle prosessinstanser er ferdige —
-        // oppdatering/rebuild av oppgaven (v1-PUT) skal ikke ende med at det mangler,
-        // uavhengig av om mocken bevarer det eller backend re-setter det.
+        // Oppdatering/rebuild av oppgaven går via v1-PUT som nullstiller nokkelord i
+        // mocken (asserted semantikk, jf. melosys-docker-compose#148); backend skal
+        // re-sette nøkkelordet etterpå. Re-sjekken etter at alle prosessinstanser er
+        // ferdige fanger derfor regresjon i backends re-assert-vern.
         await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
     });
 
@@ -228,9 +229,10 @@ test.describe('Årsavregningsoppgave — skatteår i beskrivelse (MELOSYS-8123)'
         await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
         await waitForProcessInstances(page.request, 30);
 
-        // Nøkkelordet skal finnes også etter at alle prosessinstanser er ferdige —
-        // oppdatering/rebuild av oppgaven (v1-PUT) skal ikke ende med at det mangler,
-        // uavhengig av om mocken bevarer det eller backend re-setter det.
+        // Oppdatering/rebuild av oppgaven går via v1-PUT som nullstiller nokkelord i
+        // mocken (asserted semantikk, jf. melosys-docker-compose#148); backend skal
+        // re-sette nøkkelordet etterpå. Re-sjekken etter at alle prosessinstanser er
+        // ferdige fanger derfor regresjon i backends re-assert-vern.
         await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
     });
 
@@ -305,9 +307,10 @@ test.describe('Årsavregningsoppgave — skatteår i beskrivelse (MELOSYS-8123)'
         await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
         await waitForProcessInstances(page.request, 30);
 
-        // Nøkkelordet skal finnes også etter at alle prosessinstanser er ferdige —
-        // oppdatering/rebuild av oppgaven (v1-PUT) skal ikke ende med at det mangler,
-        // uavhengig av om mocken bevarer det eller backend re-setter det.
+        // Oppdatering/rebuild av oppgaven går via v1-PUT som nullstiller nokkelord i
+        // mocken (asserted semantikk, jf. melosys-docker-compose#148); backend skal
+        // re-sette nøkkelordet etterpå. Re-sjekken etter at alle prosessinstanser er
+        // ferdige fanger derfor regresjon i backends re-assert-vern.
         await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
     });
 });

--- a/tests/utenfor-avtaleland/workflows/arsavregning-oppgave-aar-i-beskrivelse.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/arsavregning-oppgave-aar-i-beskrivelse.spec.ts
@@ -1,0 +1,262 @@
+import {expect, test} from '../../../fixtures';
+import type {APIRequestContext, Page} from '@playwright/test';
+import {AuthHelper} from '../../../helpers/auth-helper';
+import {HovedsidePage} from '../../../pages/hovedside.page';
+import {OpprettNySakPage} from '../../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import {MedlemskapPage} from '../../../pages/behandling/medlemskap.page';
+import {ArbeidsforholdPage} from '../../../pages/behandling/arbeidsforhold.page';
+import {LovvalgPage} from '../../../pages/behandling/lovvalg.page';
+import {ResultatPeriodePage} from '../../../pages/behandling/resultat-periode.page';
+import {TrygdeavgiftPage} from '../../../pages/trygdeavgift/trygdeavgift.page';
+import {VedtakPage} from '../../../pages/vedtak/vedtak.page';
+import {FORRIGE_AAR, USER_ID_VALID} from '../../../pages/shared/constants';
+import {UnleashHelper} from '../../../helpers/unleash-helper';
+import {AdminApiHelper, waitForProcessInstances} from '../../../helpers/api-helper';
+import {fetchOppgaver} from '../../../helpers/mock-helper';
+import {publishSkattehendelse} from '../../../helpers/skattehendelse-helper';
+import {TestPeriods, TestPeriodsISO} from '../../../helpers/date-helper';
+import {withFaktureringDatabase} from '../../../helpers/pg-db-helper';
+
+/**
+ * MELOSYS-8123: Angi år i beskrivelse ved opprettelse av årsavregningsoppgave
+ *
+ * Spec: specs/aarsavregning-oppgave-skatteaar-i-beskrivelse.md
+ *
+ * Verifiserer at skatteåret settes i beskrivelsesfeltet på BEH_ARSAVREG-oppgaven
+ * for alle tre automatiske opprettelses-triggere:
+ *   1. Skattehendelse fra Skatteetaten (Kafka)
+ *   2. Periodisk jobb for ikke-skattepliktige
+ *   3. Saksbehandlingsflyt som berører tidligere år
+ */
+
+/** AktørId for USER_ID_VALID (30056928150) i PDL-mocken — oppgavens gjelderfelt */
+const AKTOER_ID_VALID = '1111111111111';
+
+/**
+ * Felles forutsetning: vedtatt FTRL-sak med trygdeavgift som betales til NAV
+ * (ikke-skattepliktig). Trigger 1 og 2 bruker forrige-års-periode (default);
+ * trigger 3 bruker inneværende år som utgangspunkt for ny vurdering.
+ *
+ * Toggle melosys.faktureringskomponenten.ikke-tidligere-perioder må være AV
+ * under opprettelsen — UI-et for tidligere-års-perioder krever det, og
+ * faktureringskomponenten avviser tidligere-års-fakturaserier med togglen PÅ.
+ */
+async function opprettVedtattIkkeSkattepliktigSak(
+    page: Page,
+    periode: { start: string; end: string } = TestPeriods.previousYearPeriod
+): Promise<void> {
+    const hovedside = new HovedsidePage(page);
+    const opprettSak = new OpprettNySakPage(page);
+    const medlemskap = new MedlemskapPage(page);
+    const arbeidsforhold = new ArbeidsforholdPage(page);
+    const lovvalg = new LovvalgPage(page);
+    const resultatPeriode = new ResultatPeriodePage(page);
+    const trygdeavgift = new TrygdeavgiftPage(page);
+    const vedtak = new VedtakPage(page);
+
+    console.log('📝 Oppretter sak...');
+    await hovedside.gotoOgOpprettNySak();
+    await opprettSak.opprettStandardSak(USER_ID_VALID);
+    await opprettSak.assertions.verifiserBehandlingOpprettet();
+
+    await waitForProcessInstances(page.request, 30);
+    await hovedside.goto();
+    await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).click();
+
+    console.log(`📝 Medlemskap (${periode.start} - ${periode.end})...`);
+    await medlemskap.velgPeriode(periode.start, periode.end);
+    await medlemskap.velgLand('Afghanistan');
+    await medlemskap.velgTrygdedekning('FTRL_2_9_FØRSTE_LEDD_C_HELSE_PENSJON');
+    await medlemskap.klikkBekreftOgFortsett();
+
+    console.log('📝 Arbeidsforhold...');
+    await arbeidsforhold.fyllUtArbeidsforhold('Ståles Stål AS');
+
+    console.log('📝 Lovvalg...');
+    await lovvalg.velgBestemmelse('FTRL_KAP2_2_8_FØRSTE_LEDD_A');
+    await lovvalg.svarJaPaaFørsteSpørsmål();
+    await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker vært medlem i minst');
+    await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker nær tilknytning til');
+    await lovvalg.klikkBekreftOgFortsett();
+
+    console.log('📝 Resultat...');
+    await resultatPeriode.fyllUtResultatPeriode('INNVILGET');
+
+    console.log('📝 Trygdeavgift (ikke-skattepliktig)...');
+    await trygdeavgift.ventPåSideLastet();
+    await trygdeavgift.velgSkattepliktig(false);
+    await trygdeavgift.velgInntektskilde('INNTEKT_FRA_UTLANDET');
+    await trygdeavgift.velgBetalesAga(false);
+    await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
+    await trygdeavgift.klikkBekreftOgFortsett();
+
+    console.log('📝 Fatter vedtak...');
+    await vedtak.klikkFattVedtak();
+    await waitForProcessInstances(page.request, 30);
+}
+
+/**
+ * Binder «Så»-linjene i speken: poller til nøyaktig én BEH_ARSAVREG-oppgave
+ * finnes i mockens oppgaveregister, og verifiserer beskrivelse (skatteår),
+ * tema, oppgavetype og gjelderfelt.
+ */
+async function verifiserAarsavregningsoppgaveMedSkatteaar(
+    request: APIRequestContext,
+    skatteaar: number
+): Promise<void> {
+    await expect
+        .poll(
+            async () => {
+                const oppgaver = await fetchOppgaver(request);
+                return oppgaver.filter((o) => o.oppgavetype === 'BEH_ARSAVREG').length;
+            },
+            {
+                message: 'Venter på at BEH_ARSAVREG-oppgave opprettes i oppgaveregisteret',
+                timeout: 30_000,
+            }
+        )
+        .toBe(1);
+
+    const oppgaver = await fetchOppgaver(request);
+    const oppgave = oppgaver.find((o) => o.oppgavetype === 'BEH_ARSAVREG')!;
+    console.log(`🔍 Årsavregningsoppgave: beskrivelse='${oppgave.beskrivelse}'`);
+
+    // Selve akseptansekriteriet (MELOSYS-8123): skatteåret står i beskrivelsesfeltet.
+    // Format-robust inntil avklaring fra fagperson ('2025' vs 'Skatteår 2025').
+    expect(oppgave.beskrivelse, `Skatteår ${skatteaar} skal stå i beskrivelsesfeltet`).toContain(
+        String(skatteaar)
+    );
+
+    // «Og oppgaven har ellers riktig tema, oppgavetype og gjelderfelt»
+    expect(oppgave.tema, 'Oppgaven skal ha tema Trygdeavgift').toBe('TRY');
+    expect(oppgave.behandlingstema, 'FTRL/YRKESAKTIV → UTENFOR_AVTALAND_YRKESAKTIV').toBe('ab0484');
+    expect(oppgave.aktoerId, 'Oppgaven skal gjelde testbrukeren').toBe(AKTOER_ID_VALID);
+}
+
+test.describe('Årsavregningsoppgave — skatteår i beskrivelse (MELOSYS-8123)', () => {
+    test('skattehendelse for skatteår X gir årsavregningsoppgave med X i beskrivelsen', async ({
+        page,
+        request,
+    }) => {
+        test.setTimeout(180_000);
+        const auth = new AuthHelper(page);
+        const unleash = new UnleashHelper(request);
+
+        // Toggle AV under vedtak: hindrer at saksbehandlingsflyten (trigger 3)
+        // auto-oppretter årsavregningen før skattehendelsen får gjort det.
+        await unleash.disableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+        await auth.login();
+
+        await opprettVedtattIkkeSkattepliktigSak(page);
+
+        await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+
+        console.log(`📨 Sender skattehendelse for skatteår ${FORRIGE_AAR}...`);
+        publishSkattehendelse({
+            gjelderPeriode: String(FORRIGE_AAR),
+            identifikator: USER_ID_VALID,
+            hendelsetype: 'NY',
+        });
+
+        await verifiserAarsavregningsoppgaveMedSkatteaar(request, FORRIGE_AAR);
+        await waitForProcessInstances(page.request, 30);
+    });
+
+    test('ikke-skattepliktig-jobben for skatteår X gir årsavregningsoppgave med X i beskrivelsen', async ({
+        page,
+        request,
+    }) => {
+        test.setTimeout(180_000);
+        const auth = new AuthHelper(page);
+        const unleash = new UnleashHelper(request);
+        const adminApi = new AdminApiHelper();
+
+        // Toggle AV under vedtak: årsavregningen skal opprettes av jobben, ikke av vedtaket.
+        await unleash.disableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+        await auth.login();
+
+        await opprettVedtattIkkeSkattepliktigSak(page);
+
+        await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+
+        const periodeISO = TestPeriodsISO.previousYearPeriod;
+        console.log(`⚙️ Kjører ikke-skattepliktige-jobben for ${periodeISO.start} - ${periodeISO.end}...`);
+        await adminApi.finnIkkeSkattepliktigeSaker(request, periodeISO.start, periodeISO.end, true);
+        const jobbStatus = await adminApi.waitForIkkeSkattepliktigeSakerJob(request, 60, 1000);
+        expect(jobbStatus.antallProsessert, 'Jobben skal prosessere saken').toBe(1);
+
+        await verifiserAarsavregningsoppgaveMedSkatteaar(request, FORRIGE_AAR);
+        await waitForProcessInstances(page.request, 30);
+    });
+
+    test('saksbehandlingsflyt som berører tidligere år X gir årsavregningsoppgave med X i beskrivelsen', async ({
+        page,
+        request,
+    }) => {
+        test.setTimeout(240_000);
+        const auth = new AuthHelper(page);
+        const unleash = new UnleashHelper(request);
+
+        // Endringen som berører tidligere år gjøres som ny vurdering: førstegangs-
+        // vedtaket gjelder inneværende år (toggle AV — fakturering må akseptere
+        // serien), NV endrer perioden til kun forrige år med toggle PÅ slik at
+        // OppretteÅrsavregningVedEndring auto-oppretter årsavregningen.
+        await unleash.disableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+        await auth.login();
+
+        await opprettVedtattIkkeSkattepliktigSak(page, TestPeriods.currentYearPeriod);
+
+        // Fakturaene må være BESTILT for at NV-avregningen skal gå gjennom
+        await withFaktureringDatabase(async (db) => {
+            const updated = await db.execute("UPDATE faktura SET status = 'BESTILT'");
+            console.log(`📝 Satte ${updated} faktura-rader til BESTILT`);
+        });
+
+        await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+
+        // Ny vurdering: perioden endres til kun forrige år
+        const hovedside = new HovedsidePage(page);
+        const opprettSak = new OpprettNySakPage(page);
+        const medlemskap = new MedlemskapPage(page);
+        const arbeidsforhold = new ArbeidsforholdPage(page);
+        const lovvalg = new LovvalgPage(page);
+        const resultatPeriode = new ResultatPeriodePage(page);
+        const trygdeavgift = new TrygdeavgiftPage(page);
+        const vedtak = new VedtakPage(page);
+
+        console.log('📝 Oppretter ny vurdering...');
+        await hovedside.klikkOpprettNySak();
+        await opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD');
+        await waitForProcessInstances(page.request, 30);
+
+        await hovedside.goto();
+        await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).first().click();
+
+        const periodeNV = TestPeriods.previousYearPeriod;
+        console.log(`📝 NV medlemskap (${periodeNV.start} - ${periodeNV.end})...`);
+        await medlemskap.velgPeriode(periodeNV.start, periodeNV.end);
+        await medlemskap.klikkBekreftOgFortsett();
+
+        await arbeidsforhold.fyllUtArbeidsforhold('Ståles Stål AS');
+
+        console.log('📝 NV lovvalg (FTRL 2-1 fjerde ledd)...');
+        await lovvalg.velgBestemmelse('FTRL_KAP2_2_1');
+        await lovvalg.velgBrukersSituasjon('MIDLERTIDIG_ARBEID_2_1_FJERDE_LEDD');
+        await lovvalg.svarJaPaaFørsteSpørsmål();
+        await lovvalg.svarJaPaaSpørsmålIGruppe('Er søkers arbeidsoppdrag i');
+        await lovvalg.svarJaPaaSpørsmålIGruppe('Plikter arbeidsgiver å betale');
+        await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker lovlig opphold i');
+        await lovvalg.klikkBekreftOgFortsett();
+
+        // Resultat og trygdeavgift beholdes fra forrige behandling
+        await resultatPeriode.klikkBekreftOgFortsett();
+        await trygdeavgift.klikkBekreftOgFortsett();
+
+        console.log('📝 Fatter vedtak for ny vurdering...');
+        await vedtak.fattVedtakForNyVurdering('FEIL_I_BEHANDLING');
+        await waitForProcessInstances(page.request, 30);
+
+        await verifiserAarsavregningsoppgaveMedSkatteaar(request, FORRIGE_AAR);
+        await waitForProcessInstances(page.request, 30);
+    });
+});

--- a/tests/utenfor-avtaleland/workflows/arsavregning-oppgave-aar-i-beskrivelse.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/arsavregning-oppgave-aar-i-beskrivelse.spec.ts
@@ -12,18 +12,21 @@ import {VedtakPage} from '../../../pages/vedtak/vedtak.page';
 import {FORRIGE_AAR, USER_ID_VALID} from '../../../pages/shared/constants';
 import {UnleashHelper} from '../../../helpers/unleash-helper';
 import {AdminApiHelper, waitForProcessInstances} from '../../../helpers/api-helper';
-import {fetchOppgaver} from '../../../helpers/mock-helper';
+import {fetchOppgaver, fetchOppgaveV2} from '../../../helpers/mock-helper';
 import {publishSkattehendelse} from '../../../helpers/skattehendelse-helper';
 import {TestPeriods, TestPeriodsISO} from '../../../helpers/date-helper';
 import {withFaktureringDatabase} from '../../../helpers/pg-db-helper';
 
 /**
  * MELOSYS-8123: Angi år i beskrivelse ved opprettelse av årsavregningsoppgave
+ * MELOSYS-8128: Sett år som nøkkelord på årsavregningsoppgaver via Oppgave-API v2
  *
- * Spec: specs/aarsavregning-oppgave-skatteaar-i-beskrivelse.md
+ * Spec: specs/aarsavregning-oppgave-skatteaar-i-beskrivelse.md (8123)
+ * Spec: specs/aarsavregning-oppgave-nokkelord.md (8128)
  *
- * Verifiserer at skatteåret settes i beskrivelsesfeltet på BEH_ARSAVREG-oppgaven
- * for alle tre automatiske opprettelses-triggere:
+ * Verifiserer at skatteåret settes i beskrivelsesfeltet (8123) og som nøkkelordet
+ * «Årsavregning <år>» (8128) på BEH_ARSAVREG-oppgaven for alle tre automatiske
+ * opprettelses-triggere:
  *   1. Skattehendelse fra Skatteetaten (Kafka)
  *   2. Periodisk jobb for ikke-skattepliktige
  *   3. Saksbehandlingsflyt som berører tidligere år
@@ -96,14 +99,15 @@ async function opprettVedtattIkkeSkattepliktigSak(
 }
 
 /**
- * Binder «Så»-linjene i speken: poller til nøyaktig én BEH_ARSAVREG-oppgave
+ * Binder «Så»-linjene i 8123-speken: poller til nøyaktig én BEH_ARSAVREG-oppgave
  * finnes i mockens oppgaveregister, og verifiserer beskrivelse (skatteår),
- * tema, oppgavetype og gjelderfelt.
+ * tema, oppgavetype og gjelderfelt. Returnerer oppgave-id for videre
+ * nøkkelord-verifisering (8128) — samme id i v1 og v2 av Oppgave-API-et.
  */
 async function verifiserAarsavregningsoppgaveMedSkatteaar(
     request: APIRequestContext,
     skatteaar: number
-): Promise<void> {
+): Promise<number> {
     await expect
         .poll(
             async () => {
@@ -131,6 +135,35 @@ async function verifiserAarsavregningsoppgaveMedSkatteaar(
     expect(oppgave.tema, 'Oppgaven skal ha tema Trygdeavgift').toBe('TRY');
     expect(oppgave.behandlingstema, 'FTRL/YRKESAKTIV → UTENFOR_AVTALAND_YRKESAKTIV').toBe('ab0484');
     expect(oppgave.aktoerId, 'Oppgaven skal gjelde testbrukeren').toBe(AKTOER_ID_VALID);
+
+    return oppgave.id;
+}
+
+/**
+ * Binder «Så»-linjene i 8128-speken: nøkkelordet «Årsavregning <år>» settes av
+ * melosys-api i et separat PATCH-kall (Oppgave-API v2) rett ETTER at oppgaven
+ * er opprettet/oppdatert — poll til det er på plass. Eksakt format fra
+ * OppgaveService: `Årsavregning ${skatteaar}`.
+ */
+async function verifiserNokkelordPaaOppgave(
+    request: APIRequestContext,
+    oppgaveId: number,
+    skatteaar: number
+): Promise<void> {
+    const forventet = `Årsavregning ${skatteaar}`;
+    await expect
+        .poll(
+            async () => {
+                const oppgave = await fetchOppgaveV2(request, oppgaveId);
+                return oppgave.nokkelord;
+            },
+            {
+                message: `Venter på nøkkelordet «${forventet}» på oppgave ${oppgaveId} (Oppgave-API v2)`,
+                timeout: 30_000,
+            }
+        )
+        .toContain(forventet);
+    console.log(`🔑 Oppgave ${oppgaveId} har nøkkelordet «${forventet}»`);
 }
 
 test.describe('Årsavregningsoppgave — skatteår i beskrivelse (MELOSYS-8123)', () => {
@@ -158,8 +191,14 @@ test.describe('Årsavregningsoppgave — skatteår i beskrivelse (MELOSYS-8123)'
             hendelsetype: 'NY',
         });
 
-        await verifiserAarsavregningsoppgaveMedSkatteaar(request, FORRIGE_AAR);
+        const oppgaveId = await verifiserAarsavregningsoppgaveMedSkatteaar(request, FORRIGE_AAR);
+        await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
         await waitForProcessInstances(page.request, 30);
+
+        // Oppdatering/rebuild av oppgaven går via v1-PUT som nullstiller nokkelord
+        // i mocken; backend skal re-sette nøkkelordet etterpå. Re-sjekken etter at
+        // alle prosessinstanser er ferdige fanger derfor reell regresjon.
+        await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
     });
 
     test('ikke-skattepliktig-jobben for skatteår X gir årsavregningsoppgave med X i beskrivelsen', async ({
@@ -185,8 +224,14 @@ test.describe('Årsavregningsoppgave — skatteår i beskrivelse (MELOSYS-8123)'
         const jobbStatus = await adminApi.waitForIkkeSkattepliktigeSakerJob(request, 60, 1000);
         expect(jobbStatus.antallProsessert, 'Jobben skal prosessere saken').toBe(1);
 
-        await verifiserAarsavregningsoppgaveMedSkatteaar(request, FORRIGE_AAR);
+        const oppgaveId = await verifiserAarsavregningsoppgaveMedSkatteaar(request, FORRIGE_AAR);
+        await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
         await waitForProcessInstances(page.request, 30);
+
+        // Oppdatering/rebuild av oppgaven går via v1-PUT som nullstiller nokkelord
+        // i mocken; backend skal re-sette nøkkelordet etterpå. Re-sjekken etter at
+        // alle prosessinstanser er ferdige fanger derfor reell regresjon.
+        await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
     });
 
     test('saksbehandlingsflyt som berører tidligere år X gir årsavregningsoppgave med X i beskrivelsen', async ({
@@ -256,7 +301,13 @@ test.describe('Årsavregningsoppgave — skatteår i beskrivelse (MELOSYS-8123)'
         await vedtak.fattVedtakForNyVurdering('FEIL_I_BEHANDLING');
         await waitForProcessInstances(page.request, 30);
 
-        await verifiserAarsavregningsoppgaveMedSkatteaar(request, FORRIGE_AAR);
+        const oppgaveId = await verifiserAarsavregningsoppgaveMedSkatteaar(request, FORRIGE_AAR);
+        await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
         await waitForProcessInstances(page.request, 30);
+
+        // Oppdatering/rebuild av oppgaven går via v1-PUT som nullstiller nokkelord
+        // i mocken; backend skal re-sette nøkkelordet etterpå. Re-sjekken etter at
+        // alle prosessinstanser er ferdige fanger derfor reell regresjon.
+        await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
     });
 });

--- a/tests/utenfor-avtaleland/workflows/arsavregning-oppgave-aar-i-beskrivelse.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/arsavregning-oppgave-aar-i-beskrivelse.spec.ts
@@ -195,9 +195,9 @@ test.describe('Årsavregningsoppgave — skatteår i beskrivelse (MELOSYS-8123)'
         await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
         await waitForProcessInstances(page.request, 30);
 
-        // Oppdatering/rebuild av oppgaven går via v1-PUT som nullstiller nokkelord
-        // i mocken; backend skal re-sette nøkkelordet etterpå. Re-sjekken etter at
-        // alle prosessinstanser er ferdige fanger derfor reell regresjon.
+        // Nøkkelordet skal finnes også etter at alle prosessinstanser er ferdige —
+        // oppdatering/rebuild av oppgaven (v1-PUT) skal ikke ende med at det mangler,
+        // uavhengig av om mocken bevarer det eller backend re-setter det.
         await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
     });
 
@@ -228,9 +228,9 @@ test.describe('Årsavregningsoppgave — skatteår i beskrivelse (MELOSYS-8123)'
         await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
         await waitForProcessInstances(page.request, 30);
 
-        // Oppdatering/rebuild av oppgaven går via v1-PUT som nullstiller nokkelord
-        // i mocken; backend skal re-sette nøkkelordet etterpå. Re-sjekken etter at
-        // alle prosessinstanser er ferdige fanger derfor reell regresjon.
+        // Nøkkelordet skal finnes også etter at alle prosessinstanser er ferdige —
+        // oppdatering/rebuild av oppgaven (v1-PUT) skal ikke ende med at det mangler,
+        // uavhengig av om mocken bevarer det eller backend re-setter det.
         await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
     });
 
@@ -305,9 +305,9 @@ test.describe('Årsavregningsoppgave — skatteår i beskrivelse (MELOSYS-8123)'
         await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
         await waitForProcessInstances(page.request, 30);
 
-        // Oppdatering/rebuild av oppgaven går via v1-PUT som nullstiller nokkelord
-        // i mocken; backend skal re-sette nøkkelordet etterpå. Re-sjekken etter at
-        // alle prosessinstanser er ferdige fanger derfor reell regresjon.
+        // Nøkkelordet skal finnes også etter at alle prosessinstanser er ferdige —
+        // oppdatering/rebuild av oppgaven (v1-PUT) skal ikke ende med at det mangler,
+        // uavhengig av om mocken bevarer det eller backend re-setter det.
         await verifiserNokkelordPaaOppgave(request, oppgaveId, FORRIGE_AAR);
     });
 });


### PR DESCRIPTION
E2E-tester for at automatisk opprettede årsavregningsoppgaver får skatteåret både i beskrivelsesfeltet (MELOSYS-8123) og som nøkkelordet «Årsavregning <år>» via Oppgave-API v2 (MELOSYS-8128).

Saksbehandler skal kunne se hvilket skatteår en årsavregning gjelder direkte i Gosys-oppgaven, og filtrere på nøkkelord. Nøkkelordet settes i et separat kall som kun WARN-logges ved feil — uten e2e-dekning ville en regresjon der vært usynlig.
[MELOSYS-8123](https://nav.atlassian.net/browse/MELOSYS-8123) · [MELOSYS-8128](https://nav.atlassian.net/browse/MELOSYS-8128)

- Tre tester (skattehendelse, ikke-skattepliktig-jobben, NV-saksbehandlingsflyt) som dekker alle automatiske opprettelses-triggere, med assertions på beskrivelse + nøkkelord (polling, og re-sjekk etter prosess-fullføring siden v1-PUT nullstiller nokkelord)
- Nye helpers: `publishSkattehendelse` (rå Kafka-publisering) og `fetchOppgaveV2` (mockens Oppgave-API v2)
- Toggle `melosys.oppgave_nokkelord` lagt i default-lista i unleash-helper
- Specs for 8123 og 8128

## Testing
- [x] Lokal e2e 3/3 grønn mot melosys-api `8128-nokkelord-arsavregningsoppgave` (7cccd63b1d) og mock `8128-oppgave-v2-nokkelord-mock` (245b275c28)
- [x] CI 76/0 for 8123-delen (run 27263683089)
- [x] CI 76/0 med 8128-images (run [27286792482](https://github.com/navikt/melosys-e2e-tests/actions/runs/27286792482))

## Notater
Backend-PR-er: api [#3378](https://github.com/navikt/melosys-api/pull/3378) (8123 alt merget), mock [melosys-docker-compose#148](https://github.com/navikt/melosys-docker-compose/pull/148).

Krever melosys-api fra 8128-branchen (PR #3378). Mock-kravet er løst: [melosys-docker-compose#148](https://github.com/navikt/melosys-docker-compose/pull/148) er merget til master (58f7713), så `mock:latest` har Oppgave-API v2 fra og med neste bygg. CI-runnet over brukte override-taggen fra samme branch.

