### PR TITLE
NOJIRA E2E-tester for trygdeavtale unntaksregistrering

### DIFF
--- a/pages/trygdeavtale/trygdeavtale-unntaksregistrering.assertions.ts
+++ b/pages/trygdeavtale/trygdeavtale-unntaksregistrering.assertions.ts
@@ -1,0 +1,217 @@
+import { APIRequestContext, Page, expect } from '@playwright/test';
+import { DatabaseHelper, withDatabase } from '../../helpers/db-helper';
+import { fetchMedlPeriode } from '../../helpers/mock-helper';
+
+/**
+ * Assertion methods for TrygdeavtaleUnntaksregistreringPage
+ *
+ * Verifiserer DB-utfallet av unntaksregistrering på en trygdeavtale-sak
+ * (prosess REGISTRERE_UNNTAK_FRA_MEDLEMSKAP: LAGRE_LOVVALGSPERIODE_MEDL →
+ * AVSLUTT_SAK_OG_BEHANDLING) + MEDL-perioden i mock-registeret.
+ *
+ * Databasen renses før hver test (cleanup-fixture), så testens sak/behandling
+ * er de eneste radene — ingen tidsfilter trengs.
+ */
+export class TrygdeavtaleUnntaksregistreringAssertions {
+  constructor(readonly page: Page) {}
+
+  /**
+   * Verifiser hele DB-utfallet av et GODKJENT registrert unntak:
+   *  - behandlingen er AVSLUTTET, fagsaken LOVVALG_AVKLART (TRYGDEAVTALE/UNNTAK)
+   *  - behandlingsresultat REGISTRERT_UNNTAK / GODKJENT / fastsatt av forventet land
+   *  - prosessinstansen REGISTRERE_UNNTAK_FRA_MEDLEMSKAP er FERDIG med
+   *    SIST_FULLFORT_STEG=AVSLUTT_SAK_OG_BEHANDLING, og ingen prosesser FEILET
+   *  - lovvalgsperioden er INNVILGET/UNNTATT/UTEN_DEKNING med riktig
+   *    bestemmelse og MEDLPERIODE_ID satt (= overført til MEDL)
+   *
+   * @returns medlperiode_id for MEDL-mock-oppslag
+   */
+  async verifiserGodkjentUnntakIDatabase(forventet: {
+    fom: string; // DD.MM.YYYY
+    tom: string; // DD.MM.YYYY
+    land: string; // f.eks. 'AU'
+    bestemmelse: string; // f.eks. 'AUS_ART9_3'
+  }): Promise<number> {
+    return await withDatabase(async (db) => {
+      await this.verifiserBehandlingOgProsess(db);
+
+      const fagsak = await db.queryOne<{
+        STATUS: string;
+        FAGSAK_TYPE: string;
+        TEMA: string;
+      }>(`SELECT STATUS, FAGSAK_TYPE, TEMA FROM FAGSAK`);
+      expect(fagsak, 'Forventet en fagsak').not.toBeNull();
+      expect(fagsak!.FAGSAK_TYPE).toBe('TRYGDEAVTALE');
+      expect(fagsak!.TEMA).toBe('UNNTAK');
+      expect(fagsak!.STATUS, 'Fagsaken skal være LOVVALG_AVKLART etter godkjent unntak').toBe(
+        'LOVVALG_AVKLART'
+      );
+      console.log('✅ Fagsak: TRYGDEAVTALE/UNNTAK → LOVVALG_AVKLART');
+
+      const resultat = await db.queryOne<{
+        RESULTAT_TYPE: string;
+        UTFALL_REGISTRERING_UNNTAK: string;
+        FASTSATT_AV_LAND: string;
+      }>(
+        `SELECT RESULTAT_TYPE, UTFALL_REGISTRERING_UNNTAK, FASTSATT_AV_LAND
+         FROM BEHANDLINGSRESULTAT`
+      );
+      expect(resultat, 'Forventet et behandlingsresultat').not.toBeNull();
+      expect(resultat!.RESULTAT_TYPE).toBe('REGISTRERT_UNNTAK');
+      expect(resultat!.UTFALL_REGISTRERING_UNNTAK).toBe('GODKJENT');
+      expect(resultat!.FASTSATT_AV_LAND).toBe(forventet.land);
+      console.log(
+        `✅ Behandlingsresultat: REGISTRERT_UNNTAK/GODKJENT (fastsatt av ${resultat!.FASTSATT_AV_LAND})`
+      );
+
+      const perioder = await db.query<{
+        FOM: string;
+        TOM: string;
+        LOVVALGSLAND: string;
+        LOVVALG_BESTEMMELSE: string;
+        INNVILGELSE_RESULTAT: string;
+        MEDLEMSKAPSTYPE: string;
+        TRYGDE_DEKNING: string;
+        MEDLPERIODE_ID: number | null;
+      }>(
+        `SELECT TO_CHAR(FOM_DATO, 'DD.MM.YYYY') AS FOM,
+                TO_CHAR(TOM_DATO, 'DD.MM.YYYY') AS TOM,
+                LOVVALGSLAND, LOVVALG_BESTEMMELSE, INNVILGELSE_RESULTAT,
+                MEDLEMSKAPSTYPE, TRYGDE_DEKNING, MEDLPERIODE_ID
+         FROM LOVVALG_PERIODE`
+      );
+      expect(perioder, 'Forventet nøyaktig én lovvalgsperiode').toHaveLength(1);
+      const periode = perioder[0];
+      expect(periode.FOM).toBe(forventet.fom);
+      expect(periode.TOM).toBe(forventet.tom);
+      expect(periode.LOVVALGSLAND).toBe(forventet.land);
+      expect(periode.LOVVALG_BESTEMMELSE).toBe(forventet.bestemmelse);
+      expect(periode.INNVILGELSE_RESULTAT).toBe('INNVILGET');
+      expect(periode.MEDLEMSKAPSTYPE, 'Registrert unntak skal gi UNNTATT medlemskap').toBe(
+        'UNNTATT'
+      );
+      expect(periode.TRYGDE_DEKNING).toBe('UTEN_DEKNING');
+      expect(
+        periode.MEDLPERIODE_ID,
+        'Lovvalgsperioden skal være overført til MEDL (medlperiode_id satt)'
+      ).toBeGreaterThan(0);
+      console.log(
+        `✅ Lovvalgsperiode ${periode.FOM} – ${periode.TOM}: ${periode.LOVVALG_BESTEMMELSE}, ` +
+          `UNNTATT/UTEN_DEKNING (medlperiode_id=${periode.MEDLPERIODE_ID})`
+      );
+
+      return periode.MEDLPERIODE_ID as number;
+    });
+  }
+
+  /**
+   * Verifiser hele DB-utfallet av et IKKE_GODKJENT unntak:
+   *  - behandlingen er AVSLUTTET, fagsaken AVSLUTTET
+   *  - behandlingsresultat FERDIGBEHANDLET / IKKE_GODKJENT
+   *  - prosessinstansen REGISTRERE_UNNTAK_FRA_MEDLEMSKAP er FERDIG
+   *  - INGEN lovvalgsperiode er opprettet (og dermed ingen MEDL-periode)
+   */
+  async verifiserIkkeGodkjentUnntakIDatabase(forventet: { land: string }): Promise<void> {
+    await withDatabase(async (db) => {
+      await this.verifiserBehandlingOgProsess(db);
+
+      const fagsak = await db.queryOne<{ STATUS: string; FAGSAK_TYPE: string; TEMA: string }>(
+        `SELECT STATUS, FAGSAK_TYPE, TEMA FROM FAGSAK`
+      );
+      expect(fagsak, 'Forventet en fagsak').not.toBeNull();
+      expect(fagsak!.FAGSAK_TYPE).toBe('TRYGDEAVTALE');
+      expect(fagsak!.TEMA).toBe('UNNTAK');
+      expect(fagsak!.STATUS, 'Fagsaken skal være AVSLUTTET etter ikke-godkjent unntak').toBe(
+        'AVSLUTTET'
+      );
+      console.log('✅ Fagsak: TRYGDEAVTALE/UNNTAK → AVSLUTTET');
+
+      const resultat = await db.queryOne<{
+        RESULTAT_TYPE: string;
+        UTFALL_REGISTRERING_UNNTAK: string;
+        FASTSATT_AV_LAND: string;
+      }>(
+        `SELECT RESULTAT_TYPE, UTFALL_REGISTRERING_UNNTAK, FASTSATT_AV_LAND
+         FROM BEHANDLINGSRESULTAT`
+      );
+      expect(resultat, 'Forventet et behandlingsresultat').not.toBeNull();
+      expect(resultat!.RESULTAT_TYPE).toBe('FERDIGBEHANDLET');
+      expect(resultat!.UTFALL_REGISTRERING_UNNTAK).toBe('IKKE_GODKJENT');
+      expect(resultat!.FASTSATT_AV_LAND).toBe(forventet.land);
+      console.log('✅ Behandlingsresultat: FERDIGBEHANDLET/IKKE_GODKJENT');
+
+      // Ikke godkjent → ingen lovvalgsperiode skal lagres (frontendens
+      // lovvalgsperiode-POST avvises med 400 av api-et)
+      const perioder = await db.query<{ ID: number }>(`SELECT ID FROM LOVVALG_PERIODE`);
+      expect(
+        perioder,
+        'Ikke-godkjent unntak skal IKKE gi noen lovvalgsperiode'
+      ).toHaveLength(0);
+      console.log('✅ Ingen lovvalgsperiode opprettet (som forventet ved IKKE_GODKJENT)');
+    });
+  }
+
+  /**
+   * Felles vakt: nøyaktig én behandling som er AVSLUTTET, prosessen
+   * REGISTRERE_UNNTAK_FRA_MEDLEMSKAP FERDIG med sist fullført steg
+   * AVSLUTT_SAK_OG_BEHANDLING, og ingen feilede prosessinstanser.
+   */
+  private async verifiserBehandlingOgProsess(db: DatabaseHelper): Promise<void> {
+    const behandlinger = await db.query<{ ID: number; STATUS: string }>(
+      `SELECT ID, STATUS FROM BEHANDLING`
+    );
+    expect(behandlinger, 'Forventet nøyaktig én behandling').toHaveLength(1);
+    expect(behandlinger[0].STATUS, 'Behandlingen skal være AVSLUTTET').toBe('AVSLUTTET');
+    console.log(`✅ Behandling ${behandlinger[0].ID} AVSLUTTET`);
+
+    const feilede = await db.query<{ PROSESS_TYPE: string }>(
+      `SELECT PROSESS_TYPE FROM PROSESSINSTANS WHERE STATUS = 'FEILET'`
+    );
+    expect(
+      feilede,
+      `Forventet ingen feilede prosessinstanser, fant: ${JSON.stringify(feilede)}`
+    ).toHaveLength(0);
+
+    const prosess = await db.queryOne<{ STATUS: string; SIST_FULLFORT_STEG: string }>(
+      `SELECT STATUS, SIST_FULLFORT_STEG
+       FROM PROSESSINSTANS
+       WHERE PROSESS_TYPE = 'REGISTRERE_UNNTAK_FRA_MEDLEMSKAP'`
+    );
+    expect(prosess, 'Forventet en REGISTRERE_UNNTAK_FRA_MEDLEMSKAP-prosessinstans').not.toBeNull();
+    expect(prosess!.STATUS).toBe('FERDIG');
+    expect(prosess!.SIST_FULLFORT_STEG).toBe('AVSLUTT_SAK_OG_BEHANDLING');
+    console.log(
+      '✅ REGISTRERE_UNNTAK_FRA_MEDLEMSKAP FERDIG (sist fullført steg: AVSLUTT_SAK_OG_BEHANDLING)'
+    );
+  }
+
+  /**
+   * Verifiser i MEDL-mocken at det godkjente unntaket er skrevet som en
+   * ENDELIG, gyldig periode. NB: registrering-unntak skriver GYLD/ENDL
+   * direkte — IKKE «under avklaring» (UAVK/FORL gjelder anmodnings-/
+   * utpekingsflytene).
+   *
+   * @param request       - Playwright APIRequestContext (for MEDL-mock-oppslag)
+   * @param medlPeriodeId - MEDL-periode-id (lovvalg_periode.medlperiode_id)
+   * @param forventet     - Forventet tilstand (datoer i ISO-format YYYY-MM-DD)
+   */
+  async verifiserMedlPeriodeEndelig(
+    request: APIRequestContext,
+    medlPeriodeId: number,
+    forventet: { lovvalgsland: string; grunnlag: string; fraOgMed: string; tilOgMed: string }
+  ): Promise<void> {
+    const periode = await fetchMedlPeriode(request, medlPeriodeId);
+    expect(periode.status, `MEDL-periode ${medlPeriodeId} skal være GYLD`).toBe('GYLD');
+    expect(periode.lovvalg, 'Registrert unntak skal gi ENDELIG lovvalgsbeslutning i MEDL').toBe(
+      'ENDL'
+    );
+    expect(periode.lovvalgsland).toBe(forventet.lovvalgsland);
+    expect(periode.grunnlag).toBe(forventet.grunnlag);
+    expect(periode.fraOgMed).toBe(forventet.fraOgMed);
+    expect(periode.tilOgMed).toBe(forventet.tilOgMed);
+    console.log(
+      `✅ MEDL-periode ${medlPeriodeId}: GYLD/ENDL, lovvalgsland=${periode.lovvalgsland}, ` +
+        `grunnlag=${periode.grunnlag}, ${periode.fraOgMed} – ${periode.tilOgMed}`
+    );
+  }
+}

--- a/pages/trygdeavtale/trygdeavtale-unntaksregistrering.page.ts
+++ b/pages/trygdeavtale/trygdeavtale-unntaksregistrering.page.ts
@@ -1,0 +1,203 @@
+import { Page, expect } from '@playwright/test';
+import { BasePage } from '../shared/base.page';
+import { TrygdeavtaleUnntaksregistreringAssertions } from './trygdeavtale-unntaksregistrering.assertions';
+
+/**
+ * Page Object for unntaksregistrering på trygdeavtale-saker
+ * (rute: /melosys/TRYGDEAVTALE/unntaksregistrering/{saksnr}/?behandlingID={id}).
+ *
+ * To-stegs skjema (EnkelStegvelger):
+ * 1. «Inngang» (heading «Oppgi opplysninger fra attesten»): periode fom/tom +
+ *    avsenderland. For TRYGDEAVTALE finnes kun ETT landfelt — avsenderlandet
+ *    lagres også som lovvalgsland (FASTSATT_AV_LAND).
+ * 2. «Unntak medlemskap»: radiogruppe «Vurder unntaksperiode»
+ *    (Godkjenn / Godkjenn, men endre periode / Ikke godkjenn). Ved Godkjenn
+ *    vises bestemmelse-dropdown (f.eks. AUS_ART9_3) med read-only dekning.
+ *
+ * Submit («Bekreft og avslutt») fyrer PUT resultat/utfallregistreringunntak →
+ * POST lovvalgsperioder → POST /saksflyt/unntaksregistrering (204, fyres 2x —
+ * idempotent frontend-quirk). Vi venter kun på saksflyt-POST-en.
+ *
+ * NB: Ved «Ikke godkjenn» POSTer frontend lovvalgsperioder uten bestemmelse —
+ * api svarer 400 + WARN, men flyten fullfører likevel (saksflyt 204). Vent
+ * derfor ALDRI på lovvalgsperioder-kallet.
+ *
+ * @example
+ * const unntak = new TrygdeavtaleUnntaksregistreringPage(page);
+ * await unntak.ventPåInngang();
+ * await unntak.fyllUtInngang('01.01.2024', '31.12.2025', 'AU');
+ * await unntak.bekreftInngangOgFortsett();
+ * await unntak.godkjennMedBestemmelse('AUS_ART9_3');
+ * await unntak.bekreftOgAvslutt();
+ */
+export class TrygdeavtaleUnntaksregistreringPage extends BasePage {
+  readonly assertions: TrygdeavtaleUnntaksregistreringAssertions;
+
+  // ── Steg 1: Inngang ──────────────────────────────────────────────────
+  private readonly inngangHeading = this.page.getByRole('heading', {
+    name: 'Oppgi opplysninger fra attesten',
+    level: 1
+  });
+
+  private readonly fraOgMedField = this.page.getByRole('textbox', {
+    name: /^Fra og med/
+  });
+
+  private readonly tilOgMedField = this.page.getByRole('textbox', {
+    name: /^Til og med/
+  });
+
+  private readonly avsenderlandDropdown = this.page.getByLabel(/Avsenderland/);
+
+  private readonly bekreftOgFortsettButton = this.page.getByRole('button', {
+    name: 'Bekreft og fortsett'
+  });
+
+  // ── Steg 2: Unntak medlemskap ────────────────────────────────────────
+  private readonly unntakMedlemskapHeading = this.page.getByRole('heading', {
+    name: 'Unntak medlemskap',
+    level: 1
+  });
+
+  // exact: true så vi ikke matcher «Godkjenn, men endre periode»
+  private readonly godkjennRadio = this.page.getByRole('radio', {
+    name: 'Godkjenn',
+    exact: true
+  });
+
+  private readonly ikkeGodkjennRadio = this.page.getByRole('radio', {
+    name: 'Ikke godkjenn'
+  });
+
+  private readonly bestemmelseDropdown = this.page.getByLabel(/Bestemmelse/);
+
+  private readonly bekreftOgAvsluttButton = this.page.getByRole('button', {
+    name: 'Bekreft og avslutt'
+  });
+
+  constructor(page: Page) {
+    super(page);
+    this.assertions = new TrygdeavtaleUnntaksregistreringAssertions(page);
+  }
+
+  /**
+   * Vent på at unntaksregistrering-siden er lastet (oppgavelenken på
+   * hovedsiden peker direkte hit for sakstema UNNTAK).
+   */
+  async ventPåInngang(): Promise<void> {
+    await expect(this.page).toHaveURL(/\/unntaksregistrering\//, { timeout: 30000 });
+    await this.inngangHeading.waitFor({ state: 'visible', timeout: 30000 });
+    console.log('✅ Unntaksregistrering-siden lastet (Inngang)');
+  }
+
+  /**
+   * Fyll ut Inngang-steget: periode + avsenderland.
+   *
+   * @param fraOgMed     - Startdato DD.MM.YYYY
+   * @param tilOgMed     - Sluttdato DD.MM.YYYY
+   * @param avsenderland - Landkode (default 'AU' — Australia; IKKE India, jf. MELOSYS-6938)
+   */
+  async fyllUtInngang(
+    fraOgMed: string,
+    tilOgMed: string,
+    avsenderland: string = 'AU'
+  ): Promise<void> {
+    await this.fraOgMedField.click();
+    await this.fraOgMedField.fill(fraOgMed);
+    console.log(`✅ Fylte "Fra og med": ${fraOgMed}`);
+
+    await this.tilOgMedField.click();
+    await this.tilOgMedField.fill(tilOgMed);
+    console.log(`✅ Fylte "Til og med": ${tilOgMed}`);
+
+    await this.avsenderlandDropdown.selectOption(avsenderland);
+    console.log(`✅ Valgte avsenderland: ${avsenderland}`);
+  }
+
+  /**
+   * Bekreft Inngang-steget og fortsett til «Unntak medlemskap».
+   *
+   * VIKTIG timing-rekkefølge: Inngang-feltene lagres KUN i lokal Redux —
+   * persistering skjer via menypanelets debouncede auto-save
+   * (POST /api/mottatteopplysninger/{id}, ~1,5 s etter siste feltendring).
+   * Første klikk på «Bekreft og fortsett» auto-kjører registeroppfrisk +
+   * full re-last av saksopplysninger (DialogboksOppfriskSak med
+   * `bekreftetFraStart` — det finnes ALDRI noen «Avbryt oppdatering»-knapp,
+   * kun spinner/suksess) og går så automatisk videre til steg 2.
+   * Klikker vi før auto-saven har persistert, nullstiller re-lasten nettopp
+   * inntastet periode/avsenderland (→ «Godkjenn» disabled, Land «Ukjent»,
+   * FASTSATT_AV_LAND=null). Derfor: vent på auto-save-POST-en FØR klikket —
+   * da returnerer re-lasten de persisterte verdiene.
+   */
+  async bekreftInngangOgFortsett(): Promise<void> {
+    console.log('⏳ Venter på auto-save av mottatte opplysninger (debounced ~1,5s)...');
+    const autoSaveResponse = await this.page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/mottatteopplysninger/') &&
+        response.request().method() === 'POST' &&
+        response.ok(),
+      { timeout: 30000 }
+    );
+    console.log(`✅ Mottatte opplysninger persistert: POST → ${autoSaveResponse.status()}`);
+
+    await this.clickStepButtonWithRetry(this.bekreftOgFortsettButton);
+
+    // Klikket trigger auto-oppfrisk (spinner → «Registeropplysningene er
+    // oppdatert») og auto-naviger til steg 2 — vent kun på neste heading.
+    await this.unntakMedlemskapHeading.waitFor({ state: 'visible', timeout: 60000 });
+    console.log('✅ Steg «Unntak medlemskap» vises');
+  }
+
+  /**
+   * Velg «Godkjenn» og bestemmelse på «Unntak medlemskap»-steget.
+   * Bestemmelse-dropdownen populeres async (GET lovvalgsbestemmelser).
+   *
+   * @param bestemmelse - Bestemmelse-kode (default 'AUS_ART9_3' — Utsendt
+   *                      arbeidstaker, artikkel 9 nr. 3)
+   */
+  async godkjennMedBestemmelse(bestemmelse: string = 'AUS_ART9_3'): Promise<void> {
+    // «Godkjenn» er disabled til skjemaet har sluttdato (tom) — den kommer
+    // fra persistert mottatteopplysninger-periode ved mount av steget.
+    await expect(this.godkjennRadio).toBeEnabled({ timeout: 15000 });
+    await this.godkjennRadio.check();
+    console.log('✅ Valgte «Godkjenn»');
+
+    await this.bestemmelseDropdown.waitFor({ state: 'visible', timeout: 15000 });
+    await this.waitForDropdownToPopulate(this.bestemmelseDropdown);
+    await this.bestemmelseDropdown.selectOption(bestemmelse);
+    console.log(`✅ Valgte bestemmelse: ${bestemmelse}`);
+  }
+
+  /**
+   * Velg «Ikke godkjenn» på «Unntak medlemskap»-steget.
+   * Viser infomelding om at utenlandsk trygdemyndighet bør informeres
+   * (ingen bestemmelse-dropdown).
+   */
+  async ikkeGodkjenn(): Promise<void> {
+    await this.ikkeGodkjennRadio.check();
+    console.log('✅ Valgte «Ikke godkjenn»');
+  }
+
+  /**
+   * Klikk «Bekreft og avslutt» og vent på at saksflyt-prosessen faktisk
+   * startes (POST /saksflyt/unntaksregistrering → 204). Frontend POSTer også
+   * lovvalgsperioder først — det kallet venter vi bevisst IKKE på (gir 400
+   * ved «Ikke godkjenn», jf. klassedoc).
+   */
+  async bekreftOgAvslutt(): Promise<void> {
+    await this.bekreftOgAvsluttButton.waitFor({ state: 'visible', timeout: 10000 });
+    await expect(this.bekreftOgAvsluttButton).toBeEnabled({ timeout: 15000 });
+
+    const saksflytPromise = this.page.waitForResponse(
+      (response) =>
+        response.url().includes('/saksflyt/unntaksregistrering/') &&
+        response.request().method() === 'POST' &&
+        (response.status() === 204 || response.status() === 200),
+      { timeout: 60000 }
+    );
+
+    await this.bekreftOgAvsluttButton.click();
+    const response = await saksflytPromise;
+    console.log(`✅ Unntaksregistrering bekreftet: ${response.url()} -> ${response.status()}`);
+  }
+}

--- a/tests/trygdeavtale/trygdeavtale-unntaksregistrering.spec.ts
+++ b/tests/trygdeavtale/trygdeavtale-unntaksregistrering.spec.ts
@@ -1,0 +1,135 @@
+import { Page } from '@playwright/test';
+import { test } from '../../fixtures';
+import { AuthHelper } from '../../helpers/auth-helper';
+import { HovedsidePage } from '../../pages/hovedside.page';
+import { OpprettNySakPage } from '../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import { TrygdeavtaleUnntaksregistreringPage } from '../../pages/trygdeavtale/trygdeavtale-unntaksregistrering.page';
+import { USER_ID_VALID } from '../../pages/shared/constants';
+import { waitForProcessInstances } from '../../helpers/api-helper';
+
+/**
+ * Trygdeavtale - Unntaksregistrering (registrering av unntak fra medlemskap)
+ *
+ * Gap: trygdeavtale-anmodning-unntak-departement (e2e-dekningshull, Tier 3).
+ * UNNTAK-grenen for trygdeavtale-saker har en EGEN UI-side (unntaksregistrering)
+ * og egen prosess (REGISTRERE_UNNTAK_FRA_MEDLEMSKAP) som ingen e2e dekket.
+ * Bug-tett område: MELOSYS-6938 (unntakssaker for India avsluttes ikke) — derfor
+ * brukes Australia her, som de øvrige trygdeavtale-testene.
+ *
+ * Scope-merknad: «departement»/mottakerinstitusjon hører til EU/EØS-anmodning-
+ * om-unntak-flyten (AVKLAR_MYNDIGHET) og finnes IKKE i unntaksregistrerings-UI-et;
+ * for TRYGDEAVTALE ruter selv behandlingstema ANMODNING_OM_UNNTAK_HOVEDREGEL til
+ * samme unntaksregistrering-side. Departement er dermed ikke e2e-bart her.
+ *
+ * Flyt (felles for begge tester):
+ * 1. Opprett sak TRYGDEAVTALE/UNNTAK/REGISTRERING_UNNTAK (årsak SØKNAD)
+ * 2. Oppgavelenken på hovedsiden peker DIREKTE til unntaksregistrering-siden
+ * 3. Inngang: periode + avsenderland Australia (lagres som lovvalgsland)
+ * 4. Unntak medlemskap: Godkjenn (+ bestemmelse AUS_ART9_3) ELLER Ikke godkjenn
+ * 5. Bekreft og avslutt → prosessen REGISTRERE_UNNTAK_FRA_MEDLEMSKAP kjører
+ *
+ * Forventet utfall:
+ * - GODKJENT: fagsak LOVVALG_AVKLART, resultat REGISTRERT_UNNTAK/GODKJENT,
+ *   lovvalgsperiode UNNTATT/UTEN_DEKNING overført til MEDL som GYLD/ENDL
+ *   (NB: ENDELIG — ikke «under avklaring»; UAVK/FORL gjelder anmodningsflytene)
+ * - IKKE_GODKJENT: fagsak AVSLUTTET, resultat FERDIGBEHANDLET/IKKE_GODKJENT,
+ *   INGEN lovvalgsperiode (og dermed ingen MEDL-periode)
+ *
+ * NB (kjent api-WARN ved IKKE_GODKJENT): frontend POSTer lovvalgsperioder også
+ * ved «Ikke godkjenn» → api svarer 400 + WARN, men flyten fullfører likevel.
+ * Docker-logs-fixturen flagger ikke denne WARN-en — ingen tag nødvendig.
+ */
+const FRA = '01.01.2024';
+const TIL = '31.12.2025';
+const FRA_ISO = '2024-01-01';
+const TIL_ISO = '2025-12-31';
+const LAND = 'AU';
+const BESTEMMELSE = 'AUS_ART9_3';
+
+/**
+ * Opprett en TRYGDEAVTALE/UNNTAK/REGISTRERING_UNNTAK-sak og åpne
+ * unntaksregistrering-siden via oppgavelenken på hovedsiden.
+ */
+async function opprettSakOgÅpneUnntaksregistrering(page: Page): Promise<void> {
+  const hovedside = new HovedsidePage(page);
+  const opprettSak = new OpprettNySakPage(page);
+
+  await hovedside.goto();
+  await hovedside.klikkOpprettNySak();
+  await opprettSak.fyllInnBrukerID(USER_ID_VALID);
+  await opprettSak.velgSakstype('TRYGDEAVTALE');
+  await opprettSak.velgSakstema('UNNTAK');
+  await opprettSak.velgBehandlingstema('REGISTRERING_UNNTAK');
+  await opprettSak.velgAarsak('SØKNAD');
+  await opprettSak.leggBehandlingIMine();
+  await opprettSak.klikkOpprettNyBehandling();
+  await opprettSak.assertions.verifiserBehandlingOpprettet();
+
+  // OPPRETT_SAK-prosessen må fullføre før oppgavelenken er klikkbar
+  await waitForProcessInstances(page.request, 30);
+  await hovedside.åpneBehandling('TRIVIELL KARAFFEL -');
+}
+
+test.describe('Trygdeavtale - Unntaksregistrering', () => {
+  test('skal registrere godkjent unntak med endelig MEDL-periode', async ({ page, request }) => {
+    test.setTimeout(180000);
+
+    const auth = new AuthHelper(page);
+    await auth.login();
+
+    const unntak = new TrygdeavtaleUnntaksregistreringPage(page);
+
+    await opprettSakOgÅpneUnntaksregistrering(page);
+
+    await unntak.ventPåInngang();
+    await unntak.fyllUtInngang(FRA, TIL, LAND);
+    await unntak.bekreftInngangOgFortsett();
+
+    await unntak.godkjennMedBestemmelse(BESTEMMELSE);
+    await unntak.bekreftOgAvslutt();
+
+    console.log('📝 Venter på REGISTRERE_UNNTAK_FRA_MEDLEMSKAP (kaster ved feilede prosesser)...');
+    await waitForProcessInstances(page.request, 60);
+
+    const medlPeriodeId = await unntak.assertions.verifiserGodkjentUnntakIDatabase({
+      fom: FRA,
+      tom: TIL,
+      land: LAND,
+      bestemmelse: BESTEMMELSE
+    });
+
+    await unntak.assertions.verifiserMedlPeriodeEndelig(request, medlPeriodeId, {
+      lovvalgsland: 'AUS',
+      grunnlag: 'Australia_9_3',
+      fraOgMed: FRA_ISO,
+      tilOgMed: TIL_ISO
+    });
+
+    console.log('✅ Godkjent unntaksregistrering verifisert ende-til-ende (DB + MEDL)');
+  });
+
+  test('skal avslutte saken uten lovvalgsperiode ved ikke godkjent unntak', async ({ page }) => {
+    test.setTimeout(180000);
+
+    const auth = new AuthHelper(page);
+    await auth.login();
+
+    const unntak = new TrygdeavtaleUnntaksregistreringPage(page);
+
+    await opprettSakOgÅpneUnntaksregistrering(page);
+
+    await unntak.ventPåInngang();
+    await unntak.fyllUtInngang(FRA, TIL, LAND);
+    await unntak.bekreftInngangOgFortsett();
+
+    await unntak.ikkeGodkjenn();
+    await unntak.bekreftOgAvslutt();
+
+    console.log('📝 Venter på REGISTRERE_UNNTAK_FRA_MEDLEMSKAP (kaster ved feilede prosesser)...');
+    await waitForProcessInstances(page.request, 60);
+
+    await unntak.assertions.verifiserIkkeGodkjentUnntakIDatabase({ land: LAND });
+
+    console.log('✅ Ikke-godkjent unntaksregistrering verifisert: sak avsluttet uten lovvalgsperiode');
+  });
+});


### PR DESCRIPTION
## Hva

Lukker trygdeavtale-UNNTAK-gapet (backloggens `trygdeavtale-anmodning-unntak-departement`): unntaksregistrering-flyten var udekket. To tester med delt `TrygdeavtaleUnntaksregistreringPage`-POM:

- **GODKJENT**: sak `LOVVALG_AVKLART`, resultat `REGISTRERT_UNNTAK`/`GODKJENT`/AU, prosess `REGISTRERE_UNNTAK_FRA_MEDLEMSKAP` FERDIG (siste steg `AVSLUTT_SAK_OG_BEHANDLING`), lovvalgsperiode `AUS_ART9_3`/`UNNTATT`/`UTEN_DEKNING` med `medlperiode_id`, **MEDL-periode `GYLD`/`ENDL`** (Australia_9_3).
- **IKKE_GODKJENT**: sak `AVSLUTTET`, resultat `FERDIGBEHANDLET`/`IKKE_GODKJENT`, ingen lovvalgsperiode/MEDL.

## Backlog-korreksjoner (verify-don't-trust)

- MEDL-utfallet er **endelig** (`GYLD`/`ENDL`) — ikke «under avklaring» som backloggen antok (UAVK/FORL gjelder anmodnings-/utpekingsflytene).
- **«Departement»-scope**: mottakerinstitusjon/`AVKLAR_MYNDIGHET` hører til anmodning-om-unntak-prosessen; selv `TRYGDEAVTALE` + `ANMODNING_UNNTAK_HOVEDREGEL` ruter til samme unntaksregistrerings-side — ren unntaksregistrering ER dekningen for grenen.
- Australia brukes bevisst — India-bug MELOSYS-6938 (unntakssaker avsluttes ikke) unngås.

## Timing-funn (verdt å kjenne til)

Inngang-feltene persisteres KUN via menypanelets debouncede auto-save (`POST /api/mottatteopplysninger`, ~1,5 s etter siste endring); «Bekreft og fortsett» trigger registeroppfrisk + full re-last som **nullstiller u-persistert avsenderland**. Manuell kjøring er treg nok til at auto-saven rekker å fyre — tester er ikke. POM-en venter derfor på auto-save-POST-en før steg-overgangen (race-safe: ventingen armes millisekunder etter siste felt, debouncen garanterer ≥1,5 s).

Lokalt: 2/2 grønn (47.3s) + `npm run check:tests` OK. Ingen mock-endring; ingen eksisterende filer endret.