### PR TITLE
8122 E2E-test for automatisk innhentingsbrev ved årsavregning

### DIFF
--- a/specs/aarsavregning-innhentingsbrev-automatisk.md
+++ b/specs/aarsavregning-innhentingsbrev-automatisk.md
@@ -1,7 +1,7 @@
 ---
 jira: MELOSYS-8122
 epic: MELOSYS-6579 — Automatisk opprette årsavregningsbehandlinger på ikke skattepliktige
-status: implemented  # testen er skrevet; brev-assertions er røde til feature-branchen lander (se status-merknad i binding)
+status: verified     # scenario 1+3 grønne i CI mot api-feature-image (run 27353951522); scenario 2+4 fixme (fullmektig-fikstur mangler)
 test: tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
 toggles: {}          # default-state; per-trigger-koreografi av melosys.faktureringskomponenten.ikke-tidligere-perioder er testmekanikk (se binding)
 tags: [årsavregning, brev, innhenting, skattehendelse, fullmektig, ftrl]

--- a/specs/aarsavregning-innhentingsbrev-automatisk.md
+++ b/specs/aarsavregning-innhentingsbrev-automatisk.md
@@ -90,13 +90,14 @@ Gitt at en bruker har en sak med forskuddsvis fakturert trygdeavgift
 
 > **Status-merknad:** Auto-utsending av innhentingsbrevet er implementert i melosys-api på branch
 > `8122-auto-innhentingsbrev-arsavregning` (saksflyt-steg `SEND_INNHENTINGSBREV_AARSAVREGNING` i
-> `OPPRETT_NY_BEHANDLING_AARSAVREGNING`, bak toggle `melosys.arsavregning.innhentingsbrev`,
-> default AV). Verifiseres i CI mot et pushet image fra den branchen. Til feature-imaget er i CI
-> er brev-assertionene korrekt røde. Akseptanse-test skrevet sammen med implementasjonen, samme
-> mønster som [`aarsavregning-oppgave-skatteaar-i-beskrivelse.md`](aarsavregning-oppgave-skatteaar-i-beskrivelse.md).
+> `OPPRETT_NY_BEHANDLING_AARSAVREGNING`, scopet via prosessdata-flagget `SEND_INNHENTINGSBREV`).
+> Verifisert grønt i CI mot pushet feature-image fra den branchen (run 27353951522 + re-kjøring
+> mot toggle-fri image). Akseptanse-test skrevet sammen med implementasjonen.
 >
-> **Toggle:** `melosys.arsavregning.innhentingsbrev` (default AV) styrer brev-steget — testen
-> enabler den eksplisitt før triggeren; i CI-dispatch settes også `unleash_force_enable`.
+> **Ingen brev-toggle:** Et dedikert brev-toggle ble vurdert, men droppet etter avklaring med
+> fagperson — begge flytene er allerede kontrollert oppstrøms (skattepliktige bak
+> `MELOSYS_SKATTEHENDELSE_CONSUMER`, ikke-skattepliktige = manuell admin-jobb), så brevet trigges
+> direkte via prosessdata-flagget i de to flytene. Testen trenger ingen toggle-aktivering for brevet.
 
 ### Forhold til MELOSYS-8123
 

--- a/specs/aarsavregning-innhentingsbrev-automatisk.md
+++ b/specs/aarsavregning-innhentingsbrev-automatisk.md
@@ -1,0 +1,215 @@
+---
+jira: MELOSYS-8122
+epic: MELOSYS-6579 — Automatisk opprette årsavregningsbehandlinger på ikke skattepliktige
+status: implemented  # testen er skrevet; brev-assertions er røde til feature-branchen lander (se status-merknad i binding)
+test: tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
+toggles: {}          # default-state; per-trigger-koreografi av melosys.faktureringskomponenten.ikke-tidligere-perioder er testmekanikk (se binding)
+tags: [årsavregning, brev, innhenting, skattehendelse, fullmektig, ftrl]
+analysis_trace_id: 7107e6b3-8a4f-4b02-a5a5-87ad4ff15199
+---
+
+# Automatisk innhentingsbrev ved opprettelse av årsavregning
+
+## Forretningsregel
+
+Når NAV automatisk oppretter en årsavregningsbehandling for trygdeavgift, skal brevet
+"Innhenting av inntektsopplysninger" sendes automatisk til bruker for å innhente endelig
+inntektsgrunnlag. Regelen følger steg 4 i årsavregningsflyten: *"Innhente opplysninger — fra
+bruker for ikke-skattepliktige"* (nav-wiki: Årsavregning, Confluence page_id 456855459).
+Mottakerlogikken følger det generelle brevprinsippet i Melosys: bruker er hovedmottaker, men har
+bruker en registrert fullmektig (type `FULLMEKTIG_SØKNAD`), overtar fullmektig som hovedmottaker
+([Confluence: Mottakere av brev](https://confluence.adeo.no/spaces/TEESSI/pages/395304999),
+[Kodeverk: fullmaktstype](https://confluence.adeo.no/spaces/TEESSI/pages/287472744)).
+
+## Scenario 1 — Skattepliktig uten fullmektig
+
+```gherkin
+Gitt at en bruker har en sak med forskuddsvis fakturert trygdeavgift
+  Og bruker er skattepliktig
+  Og bruker har ingen fullmektig av type FULLMEKTIG_SØKNAD registrert i saken
+ Når Melosys automatisk oppretter en årsavregningsbehandling etter skattemelding fra Skatteetaten
+ Så skal Melosys ha sendt brevet "Innhenting av inntektsopplysninger" til bruker
+```
+
+## Scenario 2 — Skattepliktig med fullmektig
+
+```gherkin
+Gitt at en bruker har en sak med forskuddsvis fakturert trygdeavgift
+  Og bruker er skattepliktig
+  Og bruker har en fullmektig av type FULLMEKTIG_SØKNAD registrert i saken
+ Når Melosys automatisk oppretter en årsavregningsbehandling etter skattemelding fra Skatteetaten
+ Så skal Melosys ha sendt brevet "Innhenting av inntektsopplysninger" til fullmektig
+```
+
+## Scenario 3 — Ikke-skattepliktig uten fullmektig
+
+```gherkin
+Gitt at en bruker har en sak med forskuddsvis fakturert trygdeavgift
+  Og bruker er ikke skattepliktig
+  Og bruker har ingen fullmektig av type FULLMEKTIG_SØKNAD registrert i saken
+ Når Melosys automatisk oppretter en årsavregningsbehandling via jobben for ikke-skattepliktige
+ Så skal Melosys ha sendt brevet "Innhenting av inntektsopplysninger" til bruker
+```
+
+## Scenario 4 — Ikke-skattepliktig med fullmektig
+
+```gherkin
+Gitt at en bruker har en sak med forskuddsvis fakturert trygdeavgift
+  Og bruker er ikke skattepliktig
+  Og bruker har en fullmektig av type FULLMEKTIG_SØKNAD registrert i saken
+ Når Melosys automatisk oppretter en årsavregningsbehandling via jobben for ikke-skattepliktige
+ Så skal Melosys ha sendt brevet "Innhenting av inntektsopplysninger" til fullmektig
+```
+
+## Akseptansekriterier (det fagperson signerer av på)
+
+- [ ] Ved automatisk opprettelse av årsavregning for skattepliktige (skattemelding-trigger): brevet "Innhenting av inntektsopplysninger" sendes automatisk til bruker
+- [ ] Ved automatisk opprettelse av årsavregning for skattepliktige med FULLMEKTIG_SØKNAD: brevet sendes til fullmektig i stedet for bruker
+- [ ] Ved automatisk opprettelse av årsavregning for ikke-skattepliktige (batch-jobb): brevet "Innhenting av inntektsopplysninger" sendes automatisk til bruker
+- [ ] Ved automatisk opprettelse av årsavregning for ikke-skattepliktige med FULLMEKTIG_SØKNAD: brevet sendes til fullmektig i stedet for bruker
+- [ ] Brevet som sendes automatisk er identisk med brevet som i dag kan sendes manuelt fra "Send brev"-menyen (brevmal `innhenting_av_inntektsopplysninger`)
+- [ ] *(Utledet — bekreft med fagperson)* Brevets årsavregningsår settes til det skatteåret behandlingen gjelder for
+
+## Kjente avgrensninger (ikke dekket her)
+
+- **Saksbehandlingsflyt-kontekst (tidligere år):** Siste AC i Jira er ufullstendig og markert "Under avklaring med Nav M&A" — scenariet der en årsavregning opprettes automatisk i kontekst av saksbehandlingsflyt for tidligere år dekkes ikke av denne speken (tilgrensende oppgavebeskrivelse-flyt finnes i [MELOSYS-8123](https://nav.atlassian.net/browse/MELOSYS-8123)).
+- **Backfill for allerede opprettede behandlinger (skatteår 2024):** Dekkes av MELOSYS-8125 som egen oppgave.
+- **Brevmal-endring (fjerne "chatte" fra kontaktinfo):** Dekkes av MELOSYS-8133.
+- **Idempotens / duplikathåndtering:** Speken definerer ikke oppførsel ved re-opprettelse eller reset av en behandling — avklar om brevet skal sendes på nytt.
+- **Feilhåndtering ved brevsending:** Oppførsel dersom dokgen/distribusjon feiler (skal behandling opprettes uten brev? alerting?) er ikke spesifisert i Jira.
+- **EØS-pensjonister:** Gjelder kun FTRL-saker med trygdeavgift; EØS-pensjonist-årsavregning er ikke dekket.
+
+---
+
+## Teknisk binding
+*(for testagenten — domeneleseren kan stoppe over linjen)*
+
+> **Verbatim-regel:** verdier merket `(verbatim)` er flyt-spesifikke `selectOption`-argumenter
+> og skal brukes **ordrett**. Ikke "korriger" dem mot eksempelverdier i POM-ens JSDoc — samme
+> dropdown bruker ulike koder i ulike flyter.
+
+> **Status-merknad:** Auto-utsending av innhentingsbrevet ved *automatisk* opprettelse av
+> årsavregning er **ikke implementert i melosys-api ennå** (MELOSYS-8122 er i «Utvikle og teste»).
+> Prosessflyten `OPPRETT_NY_BEHANDLING_ARSAVREGNING` består i dag kun av stegene
+> `OPPRETT_AARSAVREGNING_BEHANDLING` + `OPPRETT_OPPGAVE` — ingen brev-steg. Brev-assertionene
+> forventes derfor **røde** til feature-branchen lander; selve trigger-flyten (saksopprettelse,
+> vedtak, auto-opprettelse av årsavregningsbehandling) er grønn i dag. Dette er en
+> akseptanse-test skrevet *foran* implementasjonen, etter samme mønster som
+> [`aarsavregning-oppgave-skatteaar-i-beskrivelse.md`](aarsavregning-oppgave-skatteaar-i-beskrivelse.md).
+
+### Forhold til MELOSYS-8123
+
+8122 er **brev-søsknen** til 8123 i samme epic. De deler *nøyaktig* samme automatiske
+opprettelses-triggere (Kafka-skattehendelse + ikke-skattepliktig-jobb) og samme felles-
+forutsetning (vedtatt FTRL-sak med trygdeavgift, avgiftsperiode i forrige år). Forskjellen er
+**kun** «Så»-linjen: 8123 asserterer skatteår i oppgavebeskrivelsen, 8122 asserterer at
+innhentingsbrevet ble sendt (og til hvem). Felles-oppsettet under er identisk med
+`tests/utenfor-avtaleland/workflows/arsavregning-oppgave-aar-i-beskrivelse.spec.ts`.
+
+### Skatteår X i testene
+
+`FORRIGE_AAR` (konstant i `pages/shared/constants.ts`, `inneværende år − 1`).
+
+### Felles forutsetning (alle scenarier)
+
+Vedtatt FTRL-sak med trygdeavgift som betales til NAV, avgiftsperiode i forrige år — samme
+oppskrift som 8123 sin `opprettVedtattIkkeSkattepliktigSak`:
+
+- bruker: `USER_ID_VALID` (`30056928150`, "TRIVIELL KARAFFEL"; aktørId i mock: `1111111111111`)
+- `OpprettNySakPage.opprettStandardSak(USER_ID_VALID)` (FTRL / MEDLEMSKAP_LOVVALG / YRKESAKTIV / SØKNAD)
+- `MedlemskapPage`: `velgPeriode('01.01.${FORRIGE_AAR}', '31.12.${FORRIGE_AAR}')`
+  (`TestPeriods.previousYearPeriod`) · `velgLand('Afghanistan')` ·
+  `velgTrygdedekning('FTRL_2_9_FØRSTE_LEDD_C_HELSE_PENSJON')` **(verbatim)** · `klikkBekreftOgFortsett()`
+- `ArbeidsforholdPage.fyllUtArbeidsforhold('Ståles Stål AS')`
+- `LovvalgPage`: `velgBestemmelse('FTRL_KAP2_2_8_FØRSTE_LEDD_A')` **(verbatim)** ·
+  `svarJaPaaFørsteSpørsmål()` · Ja på "Har søker vært medlem i minst" og "Har søker nær tilknytning til" ·
+  `klikkBekreftOgFortsett()`
+- `ResultatPeriodePage.fyllUtResultatPeriode('INNVILGET')`
+- `TrygdeavgiftPage`: `ventPåSideLastet()` · `velgSkattepliktig(false)` ·
+  `velgInntektskilde('INNTEKT_FRA_UTLANDET')` **(verbatim)** · `velgBetalesAga(false)` ·
+  `fyllInnBruttoinntektMedApiVent('100000')` · `klikkBekreftOgFortsett()`
+- `VedtakPage.klikkFattVedtak()` · `waitForProcessInstances(page.request, 30)`
+
+> **Merk om «skattepliktig» i scenariene:** Domenelagets skille skattepliktig/ikke-skattepliktig
+> handler om *hvilken trigger* som fyrer (skattemelding fra Skatteetaten vs. ikke-skattepliktig-
+> jobben). Selve sak-oppsettet bruker `velgSkattepliktig(false)` i begge — trigger-mekanismen er
+> aksen som bindes, mottakerlogikken (bruker/fullmektig) er den andre. Dette speiler 8123-testen.
+
+**Toggle-koreografi** (`UnleashHelper`, toggle `melosys.faktureringskomponenten.ikke-tidligere-perioder`):
+- toggle **AV** under saksopprettelse/vedtak (forrige-års-UI-et krever det, og fakturering må
+  akseptere serien), **PÅ** igjen *etter* vedtaket, før selve triggeren utløses (hindrer at
+  saksbehandlingsflyt-grenen auto-oppretter årsavregningen i samme vedtak).
+
+### Trigger-utløsning
+
+1. **Skattehendelse (scenario 1, 2):** publiser rå JSON til Kafka-topic
+   `teammelosys.skattehendelser.v1-local` (api kjører `local-mock`-profil; `SkattehendelserConsumer`
+   deserialiserer via objectMapper):
+   ```
+   {"gjelderPeriode":"${FORRIGE_AAR}","identifikator":"${USER_ID_VALID}","hendelsetype":"NY"}
+   ```
+   via `helpers/skattehendelse-helper.ts` (`publishSkattehendelse`). `identifikator` kan være fnr —
+   api slår opp aktørId via PDL. Krever toggle `melosys.skattehendelse.consumer` PÅ (default).
+2. **Ikke-skattepliktig-jobb (scenario 3, 4):**
+   `AdminApiHelper.finnIkkeSkattepliktigeSaker(request, '${FORRIGE_AAR}-01-01', '${FORRIGE_AAR}-12-31', true)`
+   + `waitForIkkeSkattepliktigeSakerJob(request, 60, 1000)`; assert `antallProsessert === 1`.
+
+### Mottaker-akse: bruker vs. fullmektig
+
+Mottakerlogikken ligger i `melosys-api` `BrevmottakerService.avklarMottakereForBruker()`:
+`fagsak.finnFullmektig(Fullmaktstype.FULLMEKTIG_SØKNAD)` — finnes en fullmektig, blir brevet sendt
+**kun** til fullmektig (innhentingsbrevet er ikke i «både-bruker-og-fullmektig»-listen).
+`Produserbaredokumenter.INNHENTING_AV_INNTEKTSOPPLYSNINGER → Mottakerliste(Mottakerroller.BRUKER)`
+er default når ingen fullmektig finnes.
+
+**Scenario 1 og 3 (uten fullmektig) bindes som kjørbare tester.** Testbruker `USER_ID_VALID` har
+ingen registrert fullmakt i mock/DB → mottaker = bruker.
+
+**Scenario 2 og 4 (med fullmektig) bindes som `test.fixme`** med dokumentert oppsett-sti:
+det finnes ingen e2e-fikstur for å registrere en `FULLMEKTIG_SØKNAD`-fullmakt på saken. Fullmakten
+ligger i melosys-api sin egen `fullmakt`-tabell (`Fullmakt` → `aktoer_id`, `type`), og krever en
+`Aktoer` med `rolle = Aktoersroller.FULLMEKTIG` knyttet til fagsaken. Oppsett-sti for senere
+aktivering: DB-injeksjon via `withDatabase` (insert i `AKTOER` med FULLMEKTIG-rolle på fagsaken +
+insert i `FULLMAKT(aktoer_id, type='FULLMEKTIG_SØKNAD')`), deretter samme trigger og assert at
+brev-mottakeren er fullmektigens fnr i stedet for brukerens. Markeres `fixme` til denne fiksturen
+finnes — å fake fullmektig-oppsettet ville gitt falsk dekning.
+
+### Assertions (binder «Så»-linjene)
+
+Brevet verifiseres via `PROSESSINSTANS` i Oracle (`withDatabase`), samme mønster som vedtaksbrev-
+verifiseringen i `tests/eu-eos/eu-eos-12.1-iverksetting-mottaker-kjede.spec.ts`. Opprettelsen er
+asynkron (Kafka-consume / jobb → prosessinstans) → poll til en fersk brev-prosessinstans for
+innhentingsbrevet finnes:
+
+- brev-prosess: `PROSESS_TYPE IN ('SEND_BREV','OPPRETT_OG_DISTRIBUER_BREV')` med
+  `REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE` og `DATA` som inneholder
+  `INNHENTING_AV_INNTEKTSOPPLYSNINGER` ← **selve akseptansekriteriet** («brevet er sendt»)
+- `STATUS === 'FERDIG'` (brevet er produsert, journalført og distribuert)
+- **mottaker (scenario 1/3):** brev-prosessens `DATA` inneholder brukerens identifikator ← «til
+  bruker». Det er **uavklart** om `DATA` lagrer fnr eller aktørId for mottakeren (feature ikke
+  implementert ennå) → assertionen godtar at **minst én** av `USER_ID_VALID` (`30056928150`) og
+  aktørId `1111111111111` står i `DATA`. Eksakt identifikator pinnes når feature-branchen lander.
+  Helper-signatur: `verifiserInnhentingsbrevSendt(mottakerIdentifikatorer: string[])`.
+
+> **Robusthet:** Helperen `verifiserInnhentingsbrevSendt` matcher brevmal-strengen og mottaker som
+> delstrenger i `DATA` (samme JS-`includes`-mønster som eu-eos-12.1 bruker på `INNVILGELSE_YRKESAKTIV`).
+> Når feature-branchen lander kan eksakt prosesstype/`DATA`-felt for innhentingsbrevet måtte
+> finjusteres — assertionen er format-robust nok til at brevmal-treffet er det bærende.
+
+Avslutt hver test med `waitForProcessInstances(page.request, 30)` slik at cleanup-fixturen ikke
+treffer aktive prosessinstanser.
+
+**Page Objects:** `HovedsidePage`, `OpprettNySakPage`, `MedlemskapPage`, `ArbeidsforholdPage`,
+`LovvalgPage`, `ResultatPeriodePage`, `TrygdeavgiftPage`, `VedtakPage`
+**Konstanter:** `pages/shared/constants.ts` (`USER_ID_VALID`, `FORRIGE_AAR`)
+**Hjelpere:** `helpers/api-helper.ts` (`AdminApiHelper`, `waitForProcessInstances`),
+`helpers/skattehendelse-helper.ts` (`publishSkattehendelse`),
+`helpers/db-helper.ts` (`withDatabase`), `helpers/date-helper.ts` (`TestPeriods`, `TestPeriodsISO`),
+`helpers/unleash-helper.ts` (`UnleashHelper`)
+
+### Endringslogg (teknisk binding)
+
+- 2026-06-11: Spec opprettet som brev-søsken til MELOSYS-8123. Bundet på branchen
+  `e2e/melosys-8122-innhentingsbrev-automatisk` (avledet fra 8123-branchen for å arve
+  `skattehendelse-helper.ts`). Scenario 1+3 kjørbare (mottaker=bruker), 2+4 `test.fixme`
+  (ingen fullmakt-fikstur). Brev-assertions korrekt røde til melosys-api-feature lander.

--- a/specs/aarsavregning-innhentingsbrev-automatisk.md
+++ b/specs/aarsavregning-innhentingsbrev-automatisk.md
@@ -187,15 +187,18 @@ mot api-koden, ikke `SEND_BREV` — sistnevnte er doksys-forhåndsproduserte bre
 `DISTRIBUER_JOURNALPOST`) før den blir `FERDIG` → **poll til FERDIG** (timeout 60 s):
 
 - brev-prosess: `PROSESS_TYPE = 'OPPRETT_OG_DISTRIBUER_BREV'` med
-  `REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE` og `DATA` (serialisert DokgenBrevbestilling-
-  JSON, felt `"produserbartdokument":"INNHENTING_AV_INNTEKTSOPPLYSNINGER"`) som inneholder
+  `REGISTRERT_DATO >= :siden` (DB-tidspunktet fanget rett før triggeren via `hentDbTidspunkt`, så
+  søket kun matcher brev *denne* triggeren laget — ikke et brev fra en tidligere test) og `DATA`
+  (serialisert DokgenBrevbestilling-JSON, felt
+  `"produserbartdokument":"INNHENTING_AV_INNTEKTSOPPLYSNINGER"`) som inneholder
   `INNHENTING_AV_INNTEKTSOPPLYSNINGER` ← **selve akseptansekriteriet** («brevet er sendt»)
 - `STATUS === 'FERDIG'` (brevet er produsert, journalført og distribuert)
 - **mottaker (scenario 1/3):** samme `DATA` inneholder mottakerens ident — fullmektig-substitusjon
   skjer i `hentMottakere` FØR prosessinstansen lages, så identen er fullmektigens når
   `FULLMEKTIG_SØKNAD` finnes, ellers brukers. Assertionen godtar **minst én** av `USER_ID_VALID`
   (`30056928150`) og aktørId `1111111111111` (fnr/aktørId-format pinnes ved første grønne).
-  Helper-signatur: `verifiserInnhentingsbrevSendt(mottakerIdentifikatorer: string[])`. Det lages
+  Helper-signatur: `verifiserInnhentingsbrevSendt(mottakerIdentifikatorer: string[], siden: Date)`,
+  der `siden` er DB-tidspunktet fra `hentDbTidspunkt()` fanget rett før triggeren. Det lages
   nøyaktig ÉN slik prosessinstans (brevet går kun til én mottaker).
 
 > **Robusthet:** Helperen `verifiserInnhentingsbrevSendt` matcher brevmal-strengen og mottaker som

--- a/specs/aarsavregning-innhentingsbrev-automatisk.md
+++ b/specs/aarsavregning-innhentingsbrev-automatisk.md
@@ -88,14 +88,15 @@ Gitt at en bruker har en sak med forskuddsvis fakturert trygdeavgift
 > og skal brukes **ordrett**. Ikke "korriger" dem mot eksempelverdier i POM-ens JSDoc — samme
 > dropdown bruker ulike koder i ulike flyter.
 
-> **Status-merknad:** Auto-utsending av innhentingsbrevet ved *automatisk* opprettelse av
-> årsavregning er **ikke implementert i melosys-api ennå** (MELOSYS-8122 er i «Utvikle og teste»).
-> Prosessflyten `OPPRETT_NY_BEHANDLING_ARSAVREGNING` består i dag kun av stegene
-> `OPPRETT_AARSAVREGNING_BEHANDLING` + `OPPRETT_OPPGAVE` — ingen brev-steg. Brev-assertionene
-> forventes derfor **røde** til feature-branchen lander; selve trigger-flyten (saksopprettelse,
-> vedtak, auto-opprettelse av årsavregningsbehandling) er grønn i dag. Dette er en
-> akseptanse-test skrevet *foran* implementasjonen, etter samme mønster som
-> [`aarsavregning-oppgave-skatteaar-i-beskrivelse.md`](aarsavregning-oppgave-skatteaar-i-beskrivelse.md).
+> **Status-merknad:** Auto-utsending av innhentingsbrevet er implementert i melosys-api på branch
+> `8122-auto-innhentingsbrev-arsavregning` (saksflyt-steg `SEND_INNHENTINGSBREV_AARSAVREGNING` i
+> `OPPRETT_NY_BEHANDLING_AARSAVREGNING`, bak toggle `melosys.arsavregning.innhentingsbrev`,
+> default AV). Verifiseres i CI mot et pushet image fra den branchen. Til feature-imaget er i CI
+> er brev-assertionene korrekt røde. Akseptanse-test skrevet sammen med implementasjonen, samme
+> mønster som [`aarsavregning-oppgave-skatteaar-i-beskrivelse.md`](aarsavregning-oppgave-skatteaar-i-beskrivelse.md).
+>
+> **Toggle:** `melosys.arsavregning.innhentingsbrev` (default AV) styrer brev-steget — testen
+> enabler den eksplisitt før triggeren; i CI-dispatch settes også `unleash_force_enable`.
 
 ### Forhold til MELOSYS-8123
 
@@ -177,19 +178,24 @@ finnes — å fake fullmektig-oppsettet ville gitt falsk dekning.
 ### Assertions (binder «Så»-linjene)
 
 Brevet verifiseres via `PROSESSINSTANS` i Oracle (`withDatabase`), samme mønster som vedtaksbrev-
-verifiseringen i `tests/eu-eos/eu-eos-12.1-iverksetting-mottaker-kjede.spec.ts`. Opprettelsen er
-asynkron (Kafka-consume / jobb → prosessinstans) → poll til en fersk brev-prosessinstans for
-innhentingsbrevet finnes:
+verifiseringen i `tests/eu-eos/eu-eos-12.1-iverksetting-mottaker-kjede.spec.ts`. Brev-steget
+`SEND_INNHENTINGSBREV_AARSAVREGNING` (inne i `OPPRETT_NY_BEHANDLING_AARSAVREGNING`) kaller dokgen-
+mal-produksjon som enqueuer en **egen barn-prosessinstans** `OPPRETT_OG_DISTRIBUER_BREV` (verifisert
+mot api-koden, ikke `SEND_BREV` — sistnevnte er doksys-forhåndsproduserte brev). Den opprettes med
+`STATUS=KLAR` og plukkes asynkront av saga-workeren (`OPPRETT_OG_JOURNALFØR_BREV` →
+`DISTRIBUER_JOURNALPOST`) før den blir `FERDIG` → **poll til FERDIG** (timeout 60 s):
 
-- brev-prosess: `PROSESS_TYPE IN ('SEND_BREV','OPPRETT_OG_DISTRIBUER_BREV')` med
-  `REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE` og `DATA` som inneholder
+- brev-prosess: `PROSESS_TYPE = 'OPPRETT_OG_DISTRIBUER_BREV'` med
+  `REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE` og `DATA` (serialisert DokgenBrevbestilling-
+  JSON, felt `"produserbartdokument":"INNHENTING_AV_INNTEKTSOPPLYSNINGER"`) som inneholder
   `INNHENTING_AV_INNTEKTSOPPLYSNINGER` ← **selve akseptansekriteriet** («brevet er sendt»)
 - `STATUS === 'FERDIG'` (brevet er produsert, journalført og distribuert)
-- **mottaker (scenario 1/3):** brev-prosessens `DATA` inneholder brukerens identifikator ← «til
-  bruker». Det er **uavklart** om `DATA` lagrer fnr eller aktørId for mottakeren (feature ikke
-  implementert ennå) → assertionen godtar at **minst én** av `USER_ID_VALID` (`30056928150`) og
-  aktørId `1111111111111` står i `DATA`. Eksakt identifikator pinnes når feature-branchen lander.
-  Helper-signatur: `verifiserInnhentingsbrevSendt(mottakerIdentifikatorer: string[])`.
+- **mottaker (scenario 1/3):** samme `DATA` inneholder mottakerens ident — fullmektig-substitusjon
+  skjer i `hentMottakere` FØR prosessinstansen lages, så identen er fullmektigens når
+  `FULLMEKTIG_SØKNAD` finnes, ellers brukers. Assertionen godtar **minst én** av `USER_ID_VALID`
+  (`30056928150`) og aktørId `1111111111111` (fnr/aktørId-format pinnes ved første grønne).
+  Helper-signatur: `verifiserInnhentingsbrevSendt(mottakerIdentifikatorer: string[])`. Det lages
+  nøyaktig ÉN slik prosessinstans (brevet går kun til én mottaker).
 
 > **Robusthet:** Helperen `verifiserInnhentingsbrevSendt` matcher brevmal-strengen og mottaker som
 > delstrenger i `DATA` (samme JS-`includes`-mønster som eu-eos-12.1 bruker på `INNVILGELSE_YRKESAKTIV`).

--- a/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
@@ -1,0 +1,228 @@
+import {expect, test} from '../../../fixtures';
+import type {Page} from '@playwright/test';
+import {AuthHelper} from '../../../helpers/auth-helper';
+import {HovedsidePage} from '../../../pages/hovedside.page';
+import {OpprettNySakPage} from '../../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import {MedlemskapPage} from '../../../pages/behandling/medlemskap.page';
+import {ArbeidsforholdPage} from '../../../pages/behandling/arbeidsforhold.page';
+import {LovvalgPage} from '../../../pages/behandling/lovvalg.page';
+import {ResultatPeriodePage} from '../../../pages/behandling/resultat-periode.page';
+import {TrygdeavgiftPage} from '../../../pages/trygdeavgift/trygdeavgift.page';
+import {VedtakPage} from '../../../pages/vedtak/vedtak.page';
+import {FORRIGE_AAR, USER_ID_VALID} from '../../../pages/shared/constants';
+import {UnleashHelper} from '../../../helpers/unleash-helper';
+import {AdminApiHelper, waitForProcessInstances} from '../../../helpers/api-helper';
+import {publishSkattehendelse} from '../../../helpers/skattehendelse-helper';
+import {TestPeriods, TestPeriodsISO} from '../../../helpers/date-helper';
+import {withDatabase} from '../../../helpers/db-helper';
+
+/**
+ * MELOSYS-8122: Automatisk sende innhentingsbrev ved automatisk opprettelse av årsavregning
+ *
+ * Spec: specs/aarsavregning-innhentingsbrev-automatisk.md
+ *
+ * Brev-søsknen til MELOSYS-8123: identisk auto-årsavregning-trigger, men asserterer at brevet
+ * "Innhenting av inntektsopplysninger" (brevmal INNHENTING_AV_INNTEKTSOPPLYSNINGER) sendes
+ * automatisk — til bruker når ingen fullmektig er registrert, til fullmektig (FULLMEKTIG_SØKNAD)
+ * ellers.
+ *
+ * STATUS: Auto-utsending av brevet er ikke implementert i melosys-api ennå (MELOSYS-8122 er i
+ * «Utvikle og teste»). Brev-assertionene er derfor korrekt RØDE til feature-branchen lander;
+ * selve trigger-flyten (sak → vedtak → auto-opprettet årsavregning) er grønn i dag. Se
+ * status-merknaden i speken.
+ */
+
+/** AktørId for USER_ID_VALID (30056928150) i PDL-mocken — brevets mottaker uten fullmektig */
+const AKTOER_ID_VALID = '1111111111111';
+
+/** Brevmal-identifikator slik den står i SEND_BREV/brevbestilling-DATA (melosys-api Produserbaredokumenter) */
+const BREVMAL_INNHENTING = 'INNHENTING_AV_INNTEKTSOPPLYSNINGER';
+
+/**
+ * Felles forutsetning: vedtatt FTRL-sak med trygdeavgift som betales til NAV
+ * (ikke-skattepliktig), avgiftsperiode i forrige år.
+ *
+ * Toggle melosys.faktureringskomponenten.ikke-tidligere-perioder må være AV under opprettelsen —
+ * forrige-års-UI-et krever det, og faktureringskomponenten avviser tidligere-års-fakturaserier
+ * med togglen PÅ. Identisk med MELOSYS-8123 sin opprettVedtattIkkeSkattepliktigSak.
+ */
+async function opprettVedtattIkkeSkattepliktigSak(page: Page): Promise<void> {
+    const hovedside = new HovedsidePage(page);
+    const opprettSak = new OpprettNySakPage(page);
+    const medlemskap = new MedlemskapPage(page);
+    const arbeidsforhold = new ArbeidsforholdPage(page);
+    const lovvalg = new LovvalgPage(page);
+    const resultatPeriode = new ResultatPeriodePage(page);
+    const trygdeavgift = new TrygdeavgiftPage(page);
+    const vedtak = new VedtakPage(page);
+
+    const periode = TestPeriods.previousYearPeriod;
+
+    console.log('📝 Oppretter sak...');
+    await hovedside.gotoOgOpprettNySak();
+    await opprettSak.opprettStandardSak(USER_ID_VALID);
+    await opprettSak.assertions.verifiserBehandlingOpprettet();
+
+    await waitForProcessInstances(page.request, 30);
+    await hovedside.goto();
+    await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).click();
+
+    console.log(`📝 Medlemskap (${periode.start} - ${periode.end})...`);
+    await medlemskap.velgPeriode(periode.start, periode.end);
+    await medlemskap.velgLand('Afghanistan');
+    await medlemskap.velgTrygdedekning('FTRL_2_9_FØRSTE_LEDD_C_HELSE_PENSJON');
+    await medlemskap.klikkBekreftOgFortsett();
+
+    console.log('📝 Arbeidsforhold...');
+    await arbeidsforhold.fyllUtArbeidsforhold('Ståles Stål AS');
+
+    console.log('📝 Lovvalg...');
+    await lovvalg.velgBestemmelse('FTRL_KAP2_2_8_FØRSTE_LEDD_A');
+    await lovvalg.svarJaPaaFørsteSpørsmål();
+    await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker vært medlem i minst');
+    await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker nær tilknytning til');
+    await lovvalg.klikkBekreftOgFortsett();
+
+    console.log('📝 Resultat...');
+    await resultatPeriode.fyllUtResultatPeriode('INNVILGET');
+
+    console.log('📝 Trygdeavgift (ikke-skattepliktig)...');
+    await trygdeavgift.ventPåSideLastet();
+    await trygdeavgift.velgSkattepliktig(false);
+    await trygdeavgift.velgInntektskilde('INNTEKT_FRA_UTLANDET');
+    await trygdeavgift.velgBetalesAga(false);
+    await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
+    await trygdeavgift.klikkBekreftOgFortsett();
+
+    console.log('📝 Fatter vedtak...');
+    await vedtak.klikkFattVedtak();
+    await waitForProcessInstances(page.request, 30);
+}
+
+/**
+ * Binder «Så»-linjene: poller PROSESSINSTANS til en fersk brev-prosessinstans for
+ * innhentingsbrevet finnes, og verifiserer at den er FERDIG og adressert til forventet mottaker.
+ *
+ * Brevet enqueues som SEND_BREV / OPPRETT_OG_DISTRIBUER_BREV med brevmal-identifikatoren i DATA
+ * (samme JS-includes-mønster som vedtaksbrev-verifiseringen i eu-eos-12.1).
+ *
+ * @param mottakerIdentifikatorer mulige mottaker-identifikatorer (fnr og/eller aktørId). Det er
+ *   uavklart om brevets DATA lagrer fnr eller aktørId for mottakeren (feature ikke implementert
+ *   ennå) — assertionen godtar derfor at minst én av dem står i DATA. Eksakt identifikator pinnes
+ *   når feature-branchen lander.
+ */
+async function verifiserInnhentingsbrevSendt(
+    mottakerIdentifikatorer: string[]
+): Promise<void> {
+    type BrevRad = {DATA: string; STATUS: string; PROSESS_TYPE: string};
+
+    const hentInnhentingsbrev = async (): Promise<BrevRad | undefined> =>
+        await withDatabase(async (db) => {
+            const rader = await db.query<BrevRad>(
+                `SELECT PI.DATA, PI.STATUS, PI.PROSESS_TYPE
+                 FROM PROSESSINSTANS PI
+                 WHERE PI.PROSESS_TYPE IN ('SEND_BREV', 'OPPRETT_OG_DISTRIBUER_BREV')
+                   AND PI.REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE`,
+                {}
+            );
+            return rader.find((r) => (r.DATA || '').includes(BREVMAL_INNHENTING));
+        });
+
+    // Opprettelsen er asynkron (Kafka-consume / jobb → prosessinstans).
+    await expect
+        .poll(async () => (await hentInnhentingsbrev()) !== undefined, {
+            message: `Venter på brev-prosessinstans for ${BREVMAL_INNHENTING}`,
+            timeout: 30_000,
+        })
+        .toBe(true);
+
+    const brev = (await hentInnhentingsbrev())!;
+    console.log(`🔍 Innhentingsbrev: prosess=${brev.PROSESS_TYPE}, status=${brev.STATUS}`);
+
+    // «Så skal Melosys ha sendt brevet "Innhenting av inntektsopplysninger"»
+    expect(brev.STATUS, 'Innhentingsbrevet skal være produsert og distribuert (FERDIG)').toBe(
+        'FERDIG'
+    );
+
+    // «... til bruker» (scenario 1/3) — mottakeren skal stå i brevets DATA. Godtar fnr ELLER
+    // aktørId siden eksakt identifikator-format er uavklart til feature lander.
+    const dataHarMottaker = mottakerIdentifikatorer.some((id) => (brev.DATA || '').includes(id));
+    expect(
+        dataHarMottaker,
+        `Brevet skal være adressert til bruker (en av ${mottakerIdentifikatorer.join(' / ')})`
+    ).toBe(true);
+}
+
+test.describe('Automatisk innhentingsbrev ved årsavregning (MELOSYS-8122)', () => {
+    test('skattehendelse uten fullmektig sender innhentingsbrev til bruker', async ({
+        page,
+        request,
+    }) => {
+        test.setTimeout(180_000);
+        const auth = new AuthHelper(page);
+        const unleash = new UnleashHelper(request);
+
+        // Toggle AV under vedtak: hindrer at saksbehandlingsflyt-grenen auto-oppretter
+        // årsavregningen før skattehendelsen får gjort det.
+        await unleash.disableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+        await auth.login();
+
+        await opprettVedtattIkkeSkattepliktigSak(page);
+
+        await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+
+        console.log(`📨 Sender skattehendelse for skatteår ${FORRIGE_AAR}...`);
+        publishSkattehendelse({
+            gjelderPeriode: String(FORRIGE_AAR),
+            identifikator: USER_ID_VALID,
+            hendelsetype: 'NY',
+        });
+
+        await verifiserInnhentingsbrevSendt([USER_ID_VALID, AKTOER_ID_VALID]);
+        await waitForProcessInstances(page.request, 30);
+    });
+
+    test('ikke-skattepliktig-jobben uten fullmektig sender innhentingsbrev til bruker', async ({
+        page,
+        request,
+    }) => {
+        test.setTimeout(180_000);
+        const auth = new AuthHelper(page);
+        const unleash = new UnleashHelper(request);
+        const adminApi = new AdminApiHelper();
+
+        // Toggle AV under vedtak: årsavregningen skal opprettes av jobben, ikke av vedtaket.
+        await unleash.disableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+        await auth.login();
+
+        await opprettVedtattIkkeSkattepliktigSak(page);
+
+        await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+
+        const periodeISO = TestPeriodsISO.previousYearPeriod;
+        console.log(`⚙️ Kjører ikke-skattepliktige-jobben for ${periodeISO.start} - ${periodeISO.end}...`);
+        await adminApi.finnIkkeSkattepliktigeSaker(request, periodeISO.start, periodeISO.end, true);
+        const jobbStatus = await adminApi.waitForIkkeSkattepliktigeSakerJob(request, 60, 1000);
+        expect(jobbStatus.antallProsessert, 'Jobben skal prosessere saken').toBe(1);
+
+        await verifiserInnhentingsbrevSendt([USER_ID_VALID, AKTOER_ID_VALID]);
+        await waitForProcessInstances(page.request, 30);
+    });
+
+    // Scenario 2 og 4 — mottaker = fullmektig (FULLMEKTIG_SØKNAD).
+    //
+    // Bundet som fixme: det finnes ingen e2e-fikstur for å registrere en FULLMEKTIG_SØKNAD-fullmakt
+    // på saken. Fullmakten ligger i melosys-api sin egen `fullmakt`-tabell (Fullmakt → aktoer_id,
+    // type) og krever en Aktoer med rolle FULLMEKTIG knyttet til fagsaken. Oppsett-sti for senere
+    // aktivering (DB-injeksjon via withDatabase): insert i AKTOER med FULLMEKTIG-rolle på fagsaken
+    // + insert i FULLMAKT(aktoer_id, type='FULLMEKTIG_SØKNAD'), deretter samme trigger og assert at
+    // brevets DATA inneholder fullmektigens fnr i stedet for brukerens. Å fake oppsettet ville gitt
+    // falsk dekning — derfor fixme til fiksturen finnes. Se speken.
+    test.fixme('skattehendelse med fullmektig sender innhentingsbrev til fullmektig', async () => {
+        // Krever FULLMEKTIG_SØKNAD-fikstur — se kommentar over og speken.
+    });
+
+    test.fixme('ikke-skattepliktig-jobben med fullmektig sender innhentingsbrev til fullmektig', async () => {
+        // Krever FULLMEKTIG_SØKNAD-fikstur — se kommentar over og speken.
+    });
+});

--- a/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
@@ -194,7 +194,7 @@ async function verifiserInnhentingsbrevSendt(
     const dataHarMottaker = mottakerIdentifikatorer.some((id) => (brev!.DATA || '').includes(id));
     expect(
         dataHarMottaker,
-        `Brevet skal være adressert til bruker (en av ${mottakerIdentifikatorer.join(' / ')})`
+        `Brevet skal være adressert til mottaker (en av ${mottakerIdentifikatorer.join(' / ')})`
     ).toBe(true);
 }
 

--- a/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
@@ -111,8 +111,8 @@ async function opprettVedtattIkkeSkattepliktigSak(page: Page): Promise<void> {
  * Binder «Så»-linjene: poller PROSESSINSTANS til en fersk brev-prosessinstans for
  * innhentingsbrevet finnes, og verifiserer at den er FERDIG og adressert til forventet mottaker.
  *
- * Brevet enqueues som SEND_BREV / OPPRETT_OG_DISTRIBUER_BREV med brevmal-identifikatoren i DATA
- * (samme JS-includes-mønster som vedtaksbrev-verifiseringen i eu-eos-12.1).
+ * Brevet enqueues som en OPPRETT_OG_DISTRIBUER_BREV-prosessinstans med brevmal-identifikatoren i
+ * DATA (samme JS-includes-mønster som vedtaksbrev-verifiseringen i eu-eos-12.1).
  *
  * @param mottakerIdentifikatorer mulige mottaker-identifikatorer (fnr og/eller aktørId). Det er
  *   uavklart om brevets DATA lagrer fnr eller aktørId for mottakeren (feature ikke implementert
@@ -130,11 +130,15 @@ async function verifiserInnhentingsbrevSendt(
     // "INNHENTING_AV_INNTEKTSOPPLYSNINGER" + den oppløste mottakerens ident.
     const hentInnhentingsbrev = async (): Promise<BrevRad | undefined> =>
         await withDatabase(async (db) => {
+            // ORDER BY DESC → .find() treffer den NYESTE matchende brev-prosessinstansen, ikke en
+            // vilkårlig rad. Gjør matchingen deterministisk og foretrekker dette testens ferske brev
+            // framfor en evt. sen innkommende rad fra forrige test (cleanup kjører før, ikke etter).
             const rader = await db.query<BrevRad>(
                 `SELECT PI.DATA, PI.STATUS, PI.PROSESS_TYPE
                  FROM PROSESSINSTANS PI
                  WHERE PI.PROSESS_TYPE = 'OPPRETT_OG_DISTRIBUER_BREV'
-                   AND PI.REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE`,
+                   AND PI.REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE
+                 ORDER BY PI.REGISTRERT_DATO DESC`,
                 {}
             );
             return rader.find((r) => (r.DATA || '').includes(BREVMAL_INNHENTING));

--- a/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
@@ -26,10 +26,10 @@ import {withDatabase} from '../../../helpers/db-helper';
  * automatisk — til bruker når ingen fullmektig er registrert, til fullmektig (FULLMEKTIG_SØKNAD)
  * ellers.
  *
- * STATUS: Auto-utsending av brevet er ikke implementert i melosys-api ennå (MELOSYS-8122 er i
- * «Utvikle og teste»). Brev-assertionene er derfor korrekt RØDE til feature-branchen lander;
- * selve trigger-flyten (sak → vedtak → auto-opprettet årsavregning) er grønn i dag. Se
- * status-merknaden i speken.
+ * STATUS: Verifisert grønt i CI mot melosys-api-feature-imaget (branch
+ * 8122-auto-innhentingsbrev-arsavregning). Brevet scopes via prosessdata-flagget
+ * SEND_INNHENTINGSBREV i de to auto-flytene — ingen dedikert brev-toggle (droppet etter
+ * fagavklaring). Scenario 1+3 (mottaker=bruker) kjørbare; 2+4 (fullmektig) er test.fixme.
  */
 
 /** AktørId for USER_ID_VALID (30056928150) i PDL-mocken — brevets mottaker uten fullmektig */
@@ -37,12 +37,6 @@ const AKTOER_ID_VALID = '1111111111111';
 
 /** Brevmal-identifikator slik den står i brevbestilling-DATA (melosys-api Produserbaredokumenter) */
 const BREVMAL_INNHENTING = 'INNHENTING_AV_INNTEKTSOPPLYSNINGER';
-
-/**
- * Feature-toggle som styrer auto-utsending av innhentingsbrevet (melosys-api). Default AV når
- * udefinert — må enables eksplisitt før triggeren fyrer, ellers hopper saksflyt-steget over brevet.
- */
-const TOGGLE_INNHENTINGSBREV = 'melosys.arsavregning.innhentingsbrev';
 
 /**
  * Felles forutsetning: vedtatt FTRL-sak med trygdeavgift som betales til NAV
@@ -184,9 +178,6 @@ test.describe('Automatisk innhentingsbrev ved årsavregning (MELOSYS-8122)', () 
 
         await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
 
-        // Auto-utsending av innhentingsbrevet er bak toggle (default AV) — slå på før triggeren.
-        await unleash.enableFeature(TOGGLE_INNHENTINGSBREV);
-
         console.log(`📨 Sender skattehendelse for skatteår ${FORRIGE_AAR}...`);
         publishSkattehendelse({
             gjelderPeriode: String(FORRIGE_AAR),
@@ -214,9 +205,6 @@ test.describe('Automatisk innhentingsbrev ved årsavregning (MELOSYS-8122)', () 
         await opprettVedtattIkkeSkattepliktigSak(page);
 
         await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
-
-        // Auto-utsending av innhentingsbrevet er bak toggle (default AV) — slå på før triggeren.
-        await unleash.enableFeature(TOGGLE_INNHENTINGSBREV);
 
         const periodeISO = TestPeriodsISO.previousYearPeriod;
         console.log(`⚙️ Kjører ikke-skattepliktige-jobben for ${periodeISO.start} - ${periodeISO.end}...`);

--- a/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
@@ -35,8 +35,14 @@ import {withDatabase} from '../../../helpers/db-helper';
 /** AktørId for USER_ID_VALID (30056928150) i PDL-mocken — brevets mottaker uten fullmektig */
 const AKTOER_ID_VALID = '1111111111111';
 
-/** Brevmal-identifikator slik den står i SEND_BREV/brevbestilling-DATA (melosys-api Produserbaredokumenter) */
+/** Brevmal-identifikator slik den står i brevbestilling-DATA (melosys-api Produserbaredokumenter) */
 const BREVMAL_INNHENTING = 'INNHENTING_AV_INNTEKTSOPPLYSNINGER';
+
+/**
+ * Feature-toggle som styrer auto-utsending av innhentingsbrevet (melosys-api). Default AV når
+ * udefinert — må enables eksplisitt før triggeren fyrer, ellers hopper saksflyt-steget over brevet.
+ */
+const TOGGLE_INNHENTINGSBREV = 'melosys.arsavregning.innhentingsbrev';
 
 /**
  * Felles forutsetning: vedtatt FTRL-sak med trygdeavgift som betales til NAV
@@ -116,37 +122,44 @@ async function verifiserInnhentingsbrevSendt(
 ): Promise<void> {
     type BrevRad = {DATA: string; STATUS: string; PROSESS_TYPE: string};
 
+    // Brevet enqueues av saksflyt-steget SEND_INNHENTINGSBREV_AARSAVREGNING som en egen barn-
+    // prosessinstans OPPRETT_OG_DISTRIBUER_BREV (dokgen-mal → produserOgDistribuerBrev). DATA-
+    // kolonnen er serialisert DokgenBrevbestilling-JSON med "produserbartdokument":
+    // "INNHENTING_AV_INNTEKTSOPPLYSNINGER" + den oppløste mottakerens ident.
     const hentInnhentingsbrev = async (): Promise<BrevRad | undefined> =>
         await withDatabase(async (db) => {
             const rader = await db.query<BrevRad>(
                 `SELECT PI.DATA, PI.STATUS, PI.PROSESS_TYPE
                  FROM PROSESSINSTANS PI
-                 WHERE PI.PROSESS_TYPE IN ('SEND_BREV', 'OPPRETT_OG_DISTRIBUER_BREV')
+                 WHERE PI.PROSESS_TYPE = 'OPPRETT_OG_DISTRIBUER_BREV'
                    AND PI.REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE`,
                 {}
             );
             return rader.find((r) => (r.DATA || '').includes(BREVMAL_INNHENTING));
         });
 
-    // Opprettelsen er asynkron (Kafka-consume / jobb → prosessinstans).
+    // Barn-prosessinstansen opprettes med STATUS=KLAR og plukkes asynkront av saga-workeren
+    // (OPPRETT_OG_JOURNALFØR_BREV → DISTRIBUER_JOURNALPOST) før den blir FERDIG. Poll til FERDIG.
+    let brev: BrevRad | undefined;
     await expect
-        .poll(async () => (await hentInnhentingsbrev()) !== undefined, {
-            message: `Venter på brev-prosessinstans for ${BREVMAL_INNHENTING}`,
-            timeout: 30_000,
-        })
-        .toBe(true);
+        .poll(
+            async () => {
+                brev = await hentInnhentingsbrev();
+                return brev?.STATUS;
+            },
+            {
+                message: `Venter på at innhentingsbrevet (${BREVMAL_INNHENTING}) blir FERDIG`,
+                timeout: 60_000,
+            }
+        )
+        .toBe('FERDIG');
 
-    const brev = (await hentInnhentingsbrev())!;
-    console.log(`🔍 Innhentingsbrev: prosess=${brev.PROSESS_TYPE}, status=${brev.STATUS}`);
+    console.log(`🔍 Innhentingsbrev: prosess=${brev!.PROSESS_TYPE}, status=${brev!.STATUS}`);
 
-    // «Så skal Melosys ha sendt brevet "Innhenting av inntektsopplysninger"»
-    expect(brev.STATUS, 'Innhentingsbrevet skal være produsert og distribuert (FERDIG)').toBe(
-        'FERDIG'
-    );
-
-    // «... til bruker» (scenario 1/3) — mottakeren skal stå i brevets DATA. Godtar fnr ELLER
-    // aktørId siden eksakt identifikator-format er uavklart til feature lander.
-    const dataHarMottaker = mottakerIdentifikatorer.some((id) => (brev.DATA || '').includes(id));
+    // «Så skal Melosys ha sendt brevet "Innhenting av inntektsopplysninger" ... til bruker»
+    // (scenario 1/3). Mottakerens ident står i samme DATA (fullmektig-substitusjon skjer FØR
+    // prosessinstansen lages). Godtar fnr ELLER aktørId — eksakt format pinnes ved første grønne.
+    const dataHarMottaker = mottakerIdentifikatorer.some((id) => (brev!.DATA || '').includes(id));
     expect(
         dataHarMottaker,
         `Brevet skal være adressert til bruker (en av ${mottakerIdentifikatorer.join(' / ')})`
@@ -170,6 +183,9 @@ test.describe('Automatisk innhentingsbrev ved årsavregning (MELOSYS-8122)', () 
         await opprettVedtattIkkeSkattepliktigSak(page);
 
         await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+
+        // Auto-utsending av innhentingsbrevet er bak toggle (default AV) — slå på før triggeren.
+        await unleash.enableFeature(TOGGLE_INNHENTINGSBREV);
 
         console.log(`📨 Sender skattehendelse for skatteår ${FORRIGE_AAR}...`);
         publishSkattehendelse({
@@ -198,6 +214,9 @@ test.describe('Automatisk innhentingsbrev ved årsavregning (MELOSYS-8122)', () 
         await opprettVedtattIkkeSkattepliktigSak(page);
 
         await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+
+        // Auto-utsending av innhentingsbrevet er bak toggle (default AV) — slå på før triggeren.
+        await unleash.enableFeature(TOGGLE_INNHENTINGSBREV);
 
         const periodeISO = TestPeriodsISO.previousYearPeriod;
         console.log(`⚙️ Kjører ikke-skattepliktige-jobben for ${periodeISO.start} - ${periodeISO.end}...`);

--- a/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
@@ -30,6 +30,14 @@ import {withDatabase} from '../../../helpers/db-helper';
  * 8122-auto-innhentingsbrev-arsavregning). Brevet scopes via prosessdata-flagget
  * SEND_INNHENTINGSBREV i de to auto-flytene — ingen dedikert brev-toggle (droppet etter
  * fagavklaring). Scenario 1+3 (mottaker=bruker) kjørbare; 2+4 (fullmektig) er test.fixme.
+ *
+ * KONSOLIDERING: Denne testen deler NØYAKTIG samme trigger-oppsett (sak→vedtak→skattehendelse/jobb)
+ * som MELOSYS-8123 (arsavregning-oppgave-aar-i-beskrivelse.spec.ts, oppgavebeskrivelse). Når begge
+ * sakene er på main kan de slås sammen til én «auto-årsavregning-trigger»-test som asserter både
+ * brev (8122) og oppgavebeskrivelse (8123) → fjerner ~90s duplisert oppsett. Holdt separate så lenge
+ * sakene er umergede (én Jira/AC per test + uavhengig image/PR-kobling).
+ *
+ * Tverr-repo flyt + fallgruver: melosys-kode-wiki/flows/aarsavregning-auto-innhentingsbrev.md
  */
 
 /** AktørId for USER_ID_VALID (30056928150) i PDL-mocken — brevets mottaker uten fullmektig */
@@ -134,6 +142,11 @@ async function verifiserInnhentingsbrevSendt(
 
     // Barn-prosessinstansen opprettes med STATUS=KLAR og plukkes asynkront av saga-workeren
     // (OPPRETT_OG_JOURNALFØR_BREV → DISTRIBUER_JOURNALPOST) før den blir FERDIG. Poll til FERDIG.
+    //
+    // DEBUG-HINT: Hvis denne henger på KLAR/aldri-FERDIG + api-loggen viser ORA-02291
+    // (FK_PIHEND_STEG) → det nye saksflyt-steget mangler rad i PROSESS_STEG-lookup (Flyway). Da blir
+    // også parent-prosessinstansen aldri FERDIG (notFinished i waitForProcessInstances). Se
+    // melosys-kode-wiki/flows/aarsavregning-auto-innhentingsbrev.md.
     let brev: BrevRad | undefined;
     await expect
         .poll(

--- a/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-automatisk.spec.ts
@@ -73,7 +73,9 @@ async function opprettVedtattIkkeSkattepliktigSak(page: Page): Promise<void> {
 
     await waitForProcessInstances(page.request, 30);
     await hovedside.goto();
-    await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).click();
+    // åpneBehandling laster saksoversikten på nytt med retry (finnBehandlingslenke) — robust mot
+    // async-lasting-racen der lenken ikke er synlig enda. Foretrekkes framfor direkte getByRole-klikk.
+    await hovedside.åpneBehandling('TRIVIELL KARAFFEL -');
 
     console.log(`📝 Medlemskap (${periode.start} - ${periode.end})...`);
     await medlemskap.velgPeriode(periode.start, periode.end);
@@ -108,6 +110,19 @@ async function opprettVedtattIkkeSkattepliktigSak(page: Page): Promise<void> {
 }
 
 /**
+ * DB-klokka rett nå (SYSDATE). Fanges rett FØR en trigger fyres og sendes til
+ * verifiserInnhentingsbrevSendt som «tidligst registrert»-grense, slik at brev-søket kun matcher
+ * prosessinstanser denne triggeren faktisk laget. Bruker DB-tid (ikke testverts-tid) for å unngå
+ * klokkeskew mot Oracle.
+ */
+async function hentDbTidspunkt(): Promise<Date> {
+    return await withDatabase(async (db) => {
+        const rad = await db.queryOne<{NAA: Date}>('SELECT SYSDATE AS NAA FROM DUAL');
+        return rad!.NAA;
+    });
+}
+
+/**
  * Binder «Så»-linjene: poller PROSESSINSTANS til en fersk brev-prosessinstans for
  * innhentingsbrevet finnes, og verifiserer at den er FERDIG og adressert til forventet mottaker.
  *
@@ -118,9 +133,14 @@ async function opprettVedtattIkkeSkattepliktigSak(page: Page): Promise<void> {
  *   uavklart om brevets DATA lagrer fnr eller aktørId for mottakeren (feature ikke implementert
  *   ennå) — assertionen godtar derfor at minst én av dem står i DATA. Eksakt identifikator pinnes
  *   når feature-branchen lander.
+ * @param siden DB-tidspunkt fanget rett før triggeren (hentDbTidspunkt). Brev-søket avgrenses til
+ *   prosessinstanser registrert >= dette, så testen aldri kan bli falsk-grønn på et brev fra en
+ *   tidligere test/trigger (begge tester lager samme brevmal for samme bruker → ellers umulig å
+ *   skille på innhold). Hardere enn det gamle «siste 10 minutter»-vinduet.
  */
 async function verifiserInnhentingsbrevSendt(
-    mottakerIdentifikatorer: string[]
+    mottakerIdentifikatorer: string[],
+    siden: Date
 ): Promise<void> {
     type BrevRad = {DATA: string; STATUS: string; PROSESS_TYPE: string};
 
@@ -130,16 +150,17 @@ async function verifiserInnhentingsbrevSendt(
     // "INNHENTING_AV_INNTEKTSOPPLYSNINGER" + den oppløste mottakerens ident.
     const hentInnhentingsbrev = async (): Promise<BrevRad | undefined> =>
         await withDatabase(async (db) => {
-            // ORDER BY DESC → .find() treffer den NYESTE matchende brev-prosessinstansen, ikke en
-            // vilkårlig rad. Gjør matchingen deterministisk og foretrekker dette testens ferske brev
-            // framfor en evt. sen innkommende rad fra forrige test (cleanup kjører før, ikke etter).
+            // Avgrens til prosessinstanser registrert >= triggertidspunktet (siden) → ekskluderer en
+            // evt. sen innkommende rad fra forrige test (cleanup kjører før, ikke etter, og begge
+            // tester lager samme brevmal for samme bruker). ORDER BY DESC + .find() treffer den
+            // NYESTE matchende brev-prosessinstansen, så matchingen er deterministisk.
             const rader = await db.query<BrevRad>(
                 `SELECT PI.DATA, PI.STATUS, PI.PROSESS_TYPE
                  FROM PROSESSINSTANS PI
                  WHERE PI.PROSESS_TYPE = 'OPPRETT_OG_DISTRIBUER_BREV'
-                   AND PI.REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE
+                   AND PI.REGISTRERT_DATO >= :siden
                  ORDER BY PI.REGISTRERT_DATO DESC`,
-                {}
+                {siden}
             );
             return rader.find((r) => (r.DATA || '').includes(BREVMAL_INNHENTING));
         });
@@ -195,6 +216,8 @@ test.describe('Automatisk innhentingsbrev ved årsavregning (MELOSYS-8122)', () 
 
         await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
 
+        // Fang DB-tid FØR triggeren → brev-søket matcher kun brev denne skattehendelsen laget.
+        const triggerTidspunkt = await hentDbTidspunkt();
         console.log(`📨 Sender skattehendelse for skatteår ${FORRIGE_AAR}...`);
         publishSkattehendelse({
             gjelderPeriode: String(FORRIGE_AAR),
@@ -202,7 +225,7 @@ test.describe('Automatisk innhentingsbrev ved årsavregning (MELOSYS-8122)', () 
             hendelsetype: 'NY',
         });
 
-        await verifiserInnhentingsbrevSendt([USER_ID_VALID, AKTOER_ID_VALID]);
+        await verifiserInnhentingsbrevSendt([USER_ID_VALID, AKTOER_ID_VALID], triggerTidspunkt);
         await waitForProcessInstances(page.request, 30);
     });
 
@@ -224,12 +247,14 @@ test.describe('Automatisk innhentingsbrev ved årsavregning (MELOSYS-8122)', () 
         await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
 
         const periodeISO = TestPeriodsISO.previousYearPeriod;
+        // Fang DB-tid FØR jobben kjøres → brev-søket matcher kun brev denne jobben laget.
+        const triggerTidspunkt = await hentDbTidspunkt();
         console.log(`⚙️ Kjører ikke-skattepliktige-jobben for ${periodeISO.start} - ${periodeISO.end}...`);
         await adminApi.finnIkkeSkattepliktigeSaker(request, periodeISO.start, periodeISO.end, true);
         const jobbStatus = await adminApi.waitForIkkeSkattepliktigeSakerJob(request, 60, 1000);
         expect(jobbStatus.antallProsessert, 'Jobben skal prosessere saken').toBe(1);
 
-        await verifiserInnhentingsbrevSendt([USER_ID_VALID, AKTOER_ID_VALID]);
+        await verifiserInnhentingsbrevSendt([USER_ID_VALID, AKTOER_ID_VALID], triggerTidspunkt);
         await waitForProcessInstances(page.request, 30);
     });
 


### PR DESCRIPTION
Legger til E2E-test som verifiserer at brevet «Innhenting av inntektsopplysninger» sendes automatisk når en årsavregningsbehandling auto-opprettes — for begge auto-triggere (Kafka-skattehendelse for skattepliktige, og admin-jobben for ikke-skattepliktige).

Brevet er brev-søsknen til MELOSYS-8123 og deler samme auto-årsavregning-trigger. Testen asserterer at en `OPPRETT_OG_DISTRIBUER_BREV`-prosessinstans med brevmal `INNHENTING_AV_INNTEKTSOPPLYSNINGER` blir FERDIG og er adressert til bruker.
[MELOSYS-8122](https://jira.adeo.no/browse/MELOSYS-8122)

- Scenario 1 (skattehendelse) + 3 (ikke-skattepliktig-jobb): kjørbare, mottaker=bruker
- Scenario 2 + 4 (fullmektig): `test.fixme` — ingen e2e-fullmakt-fikstur ennå (oppsett-sti dokumentert i speken)
- Spec + teknisk binding: `specs/aarsavregning-innhentingsbrev-automatisk.md`

## Testing
- [x] E2E-tester (CI grønt mot api-feature-image: run 27355995739 + 27358334278, 2 passed / 2 fixme)
- [ ] Manuell testing lokalt

## Notater
- **Stacked på `e2e/melosys-8123-aar-i-oppgavebeskrivelse`** — deler `helpers/skattehendelse-helper.ts`. Diffen mot main viser derfor også 8123-commitene til 8123 er merget; da rydder den seg selv.
- **Krever api-feature MELOSYS-8122** (melosys-api draft-PR #3387, branch `8122-auto-innhentingsbrev-arsavregning`). Brev-assertionene er røde uten dette imaget — derfor draft til både 8123 og api-featuren er på main.