### PR TITLE
NOJIRA E2E-tester for EØS-pensjonist årsavregning uten grunnlag

### DIFF
--- a/pages/behandling/aarsavregning.assertions.ts
+++ b/pages/behandling/aarsavregning.assertions.ts
@@ -72,4 +72,64 @@ export class AarsavregningAssertions {
   async verifiserIngenFeil(): Promise<void> {
     await assertErrors(this.page, []);
   }
+
+  /**
+   * Verifiser at årsvelgeren har forhåndsvalgt forventet år.
+   * Auto-opprettede årsavregninger (prosess OPPRETT_NY_BEHANDLING_AARSAVREGNING)
+   * kjenner året fra førstegangsbehandlingen, så året skal IKKE velges manuelt.
+   */
+  async verifiserValgtÅr(år: string): Promise<void> {
+    await expect(this.page.locator('#aarVelger')).toHaveValue(år, { timeout: 10000 });
+    console.log(`✅ År ${år} er forhåndsvalgt i årsvelgeren`);
+  }
+
+  /**
+   * Verifiser uten-grunnlag-flyten (toggle `melosys.arsavregning.eos_pensjonist`
+   * + ingen tidligere trygdeavgiftsgrunnlag): info-alert vises og
+   * «Avviker innbetalt»-radioen er skjult (harInnbetaltTrygdeavgift settes
+   * automatisk til true av frontenden).
+   */
+  async verifiserUtenGrunnlagFlyt(): Promise<void> {
+    await expect(
+      this.page.getByText(
+        'Det er ingen informasjon om forskuddsvis fakturert trygdeavgift i Melosys.'
+      )
+    ).toBeVisible({ timeout: 10000 });
+    await expect(
+      this.page.getByRole('group', { name: /Avviker innbetalt/ })
+    ).toBeHidden();
+    console.log('✅ Uten-grunnlag-flyt: info-alert vises og avvik-radioen er skjult');
+  }
+
+  /**
+   * Verifiser SumArsavregning-tabellen (sumArsavregningTabell.tsx).
+   *
+   * Beløpene er norskformaterte («201,96»); negativ differanse bruker
+   * U+2212 MINUS SIGN (−), ikke bindestrek. Differanse-cellen har &nbsp;
+   * mellom beløp og «kr», så vi matcher kun beløpet der.
+   * Radene matches case-sensitivt slik at «Innbetalt trygdeavgift» ikke
+   * også treffer raden «Tidligere innbetalt trygdeavgift».
+   */
+  async verifiserSumTabell(forventet: {
+    endeligBeregnet: string;
+    innbetalt: string;
+    differanse: string;
+  }): Promise<void> {
+    const tabell = this.page.locator('.sumArsavregningTabell').first();
+    await expect(tabell).toBeVisible({ timeout: 15000 });
+
+    await expect(
+      tabell.getByRole('row').filter({ hasText: /Endelig beregnet trygdeavgift/ })
+    ).toContainText(`${forventet.endeligBeregnet} kr`);
+    await expect(
+      tabell.getByRole('row').filter({ hasText: /Innbetalt trygdeavgift/ })
+    ).toContainText(`${forventet.innbetalt} kr`);
+    await expect(
+      tabell.getByRole('row').filter({ hasText: /Differanse/ })
+    ).toContainText(forventet.differanse);
+
+    console.log(
+      `✅ Sum-tabell: endelig ${forventet.endeligBeregnet} / innbetalt ${forventet.innbetalt} / differanse ${forventet.differanse}`
+    );
+  }
 }

--- a/pages/behandling/aarsavregning.page.ts
+++ b/pages/behandling/aarsavregning.page.ts
@@ -65,6 +65,22 @@ export class AarsavregningPage extends BasePage {
     name: 'Innbetalt trygdeavgift'
   });
 
+  /**
+   * Radiogruppe «Beregn endelig trygdeavgift» / «Oppgi endelig beregnet
+   * trygdeavgift» (endeligAvgiftValgRadioGroup.tsx). Vises i uten/delt-grunnlag-
+   * flyten (toggle `melosys.arsavregning.eos_pensjonist`). «Beregn»
+   * (OPPLYSNINGER_ENDRET) er forhåndsvalgt.
+   */
+  private readonly endeligAvgiftValgGroup = this.page.locator('.endeligAvgiftValg_radio_group');
+
+  /**
+   * Manuelt avgiftsbeløp-felt (manuellAvgiftFormPart.tsx, name=manueltAvgiftBeloep).
+   * Vises kun når «Oppgi endelig beregnet trygdeavgift» er valgt.
+   */
+  private readonly endeligBeregnetTrygdeavgiftField = this.page.getByRole('textbox', {
+    name: 'Endelig beregnet trygdeavgift'
+  });
+
   private readonly bekreftButton = this.page.getByRole('button', { name: 'Bekreft og fortsett' });
 
   private readonly fattVedtakButton = this.page.getByRole('button', { name: 'Fatt vedtak' });
@@ -218,6 +234,77 @@ export class AarsavregningPage extends BasePage {
     }
 
     console.log(`✅ Fylte inn innbetalt trygdeavgift: ${beløp}`);
+  }
+
+  /**
+   * Velg «Oppgi endelig beregnet trygdeavgift» (MANUELL_ENDELIG_AVGIFT) i
+   * uten/delt-grunnlag-flyten.
+   *
+   * Byttet trigger DELETE av AVGIFT_SYSTEMET-perioder og en
+   * PUT …/aarsavregninger/{id}/endeligAvgift/MANUELL_ENDELIG_AVGIFT — vi venter
+   * på PUT-en før vi går videre, ellers kan påfølgende lagringer race. Etterpå
+   * forsvinner perioder/skatt/inntekt-seksjonene og det manuelle feltet
+   * «Endelig beregnet trygdeavgift» vises (eneste påkrevde felt).
+   */
+  async velgOppgiEndeligTrygdeavgift(): Promise<void> {
+    await this.endeligAvgiftValgGroup.waitFor({ state: 'visible', timeout: TIMEOUT_LONG });
+    const radioInput = this.endeligAvgiftValgGroup.locator(
+      'input[value="MANUELL_ENDELIG_AVGIFT"]'
+    );
+
+    const valgLagret = this.page.waitForResponse(
+      response =>
+        response.url().includes('/endeligAvgift/MANUELL_ENDELIG_AVGIFT') &&
+        response.request().method() === 'PUT' &&
+        response.status() === 200,
+      { timeout: TIMEOUT_API }
+    );
+
+    await radioInput.waitFor({ state: 'attached', timeout: TIMEOUT_MEDIUM });
+    await radioInput.click({ force: true });
+    await expect(radioInput).toBeChecked({ timeout: TIMEOUT_MEDIUM });
+    await valgLagret;
+    console.log('✅ Valgte «Oppgi endelig beregnet trygdeavgift» (MANUELL_ENDELIG_AVGIFT lagret)');
+
+    await this.endeligBeregnetTrygdeavgiftField.waitFor({
+      state: 'visible',
+      timeout: TIMEOUT_MEDIUM
+    });
+  }
+
+  /**
+   * Fyll det manuelle feltet «Endelig beregnet trygdeavgift»
+   * (Oppgi-varianten / MANUELL_ENDELIG_AVGIFT).
+   *
+   * Lagres via debounced PUT /api/behandlinger/{id}/aarsavregninger/{id} —
+   * vi venter på den slik at beløpet garantert er persistert før neste steg.
+   *
+   * @param beløp - Manuelt endelig avgiftsbeløp (f.eks. '250')
+   */
+  async fyllInnEndeligBeregnetTrygdeavgift(beløp: string): Promise<void> {
+    await this.endeligBeregnetTrygdeavgiftField.waitFor({
+      state: 'visible',
+      timeout: TIMEOUT_MEDIUM
+    });
+
+    const lagret = this.page.waitForResponse(
+      response =>
+        /\/api\/behandlinger\/\d+\/aarsavregninger\/\d+$/.test(
+          new URL(response.url()).pathname
+        ) &&
+        response.request().method() === 'PUT' &&
+        response.status() === 200,
+      { timeout: TIMEOUT_API }
+    );
+
+    await this.endeligBeregnetTrygdeavgiftField.fill(beløp);
+    await this.endeligBeregnetTrygdeavgiftField.press('Tab');
+    await expect(this.endeligBeregnetTrygdeavgiftField).toHaveValue(beløp, {
+      timeout: TIMEOUT_MEDIUM
+    });
+
+    await lagret;
+    console.log(`✅ Fylte inn endelig beregnet trygdeavgift (manuelt): ${beløp}`);
   }
 
   /**

--- a/pages/behandling/eu-eos-pensjonist-behandling.page.ts
+++ b/pages/behandling/eu-eos-pensjonist-behandling.page.ts
@@ -86,6 +86,25 @@ export class EuEosPensjonistBehandlingPage extends BasePage {
     });
   }
 
+  /**
+   * Gå videre fra periode-steget når Trygdeavgift-steget er TOMT.
+   *
+   * Når hele perioden ligger i et tidligere år (og default-togglene står, dvs.
+   * `melosys.faktureringskomponenten.ikke-tidligere-perioder` er PÅ) viser
+   * Trygdeavgift-steget kun varselet «Trygdeavgift for tidligere år skal
+   * fastsettes på årsavregning…» — ingen skattepliktig/inntekt-felter. Da kan
+   * vi ikke vente på skattepliktig-gruppen slik klikkBekreftOgFortsett gjør;
+   * vi venter på varselet i stedet.
+   */
+  async klikkBekreftOgFortsettTilTomtTrygdeavgiftSteg(): Promise<void> {
+    await this.clickStepButtonWithRetry(this.bekreftOgFortsettButton, {
+      waitForContent: this.page
+        .getByText(/tidligere år skal fastsettes på årsavregning/i)
+        .first(),
+      verifyHeadingChange: true,
+    });
+  }
+
   async klikkBekreftOgSend(): Promise<void> {
     await this.bekreftOgSendButton.waitFor({ state: 'visible', timeout: TIMEOUT_LONG });
     await expect(this.bekreftOgSendButton).toBeEnabled({ timeout: TIMEOUT_LONG });

--- a/tests/eu-eos/eu-eos-pensjonist-aarsavregning-uten-grunnlag.spec.ts
+++ b/tests/eu-eos/eu-eos-pensjonist-aarsavregning-uten-grunnlag.spec.ts
@@ -1,0 +1,293 @@
+import { expect, test } from '../../fixtures';
+import { AuthHelper } from '../../helpers/auth-helper';
+import { waitForProcessInstances } from '../../helpers/api-helper';
+import { withDatabase } from '../../helpers/db-helper';
+import { setupPensjonistUtenGrunnlagMedAutoAarsavregning } from './pensjonist-aarsavregning-setup';
+
+/**
+ * EU/EØS Trygdeavgift - Pensjonist årsavregning UTEN tidligere grunnlag
+ * (MELOSYS-7954/7271, gap: eos-pensjonist-uten-grunnlag-aarsavregning)
+ *
+ * Når førstegangsbehandlingens periode i sin helhet ligger i et tidligere år
+ * og default-togglene står (ikke-tidligere-perioder PÅ), lagres det IKKE noe
+ * trygdeavgiftsgrunnlag — og årsavregningen auto-opprettes ved «Bekreft og
+ * send» (prosess OPPRETT_NY_BEHANDLING_AARSAVREGNING). Årsavregningen åpner da
+ * i «uten grunnlag»-flyten (toggle `melosys.arsavregning.eos_pensjonist`, PÅ
+ * by default): «Avviker innbetalt»-radioen er skjult, «Innbetalt trygdeavgift»
+ * er et påkrevd felt, og saksbehandler velger mellom:
+ *  - «Beregn endelig trygdeavgift» (OPPLYSNINGER_ENDRET, forhåndsvalgt)
+ *  - «Oppgi endelig beregnet trygdeavgift» (MANUELL_ENDELIG_AVGIFT)
+ *
+ * Testverdiene er bevisst valgt slik at |differansen| < minstegrensen (100 kr)
+ * → ingen fakturering/refusjon-sideeffekter, og UI-teksten om minstegrensen
+ * kan asserteres deterministisk.
+ *
+ * NB: ingen UnleashHelper-kall her — hele poenget er DEFAULT toggle-state
+ * (i motsetning til de to eksisterende pensjonist-årsavregningstestene).
+ */
+
+const TESTDATA = {
+  år: '2024',
+  innbetalt: '300',
+  bruttoinntekt: '23313',
+  inntektskilde: 'PENSJON',
+  manueltBeløp: '250',
+} as const;
+
+// Differanse-beløpene bruker U+2212 MINUS SIGN (−) slik UI-et formaterer dem.
+const DIFFERANSE_BEREGN = '−98,04';
+const DIFFERANSE_OPPGI = '−50,00';
+
+/**
+ * Felles DB-fasit for begge variantene: behandling/resultat/prosesser +
+ * AARSAVREGNING-raden (kolonneverdier verifisert live i discovery 2026-06-11).
+ */
+async function verifiserAarsavregningIDatabase(
+  behandlingId: string,
+  forventet: {
+    endeligAvgiftValg: 'OPPLYSNINGER_ENDRET' | 'MANUELL_ENDELIG_AVGIFT';
+    beregnetAvgiftBelop: number | null;
+    manueltAvgiftBeloep: number | null;
+    tilFaktureringBeloep: number;
+  }
+): Promise<void> {
+  await withDatabase(async (db) => {
+    const behandling = await db.queryOne<{ STATUS: string; BEH_TYPE: string }>(
+      'SELECT STATUS, BEH_TYPE FROM BEHANDLING WHERE ID = :id',
+      { id: behandlingId }
+    );
+    expect(behandling, 'Forventet årsavregningsbehandling i DB').not.toBeNull();
+    expect(behandling!.BEH_TYPE, 'Behandlingen skal være ÅRSAVREGNING').toBe('ÅRSAVREGNING');
+    expect(behandling!.STATUS, 'Behandlingen skal være AVSLUTTET').toBe('AVSLUTTET');
+    console.log('✅ Behandling: ÅRSAVREGNING / AVSLUTTET');
+
+    const resultat = await db.queryOne<{ RESULTAT_TYPE: string }>(
+      'SELECT RESULTAT_TYPE FROM BEHANDLINGSRESULTAT WHERE BEHANDLING_ID = :id',
+      { id: behandlingId }
+    );
+    expect(resultat, 'Forventet behandlingsresultat i DB').not.toBeNull();
+    expect(resultat!.RESULTAT_TYPE, 'Resultat skal være FASTSATT_TRYGDEAVGIFT').toBe(
+      'FASTSATT_TRYGDEAVGIFT'
+    );
+    console.log('✅ Behandlingsresultat: FASTSATT_TRYGDEAVGIFT');
+
+    const aarsavregning = await db.queryOne<{
+      AAR: number;
+      BEREGNET_AVGIFT_BELOP: number | null;
+      MANUELT_AVGIFT_BELOEP: number | null;
+      TIL_FAKTURERING_BELOEP: number;
+      ENDELIG_AVGIFT_VALG: string;
+      HAR_INNBETALT_TRYGDEAVGIFT: number;
+      INNBETALT_TRYGDEAVGIFT: number;
+    }>(
+      // BEHANDLINGSRESULTAT har behandling_id som PK (pk_resultat), så
+      // AARSAVREGNING.BEHANDLINGSRESULTAT_ID er behandlingens ID direkte.
+      `SELECT AAR,
+              BEREGNET_AVGIFT_BELOP,
+              MANUELT_AVGIFT_BELOEP,
+              TIL_FAKTURERING_BELOEP,
+              ENDELIG_AVGIFT_VALG,
+              HAR_INNBETALT_TRYGDEAVGIFT,
+              INNBETALT_TRYGDEAVGIFT
+         FROM AARSAVREGNING
+        WHERE BEHANDLINGSRESULTAT_ID = :id`,
+      { id: behandlingId }
+    );
+    expect(aarsavregning, 'Forventet AARSAVREGNING-rad i DB').not.toBeNull();
+    expect(Number(aarsavregning!.AAR), 'Årsavregningen skal gjelde 2024').toBe(2024);
+    expect(
+      aarsavregning!.ENDELIG_AVGIFT_VALG,
+      `Endelig avgift-valg skal være ${forventet.endeligAvgiftValg}`
+    ).toBe(forventet.endeligAvgiftValg);
+    expect(
+      Number(aarsavregning!.HAR_INNBETALT_TRYGDEAVGIFT),
+      'HAR_INNBETALT_TRYGDEAVGIFT skal være satt (auto-true i uten-grunnlag-flyten)'
+    ).toBe(1);
+    expect(
+      Number(aarsavregning!.INNBETALT_TRYGDEAVGIFT),
+      'Innbetalt trygdeavgift skal være 300'
+    ).toBe(300);
+
+    if (forventet.beregnetAvgiftBelop === null) {
+      expect(
+        aarsavregning!.BEREGNET_AVGIFT_BELOP,
+        'BEREGNET_AVGIFT_BELOP skal være null (manuelt oppgitt avgift)'
+      ).toBeNull();
+    } else {
+      expect(
+        Number(aarsavregning!.BEREGNET_AVGIFT_BELOP),
+        `BEREGNET_AVGIFT_BELOP skal være ${forventet.beregnetAvgiftBelop}`
+      ).toBeCloseTo(forventet.beregnetAvgiftBelop, 2);
+    }
+    if (forventet.manueltAvgiftBeloep === null) {
+      expect(
+        aarsavregning!.MANUELT_AVGIFT_BELOEP,
+        'MANUELT_AVGIFT_BELOEP skal være null (beregnet avgift)'
+      ).toBeNull();
+    } else {
+      expect(
+        Number(aarsavregning!.MANUELT_AVGIFT_BELOEP),
+        `MANUELT_AVGIFT_BELOEP skal være ${forventet.manueltAvgiftBeloep}`
+      ).toBeCloseTo(forventet.manueltAvgiftBeloep, 2);
+    }
+    expect(
+      Number(aarsavregning!.TIL_FAKTURERING_BELOEP),
+      `TIL_FAKTURERING_BELOEP skal være ${forventet.tilFaktureringBeloep}`
+    ).toBeCloseTo(forventet.tilFaktureringBeloep, 2);
+    console.log(
+      `✅ AARSAVREGNING-rad: ${aarsavregning!.ENDELIG_AVGIFT_VALG}, til fakturering ${aarsavregning!.TIL_FAKTURERING_BELOEP}`
+    );
+
+    const prosesser = await db.query<{ PROSESS_TYPE: string; STATUS: string }>(
+      'SELECT PROSESS_TYPE, STATUS FROM PROSESSINSTANS WHERE BEHANDLING_ID = :id',
+      { id: behandlingId }
+    );
+    expect(prosesser.length, 'Forventet prosessinstanser for årsavregningen').toBeGreaterThan(0);
+    for (const p of prosesser) {
+      expect(p.STATUS, `Prosess ${p.PROSESS_TYPE} skal være FERDIG`).toBe('FERDIG');
+    }
+    for (const type of [
+      'OPPRETT_NY_BEHANDLING_AARSAVREGNING',
+      'IVERKSETT_VEDTAK_AARSAVREGNING',
+      'OPPRETT_OG_DISTRIBUER_BREV',
+    ]) {
+      expect(
+        prosesser.some(p => p.PROSESS_TYPE === type),
+        `Forventet prosessinstans ${type} på årsavregningsbehandlingen`
+      ).toBe(true);
+    }
+    console.log(`✅ ${prosesser.length} prosessinstanser FERDIG på årsavregningen`);
+
+    const feilede = await db.query<{ PROSESS_TYPE: string }>(
+      "SELECT PROSESS_TYPE FROM PROSESSINSTANS WHERE STATUS = 'FEILET'",
+      {}
+    );
+    expect(
+      feilede.map(p => p.PROSESS_TYPE),
+      'Ingen prosessinstanser skal være FEILET'
+    ).toEqual([]);
+  });
+}
+
+test.describe('EU/EØS Trygdeavgift - Pensjonist årsavregning uten grunnlag', () => {
+  test('skal beregne endelig trygdeavgift i uten-grunnlag-flyten (OPPLYSNINGER_ENDRET)', async ({ page }) => {
+    test.setTimeout(240000);
+
+    const auth = new AuthHelper(page);
+    await auth.login();
+
+    const { aarsavregning, vedtak, behandlingId } =
+      await setupPensjonistUtenGrunnlagMedAutoAarsavregning(page);
+
+    await aarsavregning.ventPåSideLastet();
+    // Auto-opprettet årsavregning kjenner året fra førstegangen — IKKE velg år.
+    await aarsavregning.assertions.verifiserValgtÅr(TESTDATA.år);
+    await aarsavregning.assertions.verifiserUtenGrunnlagFlyt();
+
+    // svarNei er adaptiv: i uten-grunnlag-flyten er avvik-radioen skjult, så
+    // kallet fungerer som synkronisering på at skjemaet er ferdig rendret.
+    await aarsavregning.svarNei();
+    await aarsavregning.fyllInnInnbetaltTrygdeavgift(TESTDATA.innbetalt);
+
+    // «Beregn endelig trygdeavgift» (OPPLYSNINGER_ENDRET) er forhåndsvalgt.
+    // Helseutgift-perioden (01.04–05.04.2024, Belgia) er låst/forhåndsutfylt.
+    await aarsavregning.velgSkattepliktig(false);
+    await aarsavregning.velgInntektskilde(TESTDATA.inntektskilde);
+    await aarsavregning.fyllInnBruttoinntektMedApiVent(TESTDATA.bruttoinntekt);
+
+    // Deterministisk fasit: 23 313 kr/md i 01.04–05.04.2024 → 201,96 kr avgift,
+    // minus 300 kr innbetalt → differanse −98,04 kr (U+2212-minus i UI).
+    await aarsavregning.assertions.verifiserSumTabell({
+      endeligBeregnet: '201,96',
+      innbetalt: '300,00',
+      differanse: DIFFERANSE_BEREGN,
+    });
+
+    await aarsavregning.klikkBekreftPåResultatside();
+    await vedtak.assertions.verifiserFattVedtakKnapp();
+
+    // |−98,04| < 100 kr → ingen fakturering/refusjon, kun minstegrense-info.
+    await expect(
+      page.getByText('Beløpet er under minstegrensen for fakturering/refusjon (100 kr).')
+    ).toBeVisible();
+
+    await vedtak.klikkFattVedtak();
+
+    console.log('📝 Venter på iverksetting av årsavregningsvedtaket...');
+    await waitForProcessInstances(page.request, 60);
+
+    await verifiserAarsavregningIDatabase(behandlingId, {
+      endeligAvgiftValg: 'OPPLYSNINGER_ENDRET',
+      beregnetAvgiftBelop: 201.96,
+      manueltAvgiftBeloep: null,
+      tilFaktureringBeloep: -98.04,
+    });
+
+    console.log('✅ Uten-grunnlag-årsavregning (Beregn) fullført og verifisert i DB');
+  });
+
+  test('skal oppgi endelig trygdeavgift manuelt med obligatorisk begrunnelse (MANUELL_ENDELIG_AVGIFT)', async ({ page }) => {
+    test.setTimeout(240000);
+
+    const auth = new AuthHelper(page);
+    await auth.login();
+
+    const { aarsavregning, vedtak, behandlingId } =
+      await setupPensjonistUtenGrunnlagMedAutoAarsavregning(page);
+
+    await aarsavregning.ventPåSideLastet();
+    await aarsavregning.assertions.verifiserValgtÅr(TESTDATA.år);
+    await aarsavregning.assertions.verifiserUtenGrunnlagFlyt();
+
+    await aarsavregning.svarNei();
+    await aarsavregning.fyllInnInnbetaltTrygdeavgift(TESTDATA.innbetalt);
+
+    // Bytt til manuell endelig avgift: perioder/skatt/inntekt-seksjonene
+    // forsvinner og kun «Endelig beregnet trygdeavgift»-feltet gjenstår.
+    await aarsavregning.velgOppgiEndeligTrygdeavgift();
+    await aarsavregning.fyllInnEndeligBeregnetTrygdeavgift(TESTDATA.manueltBeløp);
+
+    // 250 manuelt − 300 innbetalt → differanse −50,00 kr.
+    await aarsavregning.assertions.verifiserSumTabell({
+      endeligBeregnet: '250,00',
+      innbetalt: '300,00',
+      differanse: DIFFERANSE_OPPGI,
+    });
+
+    await aarsavregning.klikkBekreftPåResultatside();
+    await vedtak.assertions.verifiserFattVedtakKnapp();
+
+    // MANUELL_ENDELIG_AVGIFT krever begrunnelse: uten fritekst er «Fatt vedtak»
+    // en no-op (submit stoppes av validering). Verifiser at kravet vises...
+    await expect(
+      page.getByText('Følgende punkter må begrunnes i fritekstfeltet')
+    ).toBeVisible();
+    await expect(
+      page.getByText('hvorfor du har lagt inn «Endelig beregnet trygdeavgift» manuelt')
+    ).toBeVisible();
+    await expect(
+      page.getByText('Beløpet er under minstegrensen for fakturering/refusjon (100 kr).')
+    ).toBeVisible();
+
+    // ...fyll innledning + obligatorisk begrunnelse, og fatt vedtak.
+    // klikkFattVedtak venter på POST /api/saksflyt/vedtak/{id}/fatt — uten den
+    // ville en stille no-op (manglende begrunnelse) passert grønt.
+    await vedtak.fyllInnFritekst('E2E: årsavregning uten grunnlag, manuelt endelig avgiftsbeløp.');
+    await vedtak.fyllInnBegrunnelse(
+      'E2E: Endelig trygdeavgift er lagt inn manuelt (250 kr) for å verifisere MANUELL_ENDELIG_AVGIFT-flyten.'
+    );
+    await vedtak.klikkFattVedtak();
+
+    console.log('📝 Venter på iverksetting av årsavregningsvedtaket...');
+    await waitForProcessInstances(page.request, 60);
+
+    await verifiserAarsavregningIDatabase(behandlingId, {
+      endeligAvgiftValg: 'MANUELL_ENDELIG_AVGIFT',
+      beregnetAvgiftBelop: null,
+      manueltAvgiftBeloep: 250,
+      tilFaktureringBeloep: -50,
+    });
+
+    console.log('✅ Uten-grunnlag-årsavregning (Oppgi) fullført og verifisert i DB');
+  });
+});

--- a/tests/eu-eos/pensjonist-aarsavregning-setup.ts
+++ b/tests/eu-eos/pensjonist-aarsavregning-setup.ts
@@ -44,16 +44,15 @@ function hentSaksnummerFraUrl(url: string): string {
   return decodeURIComponent(saksnummer);
 }
 
-export async function setupPensjonistMedAarsavregning(
-  page: Page
-): Promise<{ aarsavregning: AarsavregningPage; vedtak: VedtakPage }> {
-  const hovedside = new HovedsidePage(page);
-  const opprettSak = new OpprettNySakPage(page);
-  const pensjonistBehandling = new EuEosPensjonistBehandlingPage(page);
-  const trygdeavgift = new TrygdeavgiftPage(page);
-  const aarsavregning = new AarsavregningPage(page);
-  const vedtak = new VedtakPage(page);
-
+/**
+ * Opprett en EØS-pensjonist førstegangsbehandling, åpne den fra hovedsiden og
+ * returner saksnummeret. Felles startblokk for begge setup-variantene under.
+ */
+async function opprettOgÅpnePensjonistSak(
+  page: Page,
+  hovedside: HovedsidePage,
+  opprettSak: OpprettNySakPage
+): Promise<string> {
   await hovedside.goto();
   await hovedside.klikkOpprettNySak();
   await opprettSak.fyllInnBrukerID(USER_ID_VALID);
@@ -69,7 +68,20 @@ export async function setupPensjonistMedAarsavregning(
   await waitForProcessInstances(page.request, 30);
   await hovedside.goto();
   await hovedside.åpneSak(BRUKERNAVN_VALID);
-  const saksnummer = hentSaksnummerFraUrl(page.url());
+  return hentSaksnummerFraUrl(page.url());
+}
+
+export async function setupPensjonistMedAarsavregning(
+  page: Page
+): Promise<{ aarsavregning: AarsavregningPage; vedtak: VedtakPage }> {
+  const hovedside = new HovedsidePage(page);
+  const opprettSak = new OpprettNySakPage(page);
+  const pensjonistBehandling = new EuEosPensjonistBehandlingPage(page);
+  const trygdeavgift = new TrygdeavgiftPage(page);
+  const aarsavregning = new AarsavregningPage(page);
+  const vedtak = new VedtakPage(page);
+
+  const saksnummer = await opprettOgÅpnePensjonistSak(page, hovedside, opprettSak);
   await pensjonistBehandling.fyllUtPeriodeOgBostedsland(
     PENSJONIST_AARSAVREGNING_TEST_DATA.periodeFra,
     PENSJONIST_AARSAVREGNING_TEST_DATA.periodeTil,
@@ -106,4 +118,58 @@ export async function setupPensjonistMedAarsavregning(
   await hovedside.åpneAarsavregningForSaksnummer(saksnummer);
 
   return { aarsavregning, vedtak };
+}
+
+/**
+ * Setup for «uten grunnlag»-varianten (MELOSYS-7954/7271):
+ * EØS-pensjonist førstegangsbehandling der HELE perioden ligger i et tidligere
+ * år (01.04–05.04.2024) og DEFAULT toggle-state beholdes (dvs.
+ * `melosys.faktureringskomponenten.ikke-tidligere-perioder` PÅ — i motsetning
+ * til setupPensjonistMedAarsavregning-testene som skrur den av).
+ *
+ * Da viser førstegangens Trygdeavgift-steg kun varselet «Trygdeavgift for
+ * tidligere år skal fastsettes på årsavregning…» (ingen felter), og det lagres
+ * IKKE noe trygdeavgiftsgrunnlag. Etter «Bekreft og send» auto-opprettes
+ * årsavregningsbehandlingen (prosess OPPRETT_NY_BEHANDLING_AARSAVREGNING) —
+ * ingen manuell opprett-årsavregning-runde, og året (2024) er forhåndsvalgt.
+ *
+ * @returns POM-er + behandlingID for den auto-opprettede årsavregningen (fra URL)
+ */
+export async function setupPensjonistUtenGrunnlagMedAutoAarsavregning(
+  page: Page
+): Promise<{ aarsavregning: AarsavregningPage; vedtak: VedtakPage; behandlingId: string }> {
+  const hovedside = new HovedsidePage(page);
+  const opprettSak = new OpprettNySakPage(page);
+  const pensjonistBehandling = new EuEosPensjonistBehandlingPage(page);
+  const trygdeavgift = new TrygdeavgiftPage(page);
+  const aarsavregning = new AarsavregningPage(page);
+  const vedtak = new VedtakPage(page);
+
+  const saksnummer = await opprettOgÅpnePensjonistSak(page, hovedside, opprettSak);
+  await pensjonistBehandling.fyllUtPeriodeOgBostedsland(
+    PENSJONIST_AARSAVREGNING_TEST_DATA.periodeFra,
+    PENSJONIST_AARSAVREGNING_TEST_DATA.periodeTil,
+    PENSJONIST_AARSAVREGNING_TEST_DATA.bostedsland
+  );
+  await pensjonistBehandling.klikkBekreftOgFortsettTilTomtTrygdeavgiftSteg();
+
+  // Tomt Trygdeavgift-steg (kun årsavregning-varselet) — gå rett videre.
+  await trygdeavgift.klikkBekreftOgFortsett();
+
+  await pensjonistBehandling.assertions.verifiserBekreftOgSendSynlig();
+  await pensjonistBehandling.klikkBekreftOgSend();
+
+  console.log('📝 Venter på prosessinstanser (inkl. auto-opprettet årsavregning)...');
+  await waitForProcessInstances(page.request, 60);
+  await hovedside.goto();
+  await hovedside.åpneAarsavregningForSaksnummer(saksnummer);
+
+  await page.waitForURL(/behandlingID=\d+/, { timeout: 15000 });
+  const behandlingId = new URL(page.url()).searchParams.get('behandlingID');
+  if (!behandlingId) {
+    throw new Error(`Fant ikke behandlingID i årsavregnings-URL-en: ${page.url()}`);
+  }
+  console.log(`📌 Auto-opprettet årsavregning: behandlingID=${behandlingId} (sak ${saksnummer})`);
+
+  return { aarsavregning, vedtak, behandlingId };
 }


### PR DESCRIPTION
## Hva

Lukker uten-grunnlag-gapet (MELOSYS-7954/7271) i årsavregnings-dekningen: når en EØS-pensjonist-sak ikke har tidligere trygdeavgiftsgrunnlag skjules «avviker innbetalt»-radioen og et nytt påkrevd «Innbetalt trygdeavgift»-felt + «Beregn/Oppgi endelig trygdeavgift»-radiogruppe vises. Denne flyten brøt to eksisterende tester da den ble innført (mai 2026) — nå får den egen dekning.

To tester med delt setup:

- **Beregn (OPPLYSNINGER_ENDRET)**: innbetalt 300, månedsinntekt 23 313 → endelig 201,96 / differanse −98,04 → DB: `BEREGNET_AVGIFT_BELOP=201.96`, `TIL_FAKTURERING_BELOEP=-98.04`
- **Oppgi (MANUELL_ENDELIG_AVGIFT)**: manuelt beløp 250 → differanse −50,00 → vedtakssteget krever **obligatorisk begrunnelse-fritekst** (Fatt vedtak er no-op uten; testen venter på `/fatt`-POST) → DB: `MANUELT_AVGIFT_BELOEP=250`, `TIL_FAKTURERING_BELOEP=-50`

Begge: behandling ÅRSAVREGNING `AVSLUTTET`, resultat `FASTSATT_TRYGDEAVGIFT`, prosessinstanser FERDIG (ingen FEILET). Beløpene er under minstegrensen (100 kr) → ingen fakturering-sideeffekter.

## Discovery-funn

- **Setup-forenkling**: førstegang med tidligere-års-periode (01.04–05.04.2024, BE) + default toggles gir et TOMT trygdeavgift-steg og **auto-opprettet** årsavregning (`OPPRETT_NY_BEHANDLING_AARSAVREGNING`) med året forhåndsvalgt.
- **Toggle-avklaring**: `melosys.arsavregning.eos_pensjonist` (PÅ default) styrer uten-grunnlag-UI-en; `melosys.arsavregning.uten.flyt` (AV default) er en blocker-alert og må forbli AV. Testene bruker ren default-state — ingen UnleashHelper-kall, og de skrur IKKE av `ikke-tidligere-perioder`-togglen slik de to eksisterende pensjonist-testene gjør.

## Refaktorering

`pensjonist-aarsavregning-setup.ts`: felles `opprettOgÅpnePensjonistSak` ekstrahert (begge eksisterende pensjonist-specs kjørt grønne som regresjon). Ingen mock-endring.

Lokalt: ny spec 2/2 grønn + begge eksisterende pensjonist-specs grønne + `npm run check:tests` OK.