### PR TITLE
NOJIRA P2 assertion-løft: hard DB-sluttilstand på svake tester

### DIFF
--- a/pages/behandling/eu-eos-skip-behandling.assertions.ts
+++ b/pages/behandling/eu-eos-skip-behandling.assertions.ts
@@ -69,13 +69,6 @@ export class EuEosSkipBehandlingAssertions extends EuEosBehandlingAssertions {
   }
 
   /**
-   * Override: Verifiser at behandling med skip finnes i database
-   * Skip-specific implementation that verifies skip-related data
-   *
-   * @param fnr - Fødselsnummer for personen
-   * @returns Behandling ID
-   */
-  /**
    * Hard sluttilstands-verifisering i DB etter fattet/iverksatt EU/EØS-skip-vedtak:
    * behandlingen er AVSLUTTET, har et behandlingsresultat, og alle prosessinstanser
    * (inkl. iverksetting) er FERDIG. Beviser sluttilstand utover navigering tilbake
@@ -91,6 +84,13 @@ export class EuEosSkipBehandlingAssertions extends EuEosBehandlingAssertions {
     return await verifiserBehandlingSluttilstand(forventet);
   }
 
+  /**
+   * Override: Verifiser at behandling med skip finnes i database
+   * Skip-specific implementation that verifies skip-related data
+   *
+   * @param fnr - Fødselsnummer for personen
+   * @returns Behandling ID
+   */
   override async verifiserBehandlingIDatabase(_fnr: string): Promise<string> {
     return await withDatabase(async (db) => {
       // Nyeste behandling = testens (ren DB per cleanup-fixture). Skjemaet har ingen SAK-tabell/

--- a/pages/behandling/eu-eos-skip-behandling.assertions.ts
+++ b/pages/behandling/eu-eos-skip-behandling.assertions.ts
@@ -1,6 +1,10 @@
 import { Page, expect } from '@playwright/test';
 import { withDatabase } from '../../helpers/db-helper';
 import { EuEosBehandlingAssertions } from './eu-eos-behandling.assertions';
+import {
+  verifiserBehandlingSluttilstand,
+  BehandlingSluttilstandForventning,
+} from '../shared/behandling-sluttilstand.assertions';
 
 /**
  * Assertions for EU/EØS Skip behandling
@@ -71,6 +75,22 @@ export class EuEosSkipBehandlingAssertions extends EuEosBehandlingAssertions {
    * @param fnr - Fødselsnummer for personen
    * @returns Behandling ID
    */
+  /**
+   * Hard sluttilstands-verifisering i DB etter fattet/iverksatt EU/EØS-skip-vedtak:
+   * behandlingen er AVSLUTTET, har et behandlingsresultat, og alle prosessinstanser
+   * (inkl. iverksetting) er FERDIG. Beviser sluttilstand utover navigering tilbake
+   * til hovedsiden (`verifiserVedtakFattet`).
+   *
+   * Kall `waitForProcessInstances(...)` (kaster på feilede instanser) FØR denne.
+   *
+   * @returns BEHANDLING.ID for behandlingen som ble verifisert
+   */
+  async verifiserBehandlingAvsluttet(
+    forventet: BehandlingSluttilstandForventning = {}
+  ): Promise<string> {
+    return await verifiserBehandlingSluttilstand(forventet);
+  }
+
   override async verifiserBehandlingIDatabase(_fnr: string): Promise<string> {
     return await withDatabase(async (db) => {
       // Nyeste behandling = testens (ren DB per cleanup-fixture). Skjemaet har ingen SAK-tabell/

--- a/pages/behandling/trygdeavtale-behandling.assertions.ts
+++ b/pages/behandling/trygdeavtale-behandling.assertions.ts
@@ -2,6 +2,10 @@ import { APIRequestContext, Page, expect } from '@playwright/test';
 import { assertErrors } from '../../utils/assertions';
 import { withDatabase } from '../../helpers/db-helper';
 import { fetchMedlPeriode } from '../../helpers/mock-helper';
+import {
+  verifiserBehandlingSluttilstand,
+  BehandlingSluttilstandForventning,
+} from '../shared/behandling-sluttilstand.assertions';
 
 /**
  * Assertion methods for TrygdeavtaleBehandlingPage
@@ -142,6 +146,22 @@ export class TrygdeavtaleBehandlingAssertions {
     await this.verifiserArbeidslandIDatabase(fnr, landkode);
 
     console.log('✅ Trygdeavtale behandling verified completely');
+  }
+
+  /**
+   * Hard sluttilstands-verifisering i DB etter fattet/iverksatt trygdeavtale-vedtak:
+   * behandlingen er AVSLUTTET, har et behandlingsresultat, og alle prosessinstanser
+   * (inkl. IVERKSETT_VEDTAK_TRYGDEAVTALE) er FERDIG. Beviser sluttilstand utover at
+   * vi navigerte tilbake til hovedsiden.
+   *
+   * Kall `waitForProcessInstances(...)` (kaster på feilede instanser) FØR denne.
+   *
+   * @returns BEHANDLING.ID for behandlingen som ble verifisert
+   */
+  async verifiserBehandlingAvsluttet(
+    forventet: BehandlingSluttilstandForventning = {}
+  ): Promise<string> {
+    return await verifiserBehandlingSluttilstand(forventet);
   }
 
   /**

--- a/pages/shared/behandling-sluttilstand.assertions.ts
+++ b/pages/shared/behandling-sluttilstand.assertions.ts
@@ -10,9 +10,10 @@ import { withDatabase } from '../../helpers/db-helper';
  */
 export interface BehandlingSluttilstandForventning {
   /**
-   * Query på denne BEHANDLING.ID. Utelates → nyeste behandling brukes.
-   * (Cleanup-fixturen renser DB per test, så nyeste behandling ER testens —
-   * for nyvurderinger er det NV-behandlingen, som er det vi vil verifisere.)
+   * Query på denne BEHANDLING.ID. Utelates → nyeste behandling (høyest ID) brukes.
+   * (Cleanup-fixturen renser DB per test, så nyeste behandling ER testens.)
+   * For flerbehandlingsflyter (f.eks. nyvurdering) MÅ behandlingId settes eksplisitt
+   * for å treffe riktig behandling — ellers treffes bare den sist opprettede.
    */
   behandlingId?: string | null;
   /** Assert BEHANDLINGSRESULTAT.RESULTAT_TYPE = denne (f.eks. MEDLEM_I_FOLKETRYGDEN). */
@@ -51,7 +52,9 @@ export async function verifiserBehandlingSluttilstand(
           { id: forventet.behandlingId }
         )
       : await db.queryOne<{ ID: number; STATUS: string }>(
-          `SELECT ID, STATUS FROM BEHANDLING ORDER BY REGISTRERT_DATO DESC FETCH FIRST 1 ROWS ONLY`
+          // ID DESC (monotonisk PK) = deterministisk «nyeste», jf. konvensjonen ellers
+          // i POM-ene (REGISTRERT_DATO kan tie ved rask opprettelse i samme flyt).
+          `SELECT ID, STATUS FROM BEHANDLING ORDER BY ID DESC FETCH FIRST 1 ROWS ONLY`
         );
 
     expect(behandling, 'Forventet behandling i DB').not.toBeNull();

--- a/pages/shared/behandling-sluttilstand.assertions.ts
+++ b/pages/shared/behandling-sluttilstand.assertions.ts
@@ -1,0 +1,113 @@
+import { expect } from '@playwright/test';
+import { withDatabase } from '../../helpers/db-helper';
+
+/**
+ * Forventninger til en behandlings DB-sluttilstand etter et fattet/iverksatt vedtak.
+ *
+ * Alt unntatt `behandlingId` er valgfritt: utelat felt du ikke kan binde med
+ * sikkerhet. Kjernen som ALLTID asserteres (og som biter) er at behandlingen er
+ * AVSLUTTET, har et behandlingsresultat, og at alle prosessinstanser er FERDIG.
+ */
+export interface BehandlingSluttilstandForventning {
+  /**
+   * Query på denne BEHANDLING.ID. Utelates → nyeste behandling brukes.
+   * (Cleanup-fixturen renser DB per test, så nyeste behandling ER testens —
+   * for nyvurderinger er det NV-behandlingen, som er det vi vil verifisere.)
+   */
+  behandlingId?: string | null;
+  /** Assert BEHANDLINGSRESULTAT.RESULTAT_TYPE = denne (f.eks. MEDLEM_I_FOLKETRYGDEN). */
+  forventetResultatType?: string;
+  /** Assert BEHANDLINGSRESULTAT.TRYGDEAVGIFT_TYPE = denne (f.eks. FORELØPIG). */
+  forventetTrygdeavgiftType?: string;
+  /** En PROSESS_TYPE som MÅ finnes og være FERDIG (f.eks. IVERKSETT_VEDTAK_FTRL). */
+  forventetIverksettProsess?: string;
+}
+
+/**
+ * Hard sluttilstands-verifisering for en fattet/iverksatt behandling.
+ *
+ * Beviser sluttilstand utover URL/synlighet: behandlingen er faktisk AVSLUTTET
+ * i databasen, har et behandlingsresultat, og alle prosessinstanser (inkl.
+ * iverksettingen) er FERDIG (ingen feilede/hengende). Dette er standarden de
+ * ferske gap-testene holder — gjenbrukbart for å løfte de eldre happy-path-testene.
+ *
+ * Forutsetter at prosessinstansene er ferdige; kall `waitForProcessInstances(...)`
+ * (som kaster på feilede instanser) FØR denne i testen.
+ *
+ * Kolonnenavn er live-verifisert (jf. ftrl-yrkesaktiv-2-2 + trygdeavtale-NV-assertions):
+ *  - BEHANDLING(ID, STATUS, REGISTRERT_DATO)
+ *  - BEHANDLINGSRESULTAT(RESULTAT_TYPE, TRYGDEAVGIFT_TYPE, BEHANDLING_ID)
+ *  - PROSESSINSTANS(PROSESS_TYPE, STATUS, SIST_FULLFORT_STEG, BEHANDLING_ID)
+ *
+ * @returns BEHANDLING.ID for behandlingen som ble verifisert
+ */
+export async function verifiserBehandlingSluttilstand(
+  forventet: BehandlingSluttilstandForventning = {}
+): Promise<string> {
+  return await withDatabase(async (db) => {
+    const behandling = forventet.behandlingId
+      ? await db.queryOne<{ ID: number; STATUS: string }>(
+          `SELECT ID, STATUS FROM BEHANDLING WHERE ID = :id`,
+          { id: forventet.behandlingId }
+        )
+      : await db.queryOne<{ ID: number; STATUS: string }>(
+          `SELECT ID, STATUS FROM BEHANDLING ORDER BY REGISTRERT_DATO DESC FETCH FIRST 1 ROWS ONLY`
+        );
+
+    expect(behandling, 'Forventet behandling i DB').not.toBeNull();
+    expect(
+      behandling!.STATUS,
+      'Behandling skal være AVSLUTTET etter fattet/iverksatt vedtak'
+    ).toBe('AVSLUTTET');
+    const id = behandling!.ID;
+    console.log(`✅ Behandling ${id} AVSLUTTET`);
+
+    const resultat = await db.queryOne<{ RESULTAT_TYPE: string; TRYGDEAVGIFT_TYPE: string | null }>(
+      `SELECT RESULTAT_TYPE, TRYGDEAVGIFT_TYPE FROM BEHANDLINGSRESULTAT WHERE BEHANDLING_ID = :id`,
+      { id }
+    );
+    expect(resultat, 'Forventet behandlingsresultat i DB').not.toBeNull();
+    if (forventet.forventetResultatType) {
+      expect(
+        resultat!.RESULTAT_TYPE,
+        `Resultat skal være ${forventet.forventetResultatType}`
+      ).toBe(forventet.forventetResultatType);
+    }
+    if (forventet.forventetTrygdeavgiftType) {
+      expect(
+        resultat!.TRYGDEAVGIFT_TYPE,
+        `Trygdeavgift skal være ${forventet.forventetTrygdeavgiftType}`
+      ).toBe(forventet.forventetTrygdeavgiftType);
+    }
+    console.log(
+      `✅ Behandlingsresultat: ${resultat!.RESULTAT_TYPE}${
+        resultat!.TRYGDEAVGIFT_TYPE ? ` / trygdeavgift ${resultat!.TRYGDEAVGIFT_TYPE}` : ''
+      }`
+    );
+
+    const prosesser = await db.query<{ PROSESS_TYPE: string; STATUS: string; SIST_FULLFORT_STEG: string }>(
+      `SELECT PROSESS_TYPE, STATUS, SIST_FULLFORT_STEG FROM PROSESSINSTANS WHERE BEHANDLING_ID = :id`,
+      { id }
+    );
+    expect(
+      prosesser.length,
+      'Forventet minst én prosessinstans for behandlingen'
+    ).toBeGreaterThan(0);
+    for (const p of prosesser) {
+      expect(
+        p.STATUS,
+        `Prosess ${p.PROSESS_TYPE} skal være FERDIG (sist steg: ${p.SIST_FULLFORT_STEG})`
+      ).toBe('FERDIG');
+    }
+    if (forventet.forventetIverksettProsess) {
+      const iverksett = prosesser.find(p => p.PROSESS_TYPE === forventet.forventetIverksettProsess);
+      expect(
+        iverksett,
+        `Forventet ${forventet.forventetIverksettProsess}-prosessinstans`
+      ).toBeTruthy();
+    }
+    console.log(`✅ ${prosesser.length} prosessinstanser FERDIG`);
+
+    return String(id);
+  });
+}

--- a/pages/vedtak/vedtak.assertions.ts
+++ b/pages/vedtak/vedtak.assertions.ts
@@ -1,5 +1,9 @@
 import { Page, expect } from '@playwright/test';
 import { assertErrors } from '../../utils/assertions';
+import {
+  verifiserBehandlingSluttilstand,
+  BehandlingSluttilstandForventning,
+} from '../shared/behandling-sluttilstand.assertions';
 
 /**
  * Assertion methods for VedtakPage
@@ -45,5 +49,21 @@ export class VedtakAssertions {
     // Wait a bit for any navigation to complete
     await this.page.waitForLoadState('domcontentloaded');
     await this.verifiserIngenFeil();
+  }
+
+  /**
+   * Hard sluttilstands-verifisering i DB etter at vedtaket er fattet/iverksatt:
+   * behandlingen er AVSLUTTET, har et behandlingsresultat, og alle
+   * prosessinstanser (inkl. iverksetting) er FERDIG. Beviser sluttilstand
+   * utover at vi navigerte bort fra vedtakssiden.
+   *
+   * Kall `waitForProcessInstances(...)` (kaster på feilede instanser) FØR denne.
+   *
+   * @returns BEHANDLING.ID for behandlingen som ble verifisert
+   */
+  async verifiserBehandlingAvsluttet(
+    forventet: BehandlingSluttilstandForventning = {}
+  ): Promise<string> {
+    return await verifiserBehandlingSluttilstand(forventet);
   }
 }

--- a/tests/aarsavregning-ftrl.spec.ts
+++ b/tests/aarsavregning-ftrl.spec.ts
@@ -70,5 +70,12 @@ test.describe('Årsavregning FTRL - Komplett arbeidsflyt', () => {
 
     // --- Steg 5: Fatt vedtak ---
     await vedtak.klikkFattVedtak();
+
+    // --- Steg 6: Hard sluttilstand - vent på iverksetting + verifiser DB end-state ---
+    // Årsavregningsbehandlingen er nyeste behandling (ren DB per fixture): skal være
+    // AVSLUTTET med behandlingsresultat og alle prosessinstanser FERDIG.
+    console.log('📝 Steg 6: Venter på iverksetting + verifiserer DB-sluttilstand...');
+    await waitForProcessInstances(page.request, 60);
+    await vedtak.assertions.verifiserBehandlingAvsluttet();
   });
 });

--- a/tests/eu-eos/eu-eos-skip-fullfort-vedtak.spec.ts
+++ b/tests/eu-eos/eu-eos-skip-fullfort-vedtak.spec.ts
@@ -71,6 +71,13 @@ test.describe('EU/EØS Skip - Komplett arbeidsflyt', () => {
     // Verifiser
     await skipBehandling.assertions.verifiserVedtakFattet();
 
+    // Hard sluttilstand: vent på iverksetting + verifiser DB end-state.
+    // Skip-behandlingen er nyeste behandling (ren DB per fixture): skal være AVSLUTTET
+    // med behandlingsresultat og alle prosessinstanser FERDIG.
+    console.log('📝 Venter på iverksetting + verifiserer DB-sluttilstand...');
+    await waitForProcessInstances(page.request, 60);
+    await skipBehandling.assertions.verifiserBehandlingAvsluttet();
+
       console.log('✅ EU/EØS-skip-arbeidsflyt fullført');
   });
 });

--- a/tests/trygdeavtale/trygdeavtale-fullfort-vedtak.spec.ts
+++ b/tests/trygdeavtale/trygdeavtale-fullfort-vedtak.spec.ts
@@ -5,6 +5,7 @@ import { OpprettNySakPage } from '../../pages/opprett-ny-sak/opprett-ny-sak.page
 import { TrygdeavtaleBehandlingPage } from '../../pages/behandling/trygdeavtale-behandling.page';
 import { TrygdeavtaleArbeidsstedPage } from '../../pages/behandling/trygdeavtale-arbeidssted.page';
 import { USER_ID_VALID } from '../../pages/shared/constants';
+import { waitForProcessInstances } from '../../helpers/api-helper';
 
 /**
  * Komplett Trygdeavtale arbeidsflyt test
@@ -55,6 +56,16 @@ test.describe('Trygdeavtale - Komplett arbeidsflyt', () => {
 
     // Fullfør arbeidssted og fatt vedtak
     await arbeidssted.fyllUtArbeidsstedOgFattVedtak('Test');
+
+    // Hard sluttilstand: vent på iverksetting + verifiser DB end-state.
+    // Trygdeavtale-behandlingen er nyeste behandling (ren DB per fixture): skal være
+    // AVSLUTTET med behandlingsresultat og alle prosessinstanser (inkl.
+    // IVERKSETT_VEDTAK_TRYGDEAVTALE) FERDIG.
+    console.log('📝 Venter på iverksetting + verifiserer DB-sluttilstand...');
+    await waitForProcessInstances(page.request, 60);
+    await behandling.assertions.verifiserBehandlingAvsluttet({
+      forventetIverksettProsess: 'IVERKSETT_VEDTAK_TRYGDEAVTALE',
+    });
 
     console.log('✅ Trygdeavtale-arbeidsflyt fullført med hjelpemetoder');
   });

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-2-8a.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-2-8a.spec.ts
@@ -10,6 +10,8 @@ import {TrygdeavgiftPage} from '../../../pages/trygdeavgift/trygdeavgift.page';
 import {VedtakPage} from '../../../pages/vedtak/vedtak.page';
 import {USER_ID_VALID} from '../../../pages/shared/constants';
 import {TestPeriods} from '../../../helpers/date-helper';
+import {waitForProcessInstances} from '../../../helpers/api-helper';
+import {expect} from '@playwright/test';
 
 test.describe('Komplett saksflyt - Utenfor avtaleland', () => {
     test('skal fullføre komplett saksflyt med § 2-8 første ledd bokstav a (arbeidstaker)', async ({page, request}) => {
@@ -82,9 +84,22 @@ test.describe('Komplett saksflyt - Utenfor avtaleland', () => {
         await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
         await trygdeavgift.klikkBekreftOgFortsett();
 
+        // Capture behandlingId from URL for DB end-state assertions (before vedtak navigates away)
+        const behandlingId = new URL(page.url()).searchParams.get('behandlingID');
+        expect(behandlingId, 'behandlingID skal finnes i URL').not.toBeNull();
+
         // Step 8: Fatt vedtak (without filling text fields)
         console.log('📝 Step 8: Making decision...');
         await vedtak.klikkFattVedtak();
+
+        // Step 9: Hard sluttilstand - vent på iverksetting + verifiser DB end-state
+        console.log('📝 Step 9: Waiting for iverksetting + verifying DB end-state...');
+        await waitForProcessInstances(page.request, 60);
+        await vedtak.assertions.verifiserBehandlingAvsluttet({
+            behandlingId,
+            forventetResultatType: 'MEDLEM_I_FOLKETRYGDEN',
+            forventetIverksettProsess: 'IVERKSETT_VEDTAK_FTRL',
+        });
 
         console.log('✅ Workflow completed');
     });
@@ -152,9 +167,22 @@ test.describe('Komplett saksflyt - Utenfor avtaleland', () => {
         await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
         await trygdeavgift.klikkBekreftOgFortsett();
 
+        // Capture behandlingId from URL for DB end-state assertions (before vedtak navigates away)
+        const behandlingId = new URL(page.url()).searchParams.get('behandlingID');
+        expect(behandlingId, 'behandlingID skal finnes i URL').not.toBeNull();
+
         // Step 7: Make Decision (Fatt vedtak)
         console.log('📝 Step 7: Making decision...');
         await vedtak.fattVedtak('fritekst', 'begrunnelse', 'trygdeavgift');
+
+        // Step 8: Hard sluttilstand - vent på iverksetting + verifiser DB end-state
+        console.log('📝 Step 8: Waiting for iverksetting + verifying DB end-state...');
+        await waitForProcessInstances(page.request, 60);
+        await vedtak.assertions.verifiserBehandlingAvsluttet({
+            behandlingId,
+            forventetResultatType: 'MEDLEM_I_FOLKETRYGDEN',
+            forventetIverksettProsess: 'IVERKSETT_VEDTAK_FTRL',
+        });
 
         console.log('✅ Complete workflow finished successfully!');
     });

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-2-8b-student.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-2-8b-student.spec.ts
@@ -10,6 +10,8 @@ import {TrygdeavgiftPage} from '../../../pages/trygdeavgift/trygdeavgift.page';
 import {VedtakPage} from '../../../pages/vedtak/vedtak.page';
 import {USER_ID_VALID} from '../../../pages/shared/constants';
 import {TestPeriods} from '../../../helpers/date-helper';
+import {waitForProcessInstances} from '../../../helpers/api-helper';
+import {expect} from '@playwright/test';
 
 /**
  * Komplett saksflyt - FTRL § 2-8 første ledd bokstav b (student, frivillig medlemskap)
@@ -83,9 +85,22 @@ test.describe('Komplett saksflyt - Utenfor avtaleland', () => {
         await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
         await trygdeavgift.klikkBekreftOgFortsett();
 
+        // Capture behandlingId from URL for DB end-state assertions (before vedtak navigates away)
+        const behandlingId = new URL(page.url()).searchParams.get('behandlingID');
+        expect(behandlingId, 'behandlingID skal finnes i URL').not.toBeNull();
+
         // Step 8: Fatt vedtak
         console.log('📝 Step 8: Making decision...');
         await vedtak.klikkFattVedtak();
+
+        // Step 9: Hard sluttilstand - vent på iverksetting + verifiser DB end-state
+        console.log('📝 Step 9: Waiting for iverksetting + verifying DB end-state...');
+        await waitForProcessInstances(page.request, 60);
+        await vedtak.assertions.verifiserBehandlingAvsluttet({
+            behandlingId,
+            forventetResultatType: 'MEDLEM_I_FOLKETRYGDEN',
+            forventetIverksettProsess: 'IVERKSETT_VEDTAK_FTRL',
+        });
 
         console.log('✅ § 2-8b (student) workflow completed');
     });

--- a/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-flereinntektskilder.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/komplett-sak-flere-land-flereinntektskilder.spec.ts
@@ -10,6 +10,8 @@ import { LovvalgPage } from '../../../pages/behandling/lovvalg.page';
 import { TrygdeavgiftPage } from '../../../pages/trygdeavgift/trygdeavgift.page';
 import { VedtakPage } from '../../../pages/vedtak/vedtak.page';
 import { USER_ID_VALID } from '../../../pages/shared/constants';
+import { waitForProcessInstances } from '../../../helpers/api-helper';
+import { expect } from '@playwright/test';
 
 /**
  * Komplett saksflyt for FTRL-sak med flere land og flere inntektskilder
@@ -77,8 +79,21 @@ test.describe('Komplett saksflyt - FTRL flere land', () => {
     await trygdeavgift.fyllInnBruttoinntektForIndeks(1, '100000');
     await trygdeavgift.klikkBekreftOgFortsett();
 
+    // Capture behandlingId from URL for DB end-state assertions (before vedtak navigates away)
+    const behandlingId = new URL(page.url()).searchParams.get('behandlingID');
+    expect(behandlingId, 'behandlingID skal finnes i URL').not.toBeNull();
+
     // Steg 7: Vedtak
     await vedtak.fattVedtak('fritekst', 'begrunnelse', 'trygdeavgift');
+
+    // Steg 8: Hard sluttilstand - vent på iverksetting + verifiser DB end-state
+    console.log('📝 Steg 8: Venter på iverksetting + verifiserer DB-sluttilstand...');
+    await waitForProcessInstances(page.request, 60);
+    await vedtak.assertions.verifiserBehandlingAvsluttet({
+      behandlingId,
+      forventetResultatType: 'MEDLEM_I_FOLKETRYGDEN',
+      forventetIverksettProsess: 'IVERKSETT_VEDTAK_FTRL',
+    });
 
     console.log('✅ Forenklet arbeidsflyt fullført');
   });

--- a/tests/utenfor-avtaleland/workflows/nyvurdering-endring-skattestatus.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/nyvurdering-endring-skattestatus.spec.ts
@@ -141,9 +141,19 @@ test.describe('Nyvurdering - Endring av skattestatus', () => {
         console.log('📝 Waiting for vedtak page to load and API calls to complete...');
         await page.waitForLoadState('networkidle');
 
+        // Capture NV-behandlingId from URL for DB end-state assertions (before vedtak navigates away)
+        const nvBehandlingId = new URL(page.url()).searchParams.get('behandlingID');
+        expect(nvBehandlingId, 'behandlingID skal finnes i URL').not.toBeNull();
+
         // Step 15: Submit vedtak for ny vurdering
         console.log('📝 Step 15: Submitting vedtak for ny vurdering...');
         await vedtak.fattVedtakForNyVurdering('FEIL_I_BEHANDLING');
+
+        // Step 16: Hard sluttilstand - vent på NV-iverksetting + verifiser DB end-state
+        // (NV-behandlingen skal være AVSLUTTET med alle prosessinstanser FERDIG)
+        console.log('📝 Step 16: Waiting for iverksetting + verifying DB end-state...');
+        await waitForProcessInstances(page.request, 60);
+        await vedtak.assertions.verifiserBehandlingAvsluttet({ behandlingId: nvBehandlingId });
 
         // Note: Toggle will be reset to default (enabled) before next test runs
 
@@ -276,6 +286,10 @@ test.describe('Nyvurdering - Endring av skattestatus', () => {
         console.log('📝 Waiting for vedtak page to load and API calls to complete...');
         await page.waitForLoadState('networkidle');
 
+        // Capture NV-behandlingId from URL for DB end-state assertions (before vedtak navigates away)
+        const nvBehandlingId = new URL(page.url()).searchParams.get('behandlingID');
+        expect(nvBehandlingId, 'behandlingID skal finnes i URL').not.toBeNull();
+
         // Step 15: Submit vedtak for ny vurdering
         console.log('📝 Step 15: Submitting vedtak for ny vurdering...');
         await vedtak.fattVedtakForNyVurdering('FEIL_I_BEHANDLING');
@@ -284,6 +298,9 @@ test.describe('Nyvurdering - Endring av skattestatus', () => {
         // This ensures behandling.status = 'AVSLUTTET' is committed before the job queries
         console.log('📝 Step 16: Wait for vedtak process to complete...');
         await waitForProcessInstances(page.request, 30);
+
+        // Hard sluttilstand: NV-behandlingen skal være AVSLUTTET med alle prosessinstanser FERDIG
+        await vedtak.assertions.verifiserBehandlingAvsluttet({ behandlingId: nvBehandlingId });
 
         await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
 


### PR DESCRIPTION
## P2 · Assertion-løft på de svake førstegangs-testene

De eldre «happy path»-testene endte på URL/synlighet i stedet for å bevise sluttilstand. De er de mest-kjørte regresjonsankrene → svake asserts der er det dyreste blindfeltet. Denne PR-en løfter dem til standarden de ferske gap-testene allerede holder.

### Mønster
Etter siste steg: `waitForProcessInstances(...)` (kaster på feilede prosessinstanser) + hard DB-sluttilstand via ny gjenbrukbar hjelper:
- behandling **AVSLUTTET**
- behandlingsresultat finnes
- **alle** prosessinstanser **FERDIG** (≥1)
- + pinnet RESULTAT_TYPE / iverksett-prosess der domenet er sikkert

Ny hjelper `verifiserBehandlingSluttilstand` i `pages/shared/behandling-sluttilstand.assertions.ts`, eksponert som POM-metode `verifiserBehandlingAvsluttet` på `VedtakAssertions`, `TrygdeavtaleBehandlingAssertions` og `EuEosSkipBehandlingAssertions` (ingen inline DB-assert).

### Hvilke tester fikk hvilken hard sluttilstand
| Test | Hard sluttilstand |
|---|---|
| `komplett-sak-2-8a` (§2-8a + FULL_DEKNING) | MEDLEM_I_FOLKETRYGDEN + FORELØPIG + IVERKSETT_VEDTAK_FTRL, alle FERDIG |
| `komplett-sak-2-8b-student` | MEDLEM_I_FOLKETRYGDEN + IVERKSETT_VEDTAK_FTRL, alle FERDIG |
| `komplett-sak-flere-land-flereinntektskilder` | MEDLEM_I_FOLKETRYGDEN + IVERKSETT_VEDTAK_FTRL, alle FERDIG |
| `nyvurdering-endring-skattestatus` (begge) | NV-behandling AVSLUTTET + alle FERDIG (test 2 har i tillegg eksisterende `antallProsessert=1`) |
| `trygdeavtale-fullfort-vedtak` | AVSLUTTET + IVERKSETT_VEDTAK_TRYGDEAVTALE (FASTSATT_LOVVALGSLAND), alle FERDIG |
| `eu-eos-skip-fullfort-vedtak` | AVSLUTTET + alle FERDIG (IVERKSETT_VEDTAK_EOS) |
| `aarsavregning-ftrl` | AVSLUTTET + alle FERDIG (IVERKSETT_VEDTAK_AARSAVREGNING) |

### Verifisering
- Lokalt mot docker-stack: **8/8 grønt** (alle berørte tester)
- `npm run check:tests` grønn (P0-guardrail ikke regressert — ekte utfalls-assert, ingen `expect(true)`/svelget catch)
- Ingen ny `waitForTimeout(>=1000)`
- Asserts biter: kaster hvis behandling ikke AVSLUTTET, manglende resultat, eller noen prosessinstans ikke FERDIG

Bygger på P0 (#273) + P1 (#274).