### PR TITLE
NOJIRA E2E-test for nyvurdering av trygdeavtale

### DIFF
--- a/pages/behandling/trygdeavtale-arbeidssted.page.ts
+++ b/pages/behandling/trygdeavtale-arbeidssted.page.ts
@@ -111,10 +111,24 @@ export class TrygdeavtaleArbeidsstedPage extends BasePage {
   /**
    * Click "Fatt vedtak" button to submit the decision
    * For Trygdeavtale, this directly submits without a separate vedtak page
+   *
+   * Waits for POST /api/saksflyt/vedtak/{id}/fatt to complete (can take
+   * 30-60s on CI) so callers don't race ahead before the vedtak exists.
    */
   async fattVedtak(): Promise<void> {
+    const responsePromise = this.page.waitForResponse(
+      response =>
+        response.url().includes('/api/saksflyt/vedtak/') &&
+        response.url().includes('/fatt') &&
+        response.request().method() === 'POST' &&
+        (response.status() === 200 || response.status() === 204),
+      { timeout: 60000 }
+    );
+
     await this.fattVedtakButton.click();
-    console.log('✅ Submitted vedtak');
+
+    const response = await responsePromise;
+    console.log(`✅ Submitted vedtak - API fullført: ${response.url()} -> ${response.status()}`);
   }
 
   /**

--- a/pages/behandling/trygdeavtale-behandling.assertions.ts
+++ b/pages/behandling/trygdeavtale-behandling.assertions.ts
@@ -1,6 +1,7 @@
-import { Page, expect } from '@playwright/test';
+import { APIRequestContext, Page, expect } from '@playwright/test';
 import { assertErrors } from '../../utils/assertions';
 import { withDatabase } from '../../helpers/db-helper';
+import { fetchMedlPeriode } from '../../helpers/mock-helper';
 
 /**
  * Assertion methods for TrygdeavtaleBehandlingPage
@@ -141,5 +142,169 @@ export class TrygdeavtaleBehandlingAssertions {
     await this.verifiserArbeidslandIDatabase(fnr, landkode);
 
     console.log('✅ Trygdeavtale behandling verified completely');
+  }
+
+  /**
+   * Verifiser hele DB-utfallet av et fattet nyvurderings-vedtak på en
+   * trygdeavtale-sak (databasen renses før hver test, så NV-behandlingen er
+   * den eneste NY_VURDERING-raden):
+   *  - NV-behandlingen er AVSLUTTET og peker på opprinnelig behandling
+   *  - behandlingsresultatet er FASTSATT_LOVVALGSLAND med forventet
+   *    NY_VURDERING_BAKGRUNN (NB: BEHANDLINGSRESULTAT har PK=BEHANDLING_ID)
+   *  - NV-en har fått en NY lovvalgsperiode-rad med forkortet TOM og SAMME
+   *    medlperiode_id som førstegangsbehandlingen (perioden er ERSTATTET
+   *    in-place i MEDL, ikke opprettet på nytt)
+   *  - ingen feilede prosessinstanser, og iverksettingen
+   *    (IVERKSETT_VEDTAK_TRYGDEAVTALE) er FERDIG
+   *
+   * @returns medlperiode_id for MEDL-mock-oppslag
+   */
+  async verifiserNyVurderingVedtakIDatabase(forventet: {
+    fom: string; // DD.MM.YYYY
+    tom: string; // DD.MM.YYYY (forkortet NV-dato)
+    bakgrunn: string; // f.eks. 'NYE_OPPLYSNINGER'
+    bestemmelse: string; // f.eks. 'AUS_ART9_3'
+  }): Promise<number> {
+    return await withDatabase(async (db) => {
+      // NV-behandlingen: avsluttet og koblet til opprinnelig behandling
+      const nvBehandlinger = await db.query<{
+        ID: number;
+        STATUS: string;
+        OPPRINNELIG_BEHANDLING_ID: number | null;
+      }>(
+        `SELECT ID, STATUS, OPPRINNELIG_BEHANDLING_ID
+         FROM BEHANDLING
+         WHERE BEH_TYPE = 'NY_VURDERING'`
+      );
+      expect(nvBehandlinger, 'Forventet nøyaktig én NY_VURDERING-behandling').toHaveLength(1);
+      const nv = nvBehandlinger[0];
+      expect(nv.STATUS, 'NV-behandlingen skal være AVSLUTTET').toBe('AVSLUTTET');
+      expect(
+        nv.OPPRINNELIG_BEHANDLING_ID,
+        'NV-behandlingen skal peke på opprinnelig behandling'
+      ).not.toBeNull();
+      console.log(
+        `✅ NV-behandling ${nv.ID} AVSLUTTET (opprinnelig behandling: ${nv.OPPRINNELIG_BEHANDLING_ID})`
+      );
+
+      // Behandlingsresultatet (PK = BEHANDLING_ID)
+      const resultat = await db.queryOne<{
+        RESULTAT_TYPE: string;
+        NY_VURDERING_BAKGRUNN: string | null;
+      }>(
+        `SELECT RESULTAT_TYPE, NY_VURDERING_BAKGRUNN
+         FROM BEHANDLINGSRESULTAT
+         WHERE BEHANDLING_ID = :id`,
+        { id: nv.ID }
+      );
+      expect(resultat, 'Forventet behandlingsresultat for NV-behandlingen').not.toBeNull();
+      expect(resultat!.RESULTAT_TYPE).toBe('FASTSATT_LOVVALGSLAND');
+      expect(resultat!.NY_VURDERING_BAKGRUNN).toBe(forventet.bakgrunn);
+      console.log(
+        `✅ Behandlingsresultat: FASTSATT_LOVVALGSLAND (bakgrunn: ${resultat!.NY_VURDERING_BAKGRUNN})`
+      );
+
+      // NV-ens lovvalgsperiode: forkortet TOM (lovvalg_periode.BEH_RESULTAT_ID
+      // refererer BEHANDLINGSRESULTAT, hvis PK er BEHANDLING_ID)
+      const nvPeriode = await db.queryOne<{
+        FOM: string;
+        TOM: string;
+        LOVVALG_BESTEMMELSE: string;
+        MEDLPERIODE_ID: number | null;
+      }>(
+        `SELECT TO_CHAR(FOM_DATO, 'DD.MM.YYYY') AS FOM,
+                TO_CHAR(TOM_DATO, 'DD.MM.YYYY') AS TOM,
+                LOVVALG_BESTEMMELSE,
+                MEDLPERIODE_ID
+         FROM LOVVALG_PERIODE
+         WHERE BEH_RESULTAT_ID = :id
+         ORDER BY ID DESC
+         FETCH FIRST 1 ROWS ONLY`,
+        { id: nv.ID }
+      );
+      expect(nvPeriode, 'Forventet en lovvalgsperiode for NV-behandlingen').not.toBeNull();
+      expect(nvPeriode!.FOM, 'FOM skal være uendret').toBe(forventet.fom);
+      expect(nvPeriode!.TOM, 'TOM skal være forkortet av nyvurderingen').toBe(forventet.tom);
+      expect(nvPeriode!.LOVVALG_BESTEMMELSE).toBe(forventet.bestemmelse);
+      expect(
+        nvPeriode!.MEDLPERIODE_ID,
+        'NV-lovvalgsperioden skal være overført til MEDL (medlperiode_id satt)'
+      ).toBeGreaterThan(0);
+
+      // Førstegangsbehandlingens periode skal ha SAMME medlperiode_id
+      // (MEDL-perioden erstattes in-place — det opprettes ikke en ny)
+      const førstegangPeriode = await db.queryOne<{ MEDLPERIODE_ID: number | null }>(
+        `SELECT MEDLPERIODE_ID
+         FROM LOVVALG_PERIODE
+         WHERE BEH_RESULTAT_ID = :id
+         ORDER BY ID DESC
+         FETCH FIRST 1 ROWS ONLY`,
+        { id: nv.OPPRINNELIG_BEHANDLING_ID }
+      );
+      expect(
+        førstegangPeriode,
+        'Forventet en lovvalgsperiode for førstegangsbehandlingen'
+      ).not.toBeNull();
+      expect(
+        nvPeriode!.MEDLPERIODE_ID,
+        'NV-perioden skal gjenbruke førstegangsbehandlingens MEDL-periode (erstattet in-place)'
+      ).toBe(førstegangPeriode!.MEDLPERIODE_ID);
+      console.log(
+        `✅ NV-lovvalgsperiode ${nvPeriode!.FOM} – ${nvPeriode!.TOM} (${nvPeriode!.LOVVALG_BESTEMMELSE}, medlperiode_id=${nvPeriode!.MEDLPERIODE_ID} — samme som førstegang)`
+      );
+
+      // Ingen feilede prosessinstanser (ren DB per fixture → ingen tidsfilter)
+      const feilede = await db.query<{ PROSESS_TYPE: string }>(
+        `SELECT PROSESS_TYPE FROM PROSESSINSTANS WHERE STATUS = 'FEILET'`
+      );
+      expect(
+        feilede,
+        `Forventet ingen feilede prosessinstanser, fant: ${JSON.stringify(feilede)}`
+      ).toHaveLength(0);
+
+      // Nyeste iverksetting av trygdeavtale-vedtak skal være FERDIG
+      const iverksett = await db.queryOne<{ STATUS: string; SIST_FULLFORT_STEG: string }>(
+        `SELECT STATUS, SIST_FULLFORT_STEG
+         FROM PROSESSINSTANS
+         WHERE PROSESS_TYPE = 'IVERKSETT_VEDTAK_TRYGDEAVTALE'
+         ORDER BY REGISTRERT_DATO DESC
+         FETCH FIRST 1 ROWS ONLY`
+      );
+      expect(
+        iverksett,
+        'Forventet en IVERKSETT_VEDTAK_TRYGDEAVTALE-prosessinstans etter NV-vedtak'
+      ).not.toBeNull();
+      expect(iverksett!.STATUS, 'NV-iverksettingen skal være FERDIG').toBe('FERDIG');
+      console.log(
+        `✅ IVERKSETT_VEDTAK_TRYGDEAVTALE FERDIG (sist fullført steg: ${iverksett!.SIST_FULLFORT_STEG}), ingen feilede prosessinstanser`
+      );
+
+      return nvPeriode!.MEDLPERIODE_ID as number;
+    });
+  }
+
+  /**
+   * Verifiser i MEDL-mocken at perioden er ERSTATTET in-place av nyvurderingen:
+   * fortsatt GYLD, men med forkortet tilOgMed.
+   *
+   * @param request       - Playwright APIRequestContext (for MEDL-mock-oppslag)
+   * @param medlPeriodeId - MEDL-periode-id (lovvalg_periode.medlperiode_id)
+   * @param forventet     - Forventet tilstand (tilOgMed i ISO-format YYYY-MM-DD)
+   */
+  async verifiserMedlPeriodeErstattet(
+    request: APIRequestContext,
+    medlPeriodeId: number,
+    forventet: { tilOgMed: string; grunnlag: string }
+  ): Promise<void> {
+    const periode = await fetchMedlPeriode(request, medlPeriodeId);
+    expect(periode.status, `MEDL-periode ${medlPeriodeId} skal fortsatt være GYLD`).toBe('GYLD');
+    expect(
+      periode.tilOgMed,
+      'MEDL-perioden skal være erstattet in-place med forkortet tilOgMed'
+    ).toBe(forventet.tilOgMed);
+    expect(periode.grunnlag).toBe(forventet.grunnlag);
+    console.log(
+      `✅ MEDL-periode ${medlPeriodeId} erstattet in-place: GYLD, tilOgMed=${periode.tilOgMed}, grunnlag=${periode.grunnlag}`
+    );
   }
 }

--- a/pages/behandling/trygdeavtale-behandling.page.ts
+++ b/pages/behandling/trygdeavtale-behandling.page.ts
@@ -61,6 +61,31 @@ export class TrygdeavtaleBehandlingPage extends BasePage {
     name: 'Bekreft og fortsett'
   });
 
+  // Locators - Vedtak step (NV). Stegvelger wrapper hvert steg i <div id={stegnavn}>
+  // (felleskomponenter/stegFane), så #VEDTAK scoper til vedtak-steget. Periode-
+  // redigeringen ligger i en span med BEM-klassen vurderingVedtak__datofelt.
+  private readonly vedtakSteg = this.page.locator('#VEDTAK');
+
+  private readonly vedtakPeriodeEndreButton = this.vedtakSteg.getByRole('button', {
+    name: 'Endre'
+  });
+
+  private readonly vedtakPeriodeTomFelt = this.vedtakSteg.locator(
+    '.vurderingVedtak__datofelt input'
+  );
+
+  private readonly vedtakPeriodeLagreButton = this.vedtakSteg
+    .locator('.vurderingVedtak__datofelt')
+    .getByRole('button', { name: 'Lagre' });
+
+  private readonly grunnForNyttVedtakDropdown = this.page.getByRole('combobox', {
+    name: /Oppgi grunn for nytt vedtak/
+  });
+
+  private readonly fattVedtakButton = this.page.getByRole('button', {
+    name: 'Fatt vedtak'
+  });
+
   constructor(page: Page) {
     super(page);
     this.assertions = new TrygdeavtaleBehandlingAssertions(page);
@@ -200,5 +225,99 @@ export class TrygdeavtaleBehandlingPage extends BasePage {
     await this.fyllUtPeriodeOgLand();
     await this.velgArbeidsgiverOgFortsett();
     await this.innvilgeOgVelgBestemmelse();
+  }
+
+  // ── Nyvurdering (NV) ─────────────────────────────────────────────────
+
+  /**
+   * NV Inngang-steget: feltene er prefilled fra forrige behandling — endre kun
+   * "Til og med" (forkort/forleng perioden) og bekreft.
+   *
+   * NB: bruk fill() (erstatter innholdet); pressSequentially appender til
+   * den prefilled datoen.
+   *
+   * @param tilOgMed - Ny sluttdato i format DD.MM.YYYY (f.eks. '31.12.2025')
+   */
+  async endreInngangTilOgMedOgFortsett(tilOgMed: string): Promise<void> {
+    await this.tilOgMedField.waitFor({ state: 'visible', timeout: 15000 });
+    await this.tilOgMedField.click();
+    await this.tilOgMedField.fill(tilOgMed);
+    console.log(`✅ NV Inngang: endret "Til og med" til ${tilOgMed}`);
+    await this.klikkBekreftOgFortsett();
+  }
+
+  /**
+   * Vedtak-steget (NV): synk vedtaksperiodens TOM-dato med Inngang-endringen.
+   *
+   * GOTCHA: Periode-visningen på vedtak-steget viser GAMMEL TOM — den synker
+   * IKKE automatisk fra Inngang-steget. Må klikke "Endre" → fylle inline
+   * TOM-felt (kun TOM er redigerbart, FOM er låst) → "Lagre".
+   *
+   * @param tilOgMed - Ny sluttdato i format DD.MM.YYYY (f.eks. '31.12.2025')
+   */
+  async endreVedtaksperiodeTom(tilOgMed: string): Promise<void> {
+    await this.vedtakPeriodeEndreButton.waitFor({ state: 'visible', timeout: 30000 });
+    await this.vedtakPeriodeEndreButton.click();
+
+    await this.vedtakPeriodeTomFelt.waitFor({ state: 'visible', timeout: 10000 });
+    await this.vedtakPeriodeTomFelt.click();
+    await this.vedtakPeriodeTomFelt.fill(tilOgMed);
+
+    // "Lagre" trigger PUT /trygdeavtale-flyt/{behandlingID}; DOM-en oppdateres
+    // optimistisk FØR svaret, så vent på selve lagringen for å unngå at
+    // etterfølgende steg racer persisteringen på treg CI
+    const lagrePromise = this.page.waitForResponse(
+      (response) =>
+        response.url().includes('/trygdeavtale-flyt/') &&
+        response.request().method() === 'PUT' &&
+        response.ok(),
+      { timeout: 30000 }
+    );
+    await this.vedtakPeriodeLagreButton.click();
+    await lagrePromise;
+
+    // Etter lagring rendres datoen som ren tekst i periode-visningen
+    await this.vedtakSteg
+      .locator('.vurderingVedtak__datofelt_wrapper')
+      .getByText(tilOgMed)
+      .waitFor({ state: 'visible', timeout: 10000 });
+    console.log(`✅ Vedtaksperiode TOM endret og lagret: ${tilOgMed}`);
+  }
+
+  /**
+   * Velg obligatorisk "grunn for nytt vedtak" på vedtak-steget.
+   * For en nyvurdering (NV) er feltet påkrevd, og "Fatt vedtak" forblir
+   * deaktivert til en grunn er valgt.
+   *
+   * @param grunn - Grunn-kode ('NYE_OPPLYSNINGER', 'FEIL_I_BEHANDLING' eller 'Fritekst')
+   */
+  async velgGrunnForNyttVedtak(grunn: string): Promise<void> {
+    await this.grunnForNyttVedtakDropdown.waitFor({ state: 'visible', timeout: 10000 });
+    await this.grunnForNyttVedtakDropdown.selectOption(grunn);
+    console.log(`✅ Valgte grunn for nytt vedtak: ${grunn}`);
+  }
+
+  /**
+   * Klikk "Fatt vedtak" på vedtak-steget og vent på at vedtaket faktisk fattes.
+   * Venter på POST /api/saksflyt/vedtak/{id}/fatt (kan ta 30-60s på CI) slik at
+   * vi ikke fortsetter før backend har registrert vedtaket.
+   */
+  async fattVedtak(): Promise<void> {
+    await this.page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+    await this.fattVedtakButton.waitFor({ state: 'visible', timeout: 10000 });
+
+    const responsePromise = this.page.waitForResponse(
+      response =>
+        response.url().includes('/api/saksflyt/vedtak/') &&
+        response.url().includes('/fatt') &&
+        response.request().method() === 'POST' &&
+        (response.status() === 200 || response.status() === 204),
+      { timeout: 60000 }
+    );
+
+    await this.fattVedtakButton.click();
+
+    const response = await responsePromise;
+    console.log(`✅ Vedtak fattet - API fullført: ${response.url()} -> ${response.status()}`);
   }
 }

--- a/tests/trygdeavtale/trygdeavtale-nyvurdering.spec.ts
+++ b/tests/trygdeavtale/trygdeavtale-nyvurdering.spec.ts
@@ -1,0 +1,125 @@
+import { test } from '../../fixtures';
+import { AuthHelper } from '../../helpers/auth-helper';
+import { HovedsidePage } from '../../pages/hovedside.page';
+import { OpprettNySakPage } from '../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import { TrygdeavtaleBehandlingPage } from '../../pages/behandling/trygdeavtale-behandling.page';
+import { TrygdeavtaleArbeidsstedPage } from '../../pages/behandling/trygdeavtale-arbeidssted.page';
+import { USER_ID_VALID } from '../../pages/shared/constants';
+import { waitForProcessInstances } from '../../helpers/api-helper';
+
+/**
+ * Nyvurdering (NV) på trygdeavtale-sak — forkortet periode erstatter MEDL-periode
+ *
+ * Gap: trygdeavtale-nyvurdering. Trygdeavtale dekkes ellers kun av én
+ * førstegangs-test; NV-flyten (5 steg: Inngang, Virksomhet, Bestemmelse,
+ * Familie, Vedtak) var udekket. Kjente bugs i NV-området: MELOSYS-7859
+ * (datovalidering), MELOSYS-6567 (attest-checkbox ved NV).
+ *
+ * Scenario:
+ * 1. Fullfør en førstegangs trygdeavtale-behandling → fattet vedtak
+ *    (Australia, art. 9 nr. 3, 01.01.2024–01.01.2026)
+ * 2. Opprett Nyvurdering på samme sak
+ * 3. Forkort perioden på Inngang-steget (TOM → 31.12.2025)
+ * 4. På Vedtak-steget: synk vedtaksperiodens TOM (viser GAMMEL dato — må
+ *    endres via "Endre" → inline TOM-felt → "Lagre"), oppgi obligatorisk
+ *    grunn for nytt vedtak (NYE_OPPLYSNINGER) og fatt vedtak
+ * 5. Verifiser:
+ *    - NV-behandlingen er AVSLUTTET med resultat FASTSATT_LOVVALGSLAND og
+ *      NY_VURDERING_BAKGRUNN=NYE_OPPLYSNINGER
+ *    - ny lovvalgsperiode-rad med forkortet TOM og SAMME medlperiode_id som
+ *      førstegangsbehandlingen
+ *    - ingen feilede prosessinstanser; IVERKSETT_VEDTAK_TRYGDEAVTALE FERDIG
+ *    - MEDL-perioden er erstattet in-place i mocken (GYLD, tilOgMed forkortet)
+ */
+const FØRSTE_FRA = '01.01.2024';
+const FØRSTE_TIL = '01.01.2026';
+const NV_FORKORTET_TIL = '31.12.2025';
+const NV_FORKORTET_TIL_ISO = '2025-12-31';
+
+test.describe('Trygdeavtale - Nyvurdering', () => {
+  test('skal forkorte periode via nyvurdering og erstatte MEDL-perioden in-place', async ({ page }) => {
+    test.setTimeout(180000);
+
+    const auth = new AuthHelper(page);
+    await auth.login();
+
+    const hovedside = new HovedsidePage(page);
+    const opprettSak = new OpprettNySakPage(page);
+    const behandling = new TrygdeavtaleBehandlingPage(page);
+    const arbeidssted = new TrygdeavtaleArbeidsstedPage(page);
+
+    // === DEL A: Førstegangs trygdeavtale-behandling → fattet vedtak ===
+    console.log('📝 Del A: Oppretter førstegangs trygdeavtale-sak...');
+    await hovedside.goto();
+    await hovedside.klikkOpprettNySak();
+    await opprettSak.fyllInnBrukerID(USER_ID_VALID);
+    await opprettSak.velgSakstype('TRYGDEAVTALE');
+    await opprettSak.velgSakstema('MEDLEMSKAP_LOVVALG');
+    await opprettSak.velgBehandlingstema('YRKESAKTIV');
+    await opprettSak.velgAarsak('SØKNAD');
+    await opprettSak.leggBehandlingIMine();
+    await opprettSak.klikkOpprettNyBehandling();
+    await opprettSak.assertions.verifiserBehandlingOpprettet();
+
+    await waitForProcessInstances(page.request, 30);
+    await hovedside.goto();
+    await hovedside.åpneBehandling('TRIVIELL KARAFFEL -');
+    await page.waitForLoadState('networkidle');
+
+    console.log('📝 Del A: Fullfører førstegangsbehandling til vedtak...');
+    await behandling.fyllUtPeriodeOgLand(FØRSTE_FRA, FØRSTE_TIL, 'AU');
+    await behandling.velgArbeidsgiverOgFortsett('Ståles Stål AS');
+    await behandling.innvilgeOgVelgBestemmelse('AUS_ART9_3');
+    await arbeidssted.fyllUtArbeidsstedOgFattVedtak('Test');
+
+    console.log('📝 Del A: Venter på iverksetting av førstegangsvedtak...');
+    await waitForProcessInstances(page.request, 30);
+
+    // === DEL B: Opprett Nyvurdering på samme sak ===
+    console.log('📝 Del B: Oppretter nyvurdering...');
+    await hovedside.goto();
+    await hovedside.klikkOpprettNySak();
+    await opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD');
+    await waitForProcessInstances(page.request, 30);
+
+    // Åpne den NYE aktive behandlingen (åpneBehandling tar første lenke = nyeste)
+    await hovedside.goto();
+    await hovedside.åpneBehandling('TRIVIELL KARAFFEL -');
+    await page.waitForLoadState('networkidle');
+
+    // === DEL C: Driv NV-flyten (Inngang → Virksomhet → Bestemmelse → Familie → Vedtak) ===
+    console.log(`📝 Del C: Forkorter perioden på Inngang-steget (TOM → ${NV_FORKORTET_TIL})...`);
+    // Inngang: felter prefilled fra forrige behandling — endre kun TOM
+    await behandling.endreInngangTilOgMedOgFortsett(NV_FORKORTET_TIL);
+    // Virksomhet: arbeidsgiver pre-valgt fra forrige behandling
+    await behandling.klikkBekreftOgFortsett();
+    // Bestemmelse og vurdering: innvilgelse + AUS_ART9_3 pre-valgt
+    await behandling.klikkBekreftOgFortsett();
+    // Familie: ingen medfølgende familiemedlemmer
+    await behandling.klikkBekreftOgFortsett();
+
+    // Vedtak-steget: synk vedtaksperiodens TOM, oppgi grunn og fatt vedtak
+    console.log('📝 Del C: Vedtak-steget — synker TOM, velger grunn og fatter vedtak...');
+    await behandling.endreVedtaksperiodeTom(NV_FORKORTET_TIL);
+    await behandling.velgGrunnForNyttVedtak('NYE_OPPLYSNINGER');
+    await behandling.fattVedtak();
+
+    // === DEL D: Verifiser DB + MEDL ===
+    console.log('📝 Del D: Venter på iverksetting av NV-vedtak (kaster ved feilede prosessinstanser)...');
+    await waitForProcessInstances(page.request, 30);
+
+    const medlPeriodeId = await behandling.assertions.verifiserNyVurderingVedtakIDatabase({
+      fom: FØRSTE_FRA,
+      tom: NV_FORKORTET_TIL,
+      bakgrunn: 'NYE_OPPLYSNINGER',
+      bestemmelse: 'AUS_ART9_3'
+    });
+
+    await behandling.assertions.verifiserMedlPeriodeErstattet(page.request, medlPeriodeId, {
+      tilOgMed: NV_FORKORTET_TIL_ISO,
+      grunnlag: 'Australia_9_3'
+    });
+
+    console.log('✅ NV på trygdeavtale-sak fullført: periode forkortet og MEDL-periode erstattet in-place');
+  });
+});


### PR DESCRIPTION
## Hva

Lukker NV-gapet for trygdeavtale i e2e-dekningen — sakstypen var kun dekket av én førstegangstest. Ny test kjører hele kjeden: førstegangsbehandling (Australia, art. 9.3) → fattet vedtak → **nyvurdering** med forkortet periode → fattet NV-vedtak.

## Verifiseringer (reelle asserts)

- **DB**: NV-behandling `AVSLUTTET` med resultat `FASTSATT_LOVVALGSLAND` + `NY_VURDERING_BAKGRUNN=NYE_OPPLYSNINGER`; ny lovvalgsperiode med forkortet TOM og **samme** `medlperiode_id` som førstegang; ingen prosessinstanser i `FEILET`; `IVERKSETT_VEDTAK_TRYGDEAVTALE` ferdig.
- **MEDL (mock)**: perioden erstattet in-place — `GYLD` med ny `tilOgMed`, ikke ny periode.

## POM-endringer

- `TrygdeavtaleBehandlingPage`: `endreInngangTilOgMedOgFortsett`, `endreVedtaksperiodeTom` (venter på `PUT /trygdeavtale-flyt/` — UI-et oppdaterer DOM optimistisk før lagringen er persistert), `velgGrunnForNyttVedtak`, `fattVedtak` (venter på `POST .../fatt`).
- `TrygdeavtaleArbeidsstedPage.fattVedtak` venter nå også på `/fatt`-POST-en — lukker en latent race i den eksisterende førstegangstesten.

## Notater fra discovery

- Vedtak-steget viser gammel TOM selv etter endring på Inngang — perioden må redigeres inline på vedtak-steget («Endre» → TOM → «Lagre»). Datofeltet har tomt label-attributt i `vurderingVedtak.tsx`, så CSS-klasse-selektor er eneste praktiske handle.
- Kjente bugs MELOSYS-7859/MELOSYS-6567 ble ikke truffet; ingen attest-checkbox finnes på NV-vedtak.
- Ingen mock-endring nødvendig.

Lokalt: begge trygdeavtale-specs grønne + `npm run check:tests` OK.