### PR TITLE
NOJIRA P1 flak-reduksjon: eksplisitte venter + retries=1

### DIFF
--- a/pages/behandling/resultat-periode.page.ts
+++ b/pages/behandling/resultat-periode.page.ts
@@ -28,6 +28,23 @@ export class ResultatPeriodePage extends BasePage {
   }
 
   /**
+   * Wait for the Perioder (Resultat) step to finish rendering after the
+   * previous step's transition.
+   *
+   * Replaces fixed `waitForTimeout(3000)` sleeps that callers used after
+   * `lovvalg.klikkBekreftOgFortsett()`. The real signal is that the first
+   * "Resultat periode" dropdown has rendered — wait for that instead of a
+   * guess. If the step never transitioned, this surfaces the real failure
+   * (a visible-timeout) instead of silently continuing.
+   */
+  async ventPåSideLastet(): Promise<void> {
+    await this.page
+      .getByLabel('Resultat periode 1')
+      .waitFor({ state: 'visible', timeout: 15000 });
+    console.log('✅ Resultat periode-steget lastet');
+  }
+
+  /**
    * Get all resultat dropdowns on the page
    * Some trygdedekning values (like FTRL_2_9_FØRSTE_LEDD_C_HELSE_PENSJON) create
    * multiple periods that each need a result selected

--- a/pages/trygdeavgift/trygdeavgift.page.ts
+++ b/pages/trygdeavgift/trygdeavgift.page.ts
@@ -97,6 +97,40 @@ export class TrygdeavgiftPage extends BasePage {
   }
 
   /**
+   * Wait for the form's debounced auto-save (PUT /trygdeavgift/beregning) to
+   * fire and complete after a field mutation in a multi-row scenario.
+   *
+   * Replaces fixed `waitForTimeout(800)` "pauses" between indexed field edits.
+   * The flake those sleeps masked: a debounced PUT's response resets the form
+   * (resetSkatteforholdsperioder/resetInntektskilder), wiping any field that
+   * was mutated but not yet persisted. Waiting for the PUT to COMPLETE before
+   * the next mutation guarantees we edit on top of settled state — on a loaded
+   * CI an 800ms sleep was not always enough for the PUT round-trip.
+   *
+   * MUST be called immediately after the synchronous mutation returns: the form
+   * has a ~500ms debounce, so registering the listener now reliably catches the
+   * upcoming PUT (it cannot have fired yet). If a particular mutation produces
+   * no PUT (e.g. adding an empty row), it falls back to a networkidle settle so
+   * the caller never hangs.
+   */
+  async ventPåAutolagring(): Promise<void> {
+    const put = await this.page.waitForResponse(
+      response =>
+        isTrygdeavgiftBeregningResponse(response) &&
+        response.request().method() === 'PUT',
+      { timeout: 2500 },
+    ).catch(() => null);
+
+    if (put) {
+      console.log('✅ Autolagring PUT /trygdeavgift/beregning fullført');
+      // Let React apply the PUT response (form-reset) before the next mutation.
+      await this.page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
+    }
+    // No PUT (e.g. an empty row was just added) → the 2.5s window already settled
+    // and there is no form-reset to wait for, so skip the extra networkidle.
+  }
+
+  /**
    * Select Skattepliktig (tax liable) status
    *
    * IMPORTANT: This method waits for the debounced PUT API call to complete.

--- a/pages/trygdeavgift/trygdeavgift.page.ts
+++ b/pages/trygdeavgift/trygdeavgift.page.ts
@@ -124,7 +124,12 @@ export class TrygdeavgiftPage extends BasePage {
     if (put) {
       console.log('✅ Autolagring PUT /trygdeavgift/beregning fullført');
       // Let React apply the PUT response (form-reset) before the next mutation.
-      await this.page.waitForLoadState('networkidle', { timeout: 2000 }).catch(() => {});
+      // Generous margin: on a loaded CI the reset can trail the response by a
+      // beat, and the next indexed mutation must not race a still-applying reset
+      // (it would silently wipe the field we are about to edit). networkidle
+      // resolves instantly when already quiet, so this only costs time on a
+      // genuinely busy network.
+      await this.page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
     }
     // No PUT (e.g. an empty row was just added) → the 2.5s window already settled
     // and there is no form-reset to wait for, so skip the extra networkidle.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,8 +25,13 @@ export default defineConfig({
   grep: process.env.MANUAL_TESTS ? /@manual/ : undefined,
   grepInvert: process.env.MANUAL_TESTS ? undefined : /@manual/,
   
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  /* Retry on CI only.
+   * P1 flak-reduksjon: senket fra 2 → 1 for å avdekke reelle flak tidligere.
+   * retries=2 maskerte flak; med de eksplisitte ventene på plass skal én
+   * grønn kjøring nå være til å stole på. Akseptansebar = 20+ påfølgende
+   * grønne kjøringer på main med retries=1 (krever løpende overvåking).
+   * Egen commit — kan reverteres uavhengig hvis flak fortsatt dukker opp. */
+  retries: process.env.CI ? 1 : 0,
 
   /* Always run tests sequentially - one worker only */
   workers: 1,

--- a/tests/ftrl/ftrl-trygdeavgift-25-prosent-regel.spec.ts
+++ b/tests/ftrl/ftrl-trygdeavgift-25-prosent-regel.spec.ts
@@ -94,7 +94,7 @@ test.describe('FTRL Trygdeavgift — 25%-regelen', () => {
     await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker nær tilknytning til');
     await lovvalg.klikkBekreftOgFortsett();
 
-    await page.waitForTimeout(3000);
+    await resultatPeriode.ventPåSideLastet();
     await resultatPeriode.fyllUtResultatPeriode('INNVILGET');
 
     const trygdeavgift = new TrygdeavgiftPage(page);
@@ -133,7 +133,7 @@ test.describe('FTRL Trygdeavgift — 25%-regelen', () => {
     await lovvalg.klikkBekreftOgFortsett();
 
     // Full dekning har én periode (ingen helse/pensjon-split)
-    await page.waitForTimeout(3000);
+    await resultatPeriode.ventPåSideLastet();
     await resultatPeriode.fyllUtResultatPeriode('INNVILGET');
 
     const trygdeavgift = new TrygdeavgiftPage(page);
@@ -319,7 +319,7 @@ test.describe('FTRL Trygdeavgift — 25%-regelen', () => {
     await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker nær tilknytning til');
     await lovvalg.klikkBekreftOgFortsett();
 
-    await page.waitForTimeout(3000);
+    await resultatPeriode.ventPåSideLastet();
     await resultatPeriode.fyllUtResultatPeriode('INNVILGET');
 
     // --- Trygdeavgift ---
@@ -327,9 +327,11 @@ test.describe('FTRL Trygdeavgift — 25%-regelen', () => {
     await trygdeavgift.ventPåSideLastet();
 
     // Skatteforhold 1: mai-okt skattepliktig (endre tom-dato fra default)
-    // Use human-like delays between operations to let React process state changes
-    // and avoid race conditions with the debounced save
-    const pause = () => page.waitForTimeout(800);
+    // Mellom hver felt-mutasjon må vi vente på at den debouncede auto-lagringen
+    // (PUT /trygdeavgift/beregning) er fullført — responsen nullstiller skjemaet,
+    // så en u-persistert mutasjon kan ellers bli overskrevet. Venter på selve
+    // PUT-en i stedet for en fast pause (mer robust på en lastet CI).
+    const pause = () => trygdeavgift.ventPåAutolagring();
 
     await trygdeavgift.fyllInnSkatteforholdDatoer(0, periodeStart, `31.10.${year}`);
     await pause();
@@ -423,8 +425,7 @@ test.describe('FTRL Trygdeavgift — 25%-regelen', () => {
     expect(apiData.inntekter).toBe(3);
 
     // Wait for any re-render debounced PUTs to complete before leaving the step.
-    await page.waitForTimeout(1500);
-    await page.waitForLoadState('networkidle');
+    await trygdeavgift.ventPåAutolagring();
 
     await trygdeavgift.klikkBekreftOgFortsett();
 
@@ -509,8 +510,8 @@ test.describe('FTRL Pensjonist — 25%-regelen', () => {
 
     // Perioder — default-verdier (Innvilget/Avslått/Innvilget) er gyldige for
     // pensjonist + helse/pensjon-dekning. Bare bekreft og gå videre.
-    await page.waitForTimeout(3000);
     const resultatPeriode = new ResultatPeriodePage(page);
+    await resultatPeriode.ventPåSideLastet();
     await resultatPeriode.klikkBekreftOgFortsett();
 
     const trygdeavgift = new TrygdeavgiftPage(page);

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-arbeidsinntekt-nv-kansellering.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-arbeidsinntekt-nv-kansellering.spec.ts
@@ -82,7 +82,7 @@ test.describe('Komplett saksflyt - Flere land med pensjon-dekning og NV-kanselle
 
         // Step 6: Resultat Periode
         console.log('Step 6: Setting resultat periode...');
-        await page.waitForTimeout(3000);
+        await resultatPeriode.ventPåSideLastet();
         await resultatPeriode.fyllUtResultatPeriode('INNVILGET');
 
         // Hent behandlingId fra URL

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-arbeidsinntekt.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-arbeidsinntekt.spec.ts
@@ -87,7 +87,7 @@ test.describe('Komplett saksflyt - Flere land med arbeidsinntekt', () => {
 
         // Step 6: Resultat Periode
         console.log('Step 6: Setting resultat periode...');
-        await page.waitForTimeout(3000);
+        await resultatPeriode.ventPåSideLastet();
         await resultatPeriode.fyllUtResultatPeriode('INNVILGET');
 
         // Step 7: Trygdeavgift - Ikke-skattepliktig med arbeidsinntekt fra Norge

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-nv-annulering-lukker-åpne-årsavregninger.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-nv-annulering-lukker-åpne-årsavregninger.spec.ts
@@ -87,7 +87,7 @@ test.describe('Komplett saksflyt - NV annulering lukker åpne årsavregninger', 
 
         // Step 6: Resultat Periode
         console.log('Step 6: Setting resultat periode...');
-        await page.waitForTimeout(3000);
+        await resultatPeriode.ventPåSideLastet();
         await resultatPeriode.fyllUtResultatPeriode('INNVILGET');
 
         // Step 7: Trygdeavgift - Ikke-skattepliktig med arbeidsinntekt fra Norge

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-nv-periode-endres-til-kun-tidligere-ar.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-nv-periode-endres-til-kun-tidligere-ar.spec.ts
@@ -88,7 +88,7 @@ test.describe('Komplett saksflyt - Flere land med arbeidsinntekt', () => {
 
         // Step 6: Resultat Periode
         console.log('Step 6: Setting resultat periode...');
-        await page.waitForTimeout(3000);
+        await resultatPeriode.ventPåSideLastet();
         await resultatPeriode.fyllUtResultatPeriode('INNVILGET');
 
         // Step 7: Trygdeavgift - Ikke-skattepliktig med arbeidsinntekt fra Norge

--- a/tests/utenfor-avtaleland/workflows/nyvurdering-endring-skattestatus.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/nyvurdering-endring-skattestatus.spec.ts
@@ -74,8 +74,8 @@ test.describe('Nyvurdering - Endring av skattestatus', () => {
         await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker nær tilknytning til');
         await lovvalg.klikkBekreftOgFortsett();
 
-        // Wait for Medlemskapsperioder page to load
-        await page.waitForTimeout(3000);
+        // Wait for Resultat periode-steget to render after the step transition
+        await resultatPeriode.ventPåSideLastet();
 
         // Log what the frontend API returns (for debugging)
         console.log('📊 Logging all frontend toggle states:');
@@ -208,8 +208,8 @@ test.describe('Nyvurdering - Endring av skattestatus', () => {
         await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker nær tilknytning til');
         await lovvalg.klikkBekreftOgFortsett();
 
-        // Wait for Medlemskapsperioder page to load
-        await page.waitForTimeout(3000);
+        // Wait for Resultat periode-steget to render after the step transition
+        await resultatPeriode.ventPåSideLastet();
 
         // Log what the frontend API returns (for debugging)
         console.log('📊 Logging all frontend toggle states:');


### PR DESCRIPTION
## P1 · Flak-reduksjon

Gjør én grønn kjøring pålitelig → steg mot å droppe `retries=2` (rask patch/release-kadens).
Bygger på P0 (#273, merget). Følger arbeidsplanen § «P1 · Flak-reduksjon».

### Hva
Erstatter de mest race-utsatte `waitForTimeout`-sleepsene med eksplisitte venter:

| Sted | Før | Etter |
|---|---|---|
| Etter stegovergang → Perioder-steget (6 spec-filer, 8 steder) | `waitForTimeout(3000)` | `ResultatPeriodePage.ventPaaSideLastet()` — venter på at «Resultat periode 1» er synlig |
| Mellom felt-mutasjoner i trygdeavgift Eksempel 1 (13 steder + 1×1500ms) | `waitForTimeout(800)` | `TrygdeavgiftPage.ventPaaAutolagring()` — venter på debouncet PUT `/trygdeavgift/beregning` |

To nye POM-metoder (venter ligger i POM, ikke inline i spec):
- **`ventPaaSideLastet()`** — surfacer en ekte feil hvis steget aldri lastet, i stedet for å fortsette stille på en gjetting.
- **`ventPaaAutolagring()`** — PUT-responsen nullstiller skjemaet, så en u-persistert mutasjon kunne ellers bli overskrevet (800ms holdt ikke alltid på lastet CI). Registrerer lytteren innenfor debounce-vinduet (~500ms); hopper over ekstra networkidle når ingen PUT fyres.

**Ingen nye `waitForTimeout(>=1000)` lagt til.** `npm run check:tests`-guardrailen (P0) er grønn.

### retries=1 (egen, revertibel commit `a214e76`)
Senker CI-retries 2 → 1 for å avdekke reelle flak tidligere. Egen commit slik at den kan reverteres uavhengig hvis suiten fortsatt flaker. Akseptansebaren (20+ påfølgende grønne på main) krever løpende overvåking — kan ikke bevises i én kjøring.

### Verifisert
- **Lokalt mot docker-stack:** FTRL 25%-regel 6/6, nyvurdering + flere-land 3/3 grønt. Eksempel 1 grønn også etter review-justering.
- **Fokuserte CI-stabilitetskjøringer** (`repeat_each=3`, `disable_retries=true`): Eksempel 1 + flere-land — resultat lenkes i tråden.
- **/code-review (high):** 7 vinkler. Korrekthetsfunn refutert (race/GET-first misforsto debounce-vindu hhv. waitForResponse-semantikk); én efficiency-justering anvendt (hopp over redundant networkidle på rader uten PUT).
- `tsc` rent for berørte filer (kun forhåndseksisterende oracledb-typefeil i db-helper gjenstår).