### PR TITLE
8141 Regresjonsvern for fritekst-autolagring i opphørsvedtak

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -309,10 +309,15 @@ services:
           - melosys-web.melosys.docker-internal
     ports:
       - "3000:3000"
+    # Nginx resolverer alle upstreams ved oppstart og dør permanent hvis én mangler i
+    # docker-DNS — derfor må ALLE tjenester nginx-configen refererer stå i depends_on,
+    # og restart-policy fange resterende oppstarts-racer (container-start ≠ DNS-registrert)
+    restart: on-failure
     depends_on:
       - melosys-api
       - mock-oauth2-server
       - faktureringskomponenten
+      - melosys-trygdeavtale
     environment:
       # Load the local environment configuration
       ENVIRONMENT_NAME: local

--- a/pages/behandling/manglende-innbetaling.page.ts
+++ b/pages/behandling/manglende-innbetaling.page.ts
@@ -76,4 +76,38 @@ export class ManglendeInnbetalingPage extends BasePage {
     });
     console.log('✅ På opphørsvedtak-steget («Opphør av frivillig medlemskap etter § 2-15»)');
   }
+
+  /**
+   * Fyll begrunnelsesfriteksten på opphørsvedtak-steget og vent på at autolagringen
+   * (debounced 1000 ms POST /resultat/fritekst fra VurderingVedtakOpphoer) fullfører
+   * FØR vedtaket fattes — ellers kan debounce-kallet kanselleres ved stegovergang.
+   *
+   * MELOSYS-8141: autolagringen sendte tidligere payload uten innledningFritekst og ga
+   * NPE/500 i melosys-api. Feiler med tydelig melding hvis autolagringen gir HTTP-feil.
+   *
+   * @param tekst - begrunnelsestekst (kun ASCII — matches mot rå request-payload)
+   */
+  async fyllInnBegrunnelseFritekstMedAutolagring(tekst: string): Promise<void> {
+    const autolagring = this.page.waitForResponse(
+      (response) =>
+        response.url().includes('/resultat/fritekst') &&
+        response.request().method() === 'POST' &&
+        (response.request().postData() ?? '').includes(tekst),
+      { timeout: 15000 }
+    );
+
+    // Eneste Quill-editor på opphørssteget er begrunnelsesfeltet («Fritekst til begrunnelse»)
+    const editor = this.page.locator('.vurderingVedtakOpphoer .ql-editor');
+    await editor.click();
+    await editor.fill(tekst);
+
+    const respons = await autolagring;
+    if (respons.status() >= 400) {
+      throw new Error(
+        `Autolagring av begrunnelsesfritekst feilet: POST ${respons.url()} -> ` +
+        `${respons.status()} (MELOSYS-8141-regresjon?)`
+      );
+    }
+    console.log(`✅ Begrunnelsesfritekst autolagret (HTTP ${respons.status()})`);
+  }
 }

--- a/specs/ftrl-opphor-fritekst-autolagring.md
+++ b/specs/ftrl-opphor-fritekst-autolagring.md
@@ -1,0 +1,97 @@
+---
+jira: MELOSYS-8141
+status: bundet
+date: 2026-06-11
+analysis_trace_id: 5eb483b8-72b6-4cc2-80c3-8d1a8abf9f2b
+---
+
+# Autolagring av fritekst i opphørsvedtak skal tåle ufullstendig payload
+
+## Forretningsregel
+
+Vedtaksbrev i Melosys inneholder fritekstfelt for innledning og begrunnelse, forankret i
+forvaltningsloven §§ 24–25 (begrunnelsesplikt ved enkeltvedtak). Ikke alle vedtakstyper
+bruker begge feltene — opphørsvedtak ved manglende innbetaling (ftrl. § 2-15) har kun
+begrunnelsesfelt. Autolagring av fritekst er en støttefunksjon som sikrer at saksbehandlers
+arbeid bevares underveis; den skal aldri gi feil, uansett hvilke felt som er utfylt på
+tidspunktet.
+
+## Scenario
+
+```gherkin
+Gitt at en saksbehandler behandler opphør av frivillig medlemskap pga. manglende innbetaling
+  Og vedtaket har et begrunnelsesfelt for fritekst
+  Og vedtaket har ikke et innledningsfelt (innledningen er standardisert for opphørsvedtak)
+ Når saksbehandler redigerer begrunnelsesfriteksten og systemet autolagrer
+ Så skal autolagringen fullføres uten feil
+  Og begrunnelsesfriteksten skal være bevart ved neste sidevisning
+  Og det skal ikke oppstå feilmeldinger i systemet
+```
+
+## Akseptansekriterier (det fagperson signerer av på)
+
+- [ ] Autolagring av fritekst fra opphørsvedtak-skjermen gir ikke HTTP-feil (utledet — bekreft med fagperson)
+- [ ] Begrunnelsesfritekst lagres korrekt selv om innledningsfritekst ikke er utfylt (utledet — bekreft med fagperson)
+- [ ] Eksisterende vedtakstyper som sender begge fritekstfelt (innvilgelse, avslag) fungerer som før (utledet — regresjonsvern)
+- [ ] Feilmeldinger i systemloggen forsvinner for denne flyten (utledet — operasjonelt krav fra saken)
+
+## Kjente avgrensninger (ikke dekket her)
+
+- Denne spec-en dekker kun autolagrings-kontrakten, ikke innholdet eller valideringen av selve opphørsvedtaket
+- Brevgenerering og brevmaler (melosys-dokgen) er utenfor scope — de har egne specs (MELOSYS-7201, MELOSYS-7339)
+- Andre behandlingstyper som også kan mangle innledningsfritekst er ikke kartlagt her — en bredere gjennomgang bør vurderes som oppfølgingssak
+
+---
+
+## Teknisk binding
+
+### Kontrakten som testes
+
+- **Endepunkt:** `POST /api/behandlinger/{behandlingID}/resultat/fritekst`
+  (`BehandlingsresultatController.oppdaterFritekster`, melosys-api)
+- **Avsender:** `VurderingVedtakOpphoer` (melosys-web,
+  `src/sider/ftrl/saksbehandling/stegKomponenter/vurderingVedtakOpphoer/`) —
+  autolagrer debounced (1000 ms) ved endring av begrunnelsesfeltet, og én gang ved
+  mount av steget. Kallet er fire-and-forget i UI-et: en 500 synes ikke for
+  saksbehandler, kun i api-loggen (MELOSYS-8141).
+- **Fiks (defence-in-depth):** api gjør `innledningFritekst` nullable i
+  `LagreFritekstDto` + `BehandlingsresultatService.oppdaterFritekster`; web sender
+  `innledningFritekst: ""` eksplisitt (melosys-web `feature/8141-innledningfritekst-opphoer`).
+
+### Testfil
+
+`tests/ftrl/ftrl-manglende-innbetaling-opphor.spec.ts` — spec-en er bundet til den
+eksisterende fulle § 2-15-flyttesten (faktura → manglende innbetaling → opphørsvedtak),
+ikke en ny testfil. Opphørsvedtak-steget kan bare nås gjennom hele kjeden (auto-opprettet
+`MANGLENDE_INNBETALING_TRYGDEAVGIFT`-behandling), så en egen test ville dublert ~4 min
+flyt uten ny dekning.
+
+### Binding av scenariolinjene
+
+| Gherkin-linje | Binding i testen |
+|---|---|
+| Gitt … behandler opphør pga. manglende innbetaling | DEL 1–4: § 2-8a-sak → faktura BESTILT → simulert manglende innbetaling → auto-opprettet behandling → steget «Manglende innbetaling» → «hele perioden» → opphørsvedtak-steget |
+| Og vedtaket har et begrunnelsesfelt | `ManglendeInnbetalingPage.fyllInnBegrunnelseFritekstMedAutolagring()` — Quill-editoren under «Fritekst til begrunnelse» |
+| Og vedtaket har ikke et innledningsfelt | Implisitt: skjermen rendrer kun begrunnelses-editor; payloaden mangler/tom `innledningFritekst` er selve trigger-betingelsen |
+| Når … redigerer og systemet autolagrer | Editoren fylles, deretter ventes det eksplisitt på `POST /resultat/fritekst` med teksten i payloaden (debounce 1000 ms) |
+| Så skal autolagringen fullføres uten feil | Respons-status asserteres `< 400` på autolagringskallet, og en respons-samler verifiserer at **ingen** `/resultat/fritekst`-kall i hele opphørsflyten feilet |
+| Og begrunnelsesfriteksten skal være bevart | DB-assert: `BEHANDLINGSRESULTAT.BEGRUNNELSE_FRITEKST LIKE '%MELOSYS-8141%'` for den nye behandlingen (kolonnen lagres av autolagringen og leses ved neste sidevisning) |
+| Og ingen feilmeldinger i systemet | `@expect-docker-errors`-taggen er fjernet — docker-log-fixturen feiler testen ved ERROR i melosys-api-loggen (CI). Nettverksvakten dekker lokalkjøring der api kjører på host og er usynlig for docker-log-sjekken |
+
+### Akseptansekriterier → vern
+
+1. **Ingen HTTP-feil:** respons-samler på `POST /resultat/fritekst` (alle kall < 400) + docker-log-sjekk uten tag.
+2. **Begrunnelse lagres uten innledning:** autolagringsresponsen (BehandlingsresultatDto) + DB-assert på `BEGRUNNELSE_FRITEKST`; `INNLEDNING_FRITEKST` forblir tom/null.
+3. **Regresjonsvern for vedtakstyper med begge felt:** dekkes av eksisterende suite — alle FTRL/EØS-vedtakstester fyller alle fritekstfelt via `VedtakPage.fyllInnAlleTekstfelt()` og fatter vedtak grønt.
+4. **Loggstøy forsvinner:** identisk med (1) på CI — taggen fjernet betyr at enhver gjenoppstått NPE feiler suiten.
+
+### Endringslogg (teknisk binding)
+
+- 2026-06-11: Bundet til eksisterende test i stedet for ny `.spec.ts` — opphørssteget er
+  kun nåbart via hele manglende-innbetaling-kjeden; duplisering gir null ekstra dekning.
+- 2026-06-11: Vern lagt på nettverksnivå (respons-samler + eksplisitt vent på autolagring)
+  i tillegg til docker-log-sjekk, fordi docker-log-fixturen ikke ser melosys-api når den
+  kjører på host lokalt (smart container detection hopper stille over).
+- 2026-06-11: `@expect-docker-errors` fjernet fra testen. **Merk:** endringen kan først
+  merges når api-fiksen (nullable `innledningFritekst`) er i CI-imaget — uten fiks er
+  testen korrekt rød (vernet biter).

--- a/tests/ftrl/CLAUDE.md
+++ b/tests/ftrl/CLAUDE.md
@@ -101,5 +101,6 @@ Minstebeløp for 2026: **99 650 kr** (se `V6.0__minstebeloep.sql` i melosys-tryg
 
 Test-spesifikasjoner finnes under `specs/`:
 - `specs/ftrl-trygdeavgift-25-prosent-regel.md` — 25%-regelen
+- `specs/ftrl-opphor-fritekst-autolagring.md` — autolagring av fritekst i opphørsvedtak (MELOSYS-8141, bundet til `ftrl-manglende-innbetaling-opphor.spec.ts`)
 - `specs/ftrl-yrkesaktiv-full-dekning.md` — Full dekning FTRL
 - `specs/ftrl-aarsavregning.md` — Årsavregning

--- a/tests/ftrl/ftrl-manglende-innbetaling-opphor.spec.ts
+++ b/tests/ftrl/ftrl-manglende-innbetaling-opphor.spec.ts
@@ -38,16 +38,19 @@ import {FaktureringHelper} from '../../helpers/fakturering-helper';
  *   - faktureringskomponenten: KAFKA_TOPIC_NAME_MANGLENDE_FAKTURABETALING=
  *     teammelosys.manglende-fakturabetaling-local (samme topic som melosys-api lytter på)
  *
- * @expect-docker-errors fordi: opphørsvedtak-steget i melosys-web (VurderingVedtakOpphoer)
- * autolagrer fritekst via POST /api/behandlinger/{id}/resultat/fritekst med KUN
- * begrunnelseFritekst i payloaden. LagreFritekstDto.innledningFritekst blir null, og
- * BehandlingsresultatService.oppdaterFritekster (Kotlin, non-null String-parameter) kaster
- * NullPointerException → 500 ERROR i melosys-api-loggen. UI og flyt er upåvirket (kjent
- * frontend/backend-kontraktsbug). Å fylle friteksten i editoren hjelper IKKE — feltet
- * innledningFritekst mangler alltid i requesten, uavhengig av innhold.
+ * MELOSYS-8141 (regresjonsvern): opphørsvedtak-steget (VurderingVedtakOpphoer) autolagrer
+ * fritekst via POST /api/behandlinger/{id}/resultat/fritekst uten utfylt innledningsfelt
+ * (innledningen er standardisert for opphørsvedtak). Dette ga tidligere NPE/500 i
+ * melosys-api (non-null innledningFritekst). Testen vokter kontrakten på to nivåer:
+ *   1. Nettverksvakt: alle /resultat/fritekst-kall i opphørsflyten skal svare < 400
+ *      (virker også lokalt der melosys-api kjører på host og er usynlig for
+ *      docker-log-sjekken)
+ *   2. Docker-log-sjekk (CI): @expect-docker-errors er fjernet — ERROR i api-loggen
+ *      feiler testen
+ * Spec: specs/ftrl-opphor-fritekst-autolagring.md
  */
 test.describe('FTRL manglende innbetaling - opphør av frivillig medlemskap § 2-15', () => {
-    test('skal opprette manglende-innbetaling-behandling automatisk og fatte opphørsvedtak @expect-docker-errors', async ({page, request}) => {
+    test('skal opprette manglende-innbetaling-behandling automatisk og fatte opphørsvedtak', async ({page, request}) => {
         test.setTimeout(240000);
 
         // Setup
@@ -179,14 +182,37 @@ test.describe('FTRL manglende innbetaling - opphør av frivillig medlemskap § 2
         await behandlingsLenke.waitFor({state: 'visible', timeout: TIMEOUT_LONG});
         await behandlingsLenke.click();
 
+        // MELOSYS-8141-vakt: samle ALLE autolagrings-responser i opphørsflyten.
+        // VurderingVedtakOpphoer autolagrer også ved mount (debounced 1s), så samleren
+        // må stå på før stegovergangen — ikke bare rundt fritekst-utfyllingen.
+        const fritekstResponser: { url: string; status: number }[] = [];
+        page.on('response', (response) => {
+            if (response.url().includes('/resultat/fritekst') && response.request().method() === 'POST') {
+                fritekstResponser.push({url: response.url(), status: response.status()});
+            }
+        });
+
         console.log('📝 Steg 12: Velger «hele medlemskapsperioden» og går til opphørsvedtak...');
         await manglendeInnbetaling.ventPaaSteg();
         await manglendeInnbetaling.velgInnbetalingManglerHelePerioden();
         await manglendeInnbetaling.bekreftOgGaaTilOpphoersvedtak();
 
-        console.log('📝 Steg 13: Fatter opphørsvedtak...');
+        console.log('📝 Steg 13: Fyller begrunnelsesfritekst og venter på autolagring (MELOSYS-8141)...');
+        const begrunnelseTekst = 'Opphoer pga. manglende innbetaling av trygdeavgift - e2e MELOSYS-8141';
+        await manglendeInnbetaling.fyllInnBegrunnelseFritekstMedAutolagring(begrunnelseTekst);
+
+        console.log('📝 Steg 14: Fatter opphørsvedtak...');
         await vedtak.klikkFattVedtak();
         await waitForProcessInstances(page.request, 60);
+
+        // MELOSYS-8141: autolagringen skal aldri feile, heller ikke mount-kallet uten fritekst
+        expect(fritekstResponser.length, 'Minst ett autolagringskall (/resultat/fritekst) i opphørsflyten')
+            .toBeGreaterThan(0);
+        const feiledeAutolagringer = fritekstResponser.filter(r => r.status >= 400);
+        expect(feiledeAutolagringer,
+            `Autolagring av fritekst skal aldri gi HTTP-feil (MELOSYS-8141): ${JSON.stringify(feiledeAutolagringer)}`)
+            .toHaveLength(0);
+        console.log(`✅ ${fritekstResponser.length} autolagringskall, alle < 400`);
 
         // === DEL 5: Slutt-tilstand - behandling, fagsak og fakturaserie ===
 
@@ -202,6 +228,18 @@ test.describe('FTRL manglende innbetaling - opphør av frivillig medlemskap § 2
                 {id: nyBehandling.ID}
             );
             expect(resultat?.RESULTAT_TYPE, 'Behandlingsresultat skal være OPPHØRT').toBe('OPPHØRT');
+
+            // MELOSYS-8141: begrunnelsesfriteksten skal være bevart (autolagret) selv om
+            // innledningsfritekst aldri ble utfylt. LIKE-spørring fordi kolonnen kan være CLOB.
+            const fritekstLagret = await db.queryOne<{ ANTALL: number }>(
+                `SELECT COUNT(*) AS ANTALL
+                 FROM BEHANDLINGSRESULTAT
+                 WHERE BEHANDLING_ID = :id
+                   AND BEGRUNNELSE_FRITEKST LIKE '%MELOSYS-8141%'`,
+                {id: nyBehandling.ID}
+            );
+            expect(fritekstLagret?.ANTALL, 'Begrunnelsesfritekst skal være lagret på behandlingsresultatet')
+                .toBe(1);
 
             const fagsak = await db.queryOne<{ STATUS: string }>(
                 'SELECT STATUS FROM FAGSAK WHERE SAKSNUMMER = :saksnummer',


### PR DESCRIPTION
Gjør om reproduksjonstesten for fritekst-autolagring i opphørsvedtak til et
regresjonsvern nå som api-fiksen (nullable innledningFritekst) er på plass.

Opphørsvedtak-steget (VurderingVedtakOpphoer) autolagrer fritekst uten
innledningsfelt — innledningen er standardisert for opphørsvedtak. Dette ga
NPE/500 i melosys-api ved hvert feltvalg på steget, usynlig i UI-et
(fire-and-forget) men støy i prod-loggene. Testen var derfor tagget
@expect-docker-errors; etter fiksen skal suiten vokte mot at feilen kommer
tilbake.
[MELOSYS-8141](https://jira.adeo.no/browse/MELOSYS-8141)

- `@expect-docker-errors` fjernet fra `ftrl-manglende-innbetaling-opphor` —
  ERROR i api-loggen feiler nå testen
- Nettverksvakt: respons-samler asserter at alle `POST /resultat/fritekst`-kall
  svarer < 400 (virker også lokalt der api kjører på host, usynlig for
  docker-log-sjekken)
- Nytt steg fyller begrunnelsesfritekst og venter på debounced autolagring før
  vedtak fattes; DB-assert på `BEHANDLINGSRESULTAT.BEGRUNNELSE_FRITEKST`
- Ny spec `specs/ftrl-opphor-fritekst-autolagring.md` (domenelag + teknisk binding)
- CI-compose: fikset oppstarts-race der melosys-web-nginx døde på manglende
  trygdeavtale-DNS (`depends_on` + `restart: on-failure`)

## Testing
- [x] Lokal e2e grønn (48 s) mot api med fiks + web uten fiks (defence-in-depth
  reelt øvd: payload uten innledningFritekst → 200)
- [x] CI grønn: [run 27340585258](https://github.com/navikt/melosys-e2e-tests/actions/runs/27340585258)
  — 80 passed / 0 failed (41 min) med `melosys-api:8141-fritekst-nullable` + web `latest`;
  manglende-innbetaling-testen grønn på første forsøk uten docker-feil

## Notater
Kan først merges når api-fiksen (MELOSYS-8141) er merget og i
`melosys-api:latest` — uten fiks er testen korrekt rød på fritekst-vakten.
