### PR TITLE
NOJIRA P3: assert vedtaksbrev-innhold per mottakertype

### DIFF
--- a/helpers/mock-helper.ts
+++ b/helpers/mock-helper.ts
@@ -209,6 +209,101 @@ export async function findNewUtgaaendeJournalpost(
 }
 
 /**
+ * A single document on a journalpost (mirrors DokumentModell in melosys-mock).
+ *
+ * The `brevkode` carries the dokgen mal-name (e.g. 'innvilgelse_ftrl',
+ * 'trygdeavtale_au') — i.e. the actual brev-variant produced for the recipient.
+ * `tittel` is the journalføringstittel set by DokumentNavnService.
+ */
+export interface BrevDokumentInfo {
+  brevkode: string | null;
+  tittel: string | null;
+  dokumentTilknyttetJournalpost: string | null;
+}
+
+/**
+ * A vedtaksbrev as journalført to the SAF/Joark mock, reduced to the fields
+ * that carry brev-innhold per mottakertype: the recipient (avsenderMottaker)
+ * and the HOVEDDOKUMENT (brevkode/tittel).
+ */
+export interface VedtaksbrevJournalpost {
+  journalpostId: string;
+  journalposttype: string | null;
+  journalStatus: string | null;
+  avsenderMottaker: { id?: string; type?: string; navn?: string; land?: string };
+  hoveddokument: BrevDokumentInfo;
+}
+
+/**
+ * Poll the SAF mock for an UTGAAENDE vedtaksbrev-journalpost addressed to a
+ * specific recipient (fnr). Returns the journalpost reduced to its HOVEDDOKUMENT
+ * so a test can assert the brev-variant (brevkode) and tittel per mottakertype.
+ *
+ * Used to verify dokgen-brevinnhold end-to-end: a FTRL §2-8-vedtak must produce
+ * brevkode 'innvilgelse_ftrl', a trygdeavtale-vedtak 'trygdeavtale_<land>' osv.
+ * Filtering on the recipient fnr means each flow's brev is found unambiguously
+ * even when several saker (for ulike personer) coexist in the same test.
+ *
+ * @param request    - Playwright APIRequestContext
+ * @param mottakerFnr - The recipient's fnr (avsenderMottaker.id)
+ * @param timeoutMs  - Max polling time (default: 30s)
+ */
+export async function finnVedtaksbrevForMottaker(
+  request: APIRequestContext,
+  mottakerFnr: string,
+  timeoutMs = 30000
+): Promise<VedtaksbrevJournalpost | null> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const response = await request.get('http://localhost:8083/testdata/verification/journalpost');
+    if (!response.ok()) {
+      throw new Error(`Failed to fetch journalposter: ${response.status()}`);
+    }
+    const journalposter = (await response.json()) as Array<{
+      journalpostId: string;
+      journalposttype: string | null;
+      journalStatus: string | null;
+      avsenderMottaker?: { id?: string; type?: string; navn?: string; land?: string };
+      dokumentModellList?: Array<{
+        brevkode: string | null;
+        tittel: string | null;
+        dokumentTilknyttetJournalpost: string | null;
+      }>;
+    }>;
+
+    const match = journalposter.find((jp) => {
+      if (jp.journalposttype !== 'UTGAAENDE') return false;
+      if (jp.avsenderMottaker?.id !== mottakerFnr) return false;
+      const hoved = (jp.dokumentModellList ?? []).find(
+        (d) => d.dokumentTilknyttetJournalpost === 'HOVEDDOKUMENT' && d.brevkode
+      );
+      return hoved != null;
+    });
+
+    if (match) {
+      const hoved = (match.dokumentModellList ?? []).find(
+        (d) => d.dokumentTilknyttetJournalpost === 'HOVEDDOKUMENT' && d.brevkode
+      )!;
+      return {
+        journalpostId: match.journalpostId,
+        journalposttype: match.journalposttype,
+        journalStatus: match.journalStatus,
+        avsenderMottaker: match.avsenderMottaker ?? {},
+        hoveddokument: {
+          brevkode: hoved.brevkode,
+          tittel: hoved.tittel,
+          dokumentTilknyttetJournalpost: hoved.dokumentTilknyttetJournalpost,
+        },
+      };
+    }
+    console.log(`⏳ Venter på vedtaksbrev-journalpost for mottaker ${mottakerFnr}...`);
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  return null;
+}
+
+/**
  * A MEDL membership-exception period stored in the melosys-mock MEDL register.
  * Mirrors MedlemskapsunntakForGet in melosys-mock.
  *

--- a/pages/shared/vedtaksbrev.assertions.ts
+++ b/pages/shared/vedtaksbrev.assertions.ts
@@ -1,0 +1,66 @@
+import { APIRequestContext, expect } from '@playwright/test';
+import {
+  finnVedtaksbrevForMottaker,
+  VedtaksbrevJournalpost,
+} from '../../helpers/mock-helper';
+
+/**
+ * Forventet vedtaksbrev for én mottakertype.
+ *
+ * Brevvarianten identifiseres av `brevkode` (dokgen-mal) — denne avhenger av
+ * sakstype/land/person (jf. bug-klyngen 6950 / 7128 / 6759, land-/person-
+ * spesifikke vedtaksbrev). `tittel` er journalføringstittelen.
+ */
+export interface VedtaksbrevForventning {
+  /** Mottakerens fnr (avsenderMottaker.id på journalposten) */
+  mottakerFnr: string;
+  /** Forventet dokgen-mal (HOVEDDOKUMENT.brevkode), f.eks. 'innvilgelse_ftrl' */
+  forventetBrevkode: string;
+  /** Forventet journalføringstittel, f.eks. 'Vedtak om frivillig medlemskap' */
+  forventetTittel: string;
+}
+
+/**
+ * Verifiser at det er produsert ett korrekt vedtaksbrev for en gitt mottaker:
+ * riktig brev-VARIANT (brevkode/dokgen-mal) og tittel, journalført som
+ * ferdigstilt (J) UTGAAENDE journalpost til riktig person.
+ *
+ * Asserter brev-INNHOLD per mottakertype — ikke bare at «et brev ble laget».
+ * brevkode/tittel sjekkes med eksakt likhet, slik at en regresjon der feil
+ * brevmal sendes for en sakstype/land slår testen RØD.
+ *
+ * @returns Den funne journalposten (for kryss-assertion av distinkthet i testen).
+ */
+export async function verifiserVedtaksbrev(
+  request: APIRequestContext,
+  forventning: VedtaksbrevForventning
+): Promise<VedtaksbrevJournalpost> {
+  const brev = await finnVedtaksbrevForMottaker(request, forventning.mottakerFnr);
+
+  expect(
+    brev,
+    `Forventet et vedtaksbrev journalført til mottaker ${forventning.mottakerFnr}`
+  ).not.toBeNull();
+
+  expect(brev!.journalposttype, 'Vedtaksbrev skal være UTGAAENDE').toBe('UTGAAENDE');
+  expect(brev!.journalStatus, 'Vedtaksbrev skal være ferdigstilt (J)').toBe('J');
+  expect(brev!.avsenderMottaker.id, 'Brev skal være adressert til riktig person').toBe(
+    forventning.mottakerFnr
+  );
+  expect(brev!.avsenderMottaker.type, 'Mottaker skal være en person (FNR)').toBe('FNR');
+
+  expect(
+    brev!.hoveddokument.brevkode,
+    `Brev-variant (dokgen-mal) skal være korrekt for mottakertypen`
+  ).toBe(forventning.forventetBrevkode);
+  expect(
+    brev!.hoveddokument.tittel,
+    `Journalføringstittel skal matche brev-varianten`
+  ).toBe(forventning.forventetTittel);
+
+  console.log(
+    `✅ Vedtaksbrev verifisert: brevkode='${brev!.hoveddokument.brevkode}', ` +
+      `tittel='${brev!.hoveddokument.tittel}', mottaker=${brev!.avsenderMottaker.id}`
+  );
+  return brev!;
+}

--- a/tests/core/vedtaksbrev-mottakertype.spec.ts
+++ b/tests/core/vedtaksbrev-mottakertype.spec.ts
@@ -143,6 +143,12 @@ test.describe('Vedtaksbrev-innhold per mottakertype', () => {
     await opprettSak.assertions.verifiserBehandlingOpprettet();
     await hovedside.åpneBehandling(`${PERSON_NAME_KOSOVO} -`);
 
+    // Flerbehandlingsflyt: FTRL- og trygdeavtale-behandlingen sameksisterer i denne
+    // testen, så behandlingId MÅ pinnes eksplisitt (ellers velger sluttilstands-
+    // asserten nyeste behandling via ORDER BY ID DESC — jf. P2-guidens advarsel).
+    const trygdeavtaleBehandlingId = new URL(page.url()).searchParams.get('behandlingID');
+    expect(trygdeavtaleBehandlingId, 'behandlingID skal finnes i URL').not.toBeNull();
+
     await trygdeavtaleBehandling.fyllUtPeriodeOgLand('01.01.2024', '01.01.2026', ARBEIDSLAND.AUSTRALIA);
     await trygdeavtaleBehandling.velgArbeidsgiverOgFortsett('Ståles Stål AS');
     await trygdeavtaleBehandling.innvilgeOgVelgBestemmelse(BESTEMMELSER.AUS_ART9_3);
@@ -151,6 +157,7 @@ test.describe('Vedtaksbrev-innhold per mottakertype', () => {
     console.log('📝 Venter på iverksetting (trygdeavtale)...');
     await waitForProcessInstances(page.request, 60);
     await trygdeavtaleBehandling.assertions.verifiserBehandlingAvsluttet({
+      behandlingId: trygdeavtaleBehandlingId,
       forventetIverksettProsess: 'IVERKSETT_VEDTAK_TRYGDEAVTALE',
     });
 

--- a/tests/core/vedtaksbrev-mottakertype.spec.ts
+++ b/tests/core/vedtaksbrev-mottakertype.spec.ts
@@ -1,0 +1,180 @@
+import { test, expect } from '../../fixtures';
+import { AuthHelper } from '../../helpers/auth-helper';
+import { HovedsidePage } from '../../pages/hovedside.page';
+import { OpprettNySakPage } from '../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import { MedlemskapPage } from '../../pages/behandling/medlemskap.page';
+import { ArbeidsforholdPage } from '../../pages/behandling/arbeidsforhold.page';
+import { LovvalgPage } from '../../pages/behandling/lovvalg.page';
+import { ResultatPeriodePage } from '../../pages/behandling/resultat-periode.page';
+import { TrygdeavgiftPage } from '../../pages/trygdeavgift/trygdeavgift.page';
+import { VedtakPage } from '../../pages/vedtak/vedtak.page';
+import { TrygdeavtaleBehandlingPage } from '../../pages/behandling/trygdeavtale-behandling.page';
+import { TrygdeavtaleArbeidsstedPage } from '../../pages/behandling/trygdeavtale-arbeidssted.page';
+import { verifiserVedtaksbrev } from '../../pages/shared/vedtaksbrev.assertions';
+import {
+  USER_ID_VALID,
+  USER_ID_KOSOVO,
+  BRUKERNAVN_VALID,
+  PERSON_NAME_KOSOVO,
+  SAKSTYPER,
+  SAKSTEMA,
+  BEHANDLINGSTEMA,
+  AARSAK,
+  ARBEIDSLAND,
+  BESTEMMELSER,
+} from '../../pages/shared/constants';
+import { TestPeriods } from '../../helpers/date-helper';
+import { waitForProcessInstances } from '../../helpers/api-helper';
+
+/**
+ * Vedtaksbrev-innhold per mottakertype (dokgen) — P3-dekningshull.
+ *
+ * I dag dekkes dokgen kun INDIREKTE (papir-A1 / anmodning / innhentingsbrev) —
+ * ingen test asserterer faktisk BREVINNHOLD per mottakertype. Bug-klyngen
+ * 6950 / 7128 / 6759 (land-/person-spesifikke vedtaksbrev) sitter nettopp her.
+ *
+ * Denne testen fatter to vedtak for to ULIKE personer/sakstyper og asserterer at
+ * HVER produserer KORREKT, DISTINKT vedtaksbrev — ikke bare at «et brev ble laget»:
+ *
+ *   1. FTRL § 2-8 frivillig medlemskap (person A) → brevmal `innvilgelse_ftrl`,
+ *      tittel «Vedtak om frivillig medlemskap».
+ *   2. Trygdeavtale Australia (person B)          → brevmal `trygdeavtale_au`,
+ *      tittel «Vedtak om medlemskap, Attest for medlemskap i folketrygden».
+ *
+ * Brevet observeres som UTGAAENDE journalpost i SAF-mocken: `HOVEDDOKUMENT.brevkode`
+ * = dokgen-malen (selve brev-VARIANTEN), `tittel` = journalføringstittelen,
+ * `avsenderMottaker` = mottakeren. Brevkoden mappes fra Produserbaredokumenter i
+ * melosys-api (DokumentproduksjonsInfoMapper) — distinkt per sakstype/land/person.
+ *
+ * Asserten BITER: sendes feil brevmal for en sakstype (en 6950/7128/6759-klasse
+ * regresjon) slår eksakt-match-asserten testen rød. Kryss-asserten nederst beviser
+ * at de to mottakertypene faktisk får ULIKE brev.
+ */
+const FTRL_BREVKODE = 'innvilgelse_ftrl';
+const FTRL_TITTEL = 'Vedtak om frivillig medlemskap';
+const TRYGDEAVTALE_BREVKODE = 'trygdeavtale_au';
+const TRYGDEAVTALE_TITTEL = 'Vedtak om medlemskap, Attest for medlemskap i folketrygden';
+
+test.describe('Vedtaksbrev-innhold per mottakertype', () => {
+  test('skal produsere korrekt, distinkt vedtaksbrev for FTRL- og trygdeavtale-mottaker', async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(300000);
+
+    const auth = new AuthHelper(page);
+    await auth.login();
+
+    const hovedside = new HovedsidePage(page);
+    const opprettSak = new OpprettNySakPage(page);
+
+    // =====================================================================
+    // Mottakertype 1: FTRL § 2-8 første ledd a (frivillig medlemskap), person A
+    // =====================================================================
+    console.log('📨 Mottakertype 1: FTRL § 2-8 frivillig medlemskap');
+    const medlemskap = new MedlemskapPage(page);
+    const arbeidsforhold = new ArbeidsforholdPage(page);
+    const lovvalg = new LovvalgPage(page);
+    const resultatPeriode = new ResultatPeriodePage(page);
+    const trygdeavgift = new TrygdeavgiftPage(page);
+    const vedtak = new VedtakPage(page);
+
+    await hovedside.gotoOgOpprettNySak();
+    await opprettSak.opprettStandardSak(USER_ID_VALID);
+    await opprettSak.assertions.verifiserBehandlingOpprettet();
+    await hovedside.åpneBehandling(`${BRUKERNAVN_VALID} -`);
+
+    const period = TestPeriods.standardPeriod;
+    await medlemskap.velgPeriode(period.start, period.end);
+    await medlemskap.velgLand('Afghanistan');
+    await medlemskap.velgTrygdedekning('FTRL_2_9_FØRSTE_LEDD_C_HELSE_PENSJON');
+    await medlemskap.klikkBekreftOgFortsett();
+
+    await arbeidsforhold.fyllUtArbeidsforhold('Ståles Stål AS');
+
+    await lovvalg.velgBestemmelse('FTRL_KAP2_2_8_FØRSTE_LEDD_A');
+    await lovvalg.svarJaPaaFørsteSpørsmål();
+    await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker vært medlem i minst');
+    await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker nær tilknytning til');
+    await lovvalg.klikkBekreftOgFortsett();
+
+    await resultatPeriode.fyllUtResultatPeriode('INNVILGET');
+
+    await trygdeavgift.ventPåSideLastet();
+    await trygdeavgift.velgSkattepliktig(false);
+    await trygdeavgift.velgInntektskilde('INNTEKT_FRA_UTLANDET');
+    await trygdeavgift.velgBetalesAga(false);
+    await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
+    await trygdeavgift.klikkBekreftOgFortsett();
+
+    const ftrlBehandlingId = new URL(page.url()).searchParams.get('behandlingID');
+    expect(ftrlBehandlingId, 'behandlingID skal finnes i URL').not.toBeNull();
+
+    await vedtak.klikkFattVedtak();
+    console.log('📝 Venter på iverksetting (FTRL)...');
+    await waitForProcessInstances(page.request, 60);
+    await vedtak.assertions.verifiserBehandlingAvsluttet({
+      behandlingId: ftrlBehandlingId,
+      forventetResultatType: 'MEDLEM_I_FOLKETRYGDEN',
+      forventetIverksettProsess: 'IVERKSETT_VEDTAK_FTRL',
+    });
+
+    const ftrlBrev = await verifiserVedtaksbrev(request, {
+      mottakerFnr: USER_ID_VALID,
+      forventetBrevkode: FTRL_BREVKODE,
+      forventetTittel: FTRL_TITTEL,
+    });
+
+    // =====================================================================
+    // Mottakertype 2: Trygdeavtale Australia (bilateral avtale), person B
+    // =====================================================================
+    console.log('📨 Mottakertype 2: Trygdeavtale Australia');
+    const trygdeavtaleBehandling = new TrygdeavtaleBehandlingPage(page);
+    const arbeidssted = new TrygdeavtaleArbeidsstedPage(page);
+
+    await hovedside.gotoOgOpprettNySak();
+    await opprettSak.fyllInnBrukerID(USER_ID_KOSOVO);
+    await opprettSak.velgSakstype(SAKSTYPER.TRYGDEAVTALE);
+    await opprettSak.velgSakstema(SAKSTEMA.MEDLEMSKAP_LOVVALG);
+    await opprettSak.velgBehandlingstema(BEHANDLINGSTEMA.YRKESAKTIV);
+    await opprettSak.velgAarsak(AARSAK.SØKNAD);
+    await opprettSak.leggBehandlingIMine();
+    await opprettSak.klikkOpprettNyBehandling();
+    await opprettSak.assertions.verifiserBehandlingOpprettet();
+    await hovedside.åpneBehandling(`${PERSON_NAME_KOSOVO} -`);
+
+    await trygdeavtaleBehandling.fyllUtPeriodeOgLand('01.01.2024', '01.01.2026', ARBEIDSLAND.AUSTRALIA);
+    await trygdeavtaleBehandling.velgArbeidsgiverOgFortsett('Ståles Stål AS');
+    await trygdeavtaleBehandling.innvilgeOgVelgBestemmelse(BESTEMMELSER.AUS_ART9_3);
+    await arbeidssted.fyllUtArbeidsstedOgFattVedtak('Test');
+
+    console.log('📝 Venter på iverksetting (trygdeavtale)...');
+    await waitForProcessInstances(page.request, 60);
+    await trygdeavtaleBehandling.assertions.verifiserBehandlingAvsluttet({
+      forventetIverksettProsess: 'IVERKSETT_VEDTAK_TRYGDEAVTALE',
+    });
+
+    const trygdeavtaleBrev = await verifiserVedtaksbrev(request, {
+      mottakerFnr: USER_ID_KOSOVO,
+      forventetBrevkode: TRYGDEAVTALE_BREVKODE,
+      forventetTittel: TRYGDEAVTALE_TITTEL,
+    });
+
+    // =====================================================================
+    // Kryss-assertion: de to mottakertypene fikk DISTINKTE vedtaksbrev
+    // =====================================================================
+    expect(
+      ftrlBrev.hoveddokument.brevkode,
+      'FTRL- og trygdeavtale-vedtak skal produsere ULIKE brevmaler (land-/person-spesifikt)'
+    ).not.toBe(trygdeavtaleBrev.hoveddokument.brevkode);
+    expect(
+      ftrlBrev.hoveddokument.tittel,
+      'De to brevvariantene skal ha ulik journalføringstittel'
+    ).not.toBe(trygdeavtaleBrev.hoveddokument.tittel);
+
+    console.log(
+      `✅ Distinkte vedtaksbrev per mottakertype: '${ftrlBrev.hoveddokument.brevkode}' vs ` +
+        `'${trygdeavtaleBrev.hoveddokument.brevkode}'`
+    );
+  });
+});


### PR DESCRIPTION
## P3 — det ene reelle dekningshullet: vedtaksbrev/dokgen-innhold per mottakertype

Siste post i E2E-kvalitetsarbeidsplanen (etter P0 #273, P1 #274, P2 #275).

### Hvorfor
dokgen ble før kun dekket **indirekte** (papir-A1 / anmodning / 8122-innhentingsbrev) — **ingen** test asserterte faktisk brevinnhold per mottakertype. Bug-klyngen **6950 / 7128 / 6759** (land-/person-spesifikke vedtaksbrev) sitter nettopp her.

### Hva
Én ny e2e fatter to vedtak for to **ulike personer/sakstyper** og asserterer at hver produserer **korrekt, distinkt** vedtaksbrev — ikke bare at *et* brev ble laget:

| Mottakertype | Brevmal (dokgen) | Journalføringstittel |
|---|---|---|
| FTRL § 2-8 frivillig (person A) | `innvilgelse_ftrl` | Vedtak om frivillig medlemskap |
| Trygdeavtale Australia (person B) | `trygdeavtale_au` | Vedtak om medlemskap, Attest for medlemskap i folketrygden |

Brevet observeres som UTGAAENDE journalpost i SAF-mocken: `HOVEDDOKUMENT.brevkode` = dokgen-malen (selve brev-**varianten**), `tittel` = journalføringstittelen, `avsenderMottaker` = mottakeren. Brevkoden mappes fra `Produserbaredokumenter` i melosys-api (`DokumentproduksjonsInfoMapper`) — distinkt per sakstype/land/person.

### Hvorfor asserten biter
- Eksakt-match (`.toBe`) på `brevkode` **og** `tittel` per mottaker → feil brevmal for en sakstype (en 6950/7128/6759-klasse regresjon) slår testen rød.
- Kryss-assert nederst beviser at de to mottakertypene faktisk får **ulike** brev.
- **Rød-bevis kjørt lokalt:** med feil forventet brevkode feiler asserten (`Expected: "trygdeavtale_au", Received: "innvilgelse_ftrl"`).

### Filer
- `helpers/mock-helper.ts` — `finnVedtaksbrevForMottaker` + `VedtaksbrevJournalpost` (poller SAF-mocken på mottaker-fnr, returnerer HOVEDDOKUMENT)
- `pages/shared/vedtaksbrev.assertions.ts` — gjenbrukbar `verifiserVedtaksbrev`
- `tests/core/vedtaksbrev-mottakertype.spec.ts` — ny test (begge flyter gjenbruker P2-herdet `verifiserBehandlingAvsluttet`)

### Verifisering
- Lokalt grønt mot docker-stacken (1 passed, 56s)
- `npm run check:tests` grønn (ingen vacuous/tautologi)
- tsc rent for nye filer