### PR TITLE
E2E-gap: inngående A003 annet land utpekt → REGISTRERT_UNNTAK

### DIFF
--- a/pages/behandling/eu-eos-utpeking.assertions.ts
+++ b/pages/behandling/eu-eos-utpeking.assertions.ts
@@ -113,4 +113,79 @@ export class EuEosUtpekingAssertions {
     expect(medl.status, 'MEDL-periode skal være uavklart (UAVK) ved foreløpig lovvalgsbeslutning').toBe('UAVK');
     console.log(`✅ MEDL-periode ${medlPeriodeId}: medlem=true, NOR, foreløpig (FORL/UAVK)`);
   }
+
+  /**
+   * Verifiser at en godkjent «annet land utpekt»-utpeking (BESLUTNING_LOVVALG_ANNET_LAND)
+   * ble iverksatt som et REGISTRERT_UNNTAK:
+   *  - behandlingsresultat: RESULTAT_TYPE REGISTRERT_UNNTAK, utfall_registrering_unntak GODKJENT
+   *  - lovvalgsperiode: peker på det ANDRE landet (f.eks. SE), art.13(1)(a), INNVILGET,
+   *    medlemskapstype UNNTATT (personen er unntatt norsk trygd), knyttet til en MEDL-periode
+   *  - REGISTRERING_UNNTAK_GODKJENN fullført uten feilede prosessinstanser
+   *  - MEDL-periode opprettet i registeret med det andre landet som lovvalgsland
+   *    (3-bokstavskode, f.eks. SWE), foreløpig lovvalg (FORL) + uavklart status (UAVK) —
+   *    speiler at behandlingen ender som MIDLERTIDIG_LOVVALGSBESLUTNING (ikke AVSLUTTET)
+   *
+   * Live-verifisert 2026-06-14 (behandling 101, lovvalgsland SE → MEDL SWE).
+   *
+   * @param request - Playwright APIRequestContext (for MEDL-mock-oppslag)
+   * @param opts.lovvalgsland     - Forventet lovvalgsland i lovvalg_periode (2-bokstav, default 'SE')
+   * @param opts.medlLovvalgsland - Forventet lovvalgsland i MEDL-registeret (3-bokstav, default 'SWE')
+   */
+  async verifiserRegistrertUnntakIverksatt(
+    request: APIRequestContext,
+    opts: { lovvalgsland?: string; medlLovvalgsland?: string } = {}
+  ): Promise<void> {
+    const lovvalgsland = opts.lovvalgsland ?? 'SE';
+    const medlLovvalgsland = opts.medlLovvalgsland ?? 'SWE';
+
+    // Databasen renses før hver test (cleanup-fixture), så «nyeste rad» = denne testens behandling.
+    const medlPeriodeId = await withDatabase(async (db) => {
+      // === Behandlingsresultat: registrert unntak, godkjent ===
+      const br = await db.queryOne<{ RESULTAT_TYPE: string; UTFALL_REGISTRERING_UNNTAK: string }>(
+        `SELECT resultat_type, utfall_registrering_unntak FROM behandlingsresultat
+         ORDER BY behandling_id DESC FETCH FIRST 1 ROWS ONLY`, {});
+      expect(br, 'Forventet et behandlingsresultat').not.toBeNull();
+      expect(br!.RESULTAT_TYPE, 'Resultattype skal være REGISTRERT_UNNTAK').toBe('REGISTRERT_UNNTAK');
+      expect(br!.UTFALL_REGISTRERING_UNNTAK, 'Utfall registrering unntak skal være GODKJENT').toBe('GODKJENT');
+      console.log('✅ Behandlingsresultat: REGISTRERT_UNNTAK / utfall GODKJENT');
+
+      // === Lovvalgsperiode: annet land, art.13(1)(a), innvilget, UNNTATT, knyttet til MEDL ===
+      const lp = await db.queryOne<{
+        LOVVALGSLAND: string; LOVVALG_BESTEMMELSE: string; INNVILGELSE_RESULTAT: string;
+        MEDLEMSKAPSTYPE: string; MEDLPERIODE_ID: number;
+      }>(
+        `SELECT lovvalgsland, lovvalg_bestemmelse, innvilgelse_resultat, medlemskapstype, medlperiode_id
+         FROM lovvalg_periode ORDER BY id DESC FETCH FIRST 1 ROWS ONLY`, {});
+      expect(lp, 'Forventet en lovvalgsperiode').not.toBeNull();
+      expect(lp!.LOVVALGSLAND, `Lovvalgsperioden skal peke på det andre landet (${lovvalgsland})`).toBe(lovvalgsland);
+      expect(lp!.LOVVALG_BESTEMMELSE, 'Lovvalgsbestemmelse skal være art.13(1)(a)').toBe('FO_883_2004_ART13_1A');
+      expect(lp!.INNVILGELSE_RESULTAT, 'Lovvalgsperioden skal være INNVILGET').toBe('INNVILGET');
+      expect(lp!.MEDLEMSKAPSTYPE, 'Medlemskapstype skal være UNNTATT (unntatt norsk trygd)').toBe('UNNTATT');
+      expect(lp!.MEDLPERIODE_ID, 'Lovvalgsperioden skal være knyttet til en MEDL-periode').toBeTruthy();
+      console.log(`✅ Lovvalgsperiode: ${lovvalgsland} / art.13(1)(a) / INNVILGET / UNNTATT / MEDL-periode ${lp!.MEDLPERIODE_ID}`);
+
+      // === REGISTRERING_UNNTAK_GODKJENN fullført, ingen feilede prosessinstanser ===
+      const feilede = await db.query<{ PROSESS_TYPE: string }>(
+        `SELECT prosess_type FROM prosessinstans WHERE status = 'FEILET'`, {});
+      expect(feilede, `Forventet ingen feilede prosessinstanser, fant: ${JSON.stringify(feilede)}`).toHaveLength(0);
+
+      const godkjenn = await db.queryOne<{ STATUS: string }>(
+        `SELECT status FROM prosessinstans WHERE prosess_type = 'REGISTRERING_UNNTAK_GODKJENN'
+         ORDER BY registrert_dato DESC FETCH FIRST 1 ROWS ONLY`, {});
+      expect(godkjenn, 'Forventet en REGISTRERING_UNNTAK_GODKJENN-prosessinstans').not.toBeNull();
+      expect(godkjenn!.STATUS, 'REGISTRERING_UNNTAK_GODKJENN skal være FERDIG').toBe('FERDIG');
+      console.log('✅ REGISTRERING_UNNTAK_GODKJENN FERDIG, ingen feilede prosessinstanser');
+
+      return lp!.MEDLPERIODE_ID;
+    });
+
+    // === MEDL-periode i registeret: lovvalg overført til det andre landet ===
+    const medl = await fetchMedlPeriode(request, medlPeriodeId);
+    expect(medl.medlem, 'MEDL-periode skal markere personen som medlem').toBe(true);
+    expect(medl.lovvalgsland, `MEDL-periode skal ha det andre landet som lovvalgsland (${medlLovvalgsland})`).toBe(medlLovvalgsland);
+    // Foreløpig lovvalg (FORL) + uavklart status (UAVK) speiler MIDLERTIDIG_LOVVALGSBESLUTNING.
+    expect(medl.lovvalg, 'MEDL-periode skal ha foreløpig lovvalg (FORL)').toBe('FORL');
+    expect(medl.status, 'MEDL-periode skal være uavklart (UAVK) ved foreløpig lovvalgsbeslutning').toBe('UAVK');
+    console.log(`✅ MEDL-periode ${medlPeriodeId}: medlem=true, ${medlLovvalgsland}, foreløpig (FORL/UAVK)`);
+  }
 }

--- a/pages/behandling/eu-eos-utpeking.page.ts
+++ b/pages/behandling/eu-eos-utpeking.page.ts
@@ -183,9 +183,11 @@ export class EuEosUtpekingPage extends BasePage {
     await this.godkjennUtpekingHeading.waitFor({ state: 'visible', timeout: 30000 });
 
     if (opts?.varsleUtland) {
+      await this.sendA012Checkbox.waitFor({ state: 'visible', timeout: 15000 });
       await this.sendA012Checkbox.check();
     }
     if (opts?.fritekst) {
+      await this.ytterligereInfoField.waitFor({ state: 'visible', timeout: 15000 });
       await this.ytterligereInfoField.click();
       await this.ytterligereInfoField.fill(opts.fritekst);
       await this.ytterligereInfoField.press('Tab');

--- a/pages/behandling/eu-eos-utpeking.page.ts
+++ b/pages/behandling/eu-eos-utpeking.page.ts
@@ -41,6 +41,12 @@ export class EuEosUtpekingPage extends BasePage {
   private readonly vurderingHeading = this.page.getByRole('heading', { name: 'Vurder lovvalgsbeslutningen (A003)' });
   private readonly vedtakHeading = this.page.getByRole('heading', { name: 'Omfattet av norsk trygdelovgivning' });
 
+  // Annet-land-grenen (BESLUTNING_LOVVALG_ANNET_LAND): steg 2 «Godkjenn utpeking».
+  private readonly godkjennUtpekingHeading = this.page.getByRole('heading', { name: 'Godkjenn utpeking' });
+  private readonly sendA012Checkbox = this.page.getByRole('checkbox', { name: 'Send A012' });
+  private readonly ytterligereInfoField = this.page.getByRole('textbox', { name: 'Ytterligere informasjon til SED (valgfri)' });
+  private readonly bekreftButton = this.page.getByRole('button', { name: 'Bekreft', exact: true });
+
   constructor(page: Page) {
     super(page);
     this.assertions = new EuEosUtpekingAssertions(page);
@@ -133,5 +139,79 @@ export class EuEosUtpekingPage extends BasePage {
     await this.fyllBegrunnelseOgFattVedtak(
       opts?.begrunnelse ?? 'Norge godkjenner utpekingen. Personen har bostedsadresse i Norge i perioden.'
     );
+  }
+
+  // === Annet-land-grenen (BESLUTNING_LOVVALG_ANNET_LAND) ===
+  //
+  // Når en innkommende A003 peker ut et ANNET EU/EØS-land (lovvalgsland != NO),
+  // går saksbehandler gjennom bare 2 steg (ikke 4 som i Norge-grenen — det er
+  // verken Inngang- eller Virksomhet-steg her):
+  //   1. Vurdering        – «Vurder lovvalgsbeslutningen (A003)»: Godkjenn / Ikke godkjenn.
+  //                         Grunnlag og periode er forhåndsutfylt fra SED-en.
+  //   2. Godkjenn utpeking – «Send A012»-checkbox (= varsleUtland) + valgfri
+  //                         fritekst → «Bekreft». Registrerer unntaket
+  //                         (REGISTRERT_UNNTAK) og overfører lovvalg til MEDL.
+  // Live-verifisert 2026-06-14 (behandling 101, lovvalgsland SE).
+
+  /**
+   * Steg 1 (Vurdering) for annet-land-grenen: godkjenn lovvalgsbeslutningen og gå
+   * videre til «Godkjenn utpeking». Identisk vurderingssteg som Norge-grenen, men
+   * neste steg er «Godkjenn utpeking» (ikke vedtak), siden et annet land er kompetent.
+   */
+  async vurderUtpekingAnnetLandOgFortsett(): Promise<void> {
+    await this.godkjennRadio.waitFor({ state: 'visible', timeout: 30000 });
+    await this.godkjennRadio.check();
+    await expect(this.bekreftOgFortsettButton).toBeEnabled({ timeout: 15000 });
+    await this.clickStepButtonWithRetry(this.bekreftOgFortsettButton, {
+      verifyHeadingChange: true,
+      waitForContent: this.godkjennUtpekingHeading,
+    });
+    console.log('✅ Godkjente lovvalgsbeslutningen (annet land utpekt)');
+  }
+
+  /**
+   * Steg 2 (Godkjenn utpeking): registrer unntaket. Venter på det kritiske
+   * godkjennings-API-kallet (POST /saksflyt/unntaksperioder/{id}/godkjenn), som
+   * navigerer tilbake til forsiden ved suksess.
+   *
+   * @param opts.varsleUtland - Huk av «Send A012» for å sende en utgående A012 på
+   *   den eksisterende bucen (krever en åpen BUC i RINA, jf. sendSed({opprettBucIRina:true})).
+   *   Default false (primær happy-path: ren MEDL-registrering, ingen SED).
+   * @param opts.fritekst - Valgfri «Ytterligere informasjon til SED».
+   */
+  async bekreftGodkjenningUtpekingAnnetLand(opts?: { varsleUtland?: boolean; fritekst?: string }): Promise<void> {
+    await this.godkjennUtpekingHeading.waitFor({ state: 'visible', timeout: 30000 });
+
+    if (opts?.varsleUtland) {
+      await this.sendA012Checkbox.check();
+    }
+    if (opts?.fritekst) {
+      await this.ytterligereInfoField.click();
+      await this.ytterligereInfoField.fill(opts.fritekst);
+      await this.ytterligereInfoField.press('Tab');
+    }
+
+    await this.bekreftButton.waitFor({ state: 'visible', timeout: 10000 });
+    const responsePromise = this.page.waitForResponse(
+      response => response.url().includes('/saksflyt/unntaksperioder/') &&
+                  response.url().includes('/godkjenn') &&
+                  response.request().method() === 'POST' &&
+                  (response.status() === 200 || response.status() === 204),
+      { timeout: 60000 }
+    );
+    await this.bekreftButton.click();
+    const response = await responsePromise;
+    console.log(`✅ Godkjente utpeking (annet land), varsleUtland=${Boolean(opts?.varsleUtland)} → ${response.status()}`);
+  }
+
+  /**
+   * Kjør hele annet-land-grenen: godkjenn lovvalgsbeslutningen og registrer unntaket.
+   *
+   * @param opts.varsleUtland - Send utgående A012 (default false).
+   * @param opts.fritekst     - Valgfri fritekst til SED.
+   */
+  async godkjennUtpekingAnnetLand(opts?: { varsleUtland?: boolean; fritekst?: string }): Promise<void> {
+    await this.vurderUtpekingAnnetLandOgFortsett();
+    await this.bekreftGodkjenningUtpekingAnnetLand(opts);
   }
 }

--- a/tests/eu-eos/eu-eos-inngaaende-a003-annet-land-utpekt-registrert-unntak.spec.ts
+++ b/tests/eu-eos/eu-eos-inngaaende-a003-annet-land-utpekt-registrert-unntak.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '../../fixtures';
+import { AuthHelper } from '../../helpers/auth-helper';
+import { SedHelper } from '../../helpers/sed-helper';
+import { HovedsidePage } from '../../pages/hovedside.page';
+import { EuEosUtpekingPage } from '../../pages/behandling/eu-eos-utpeking.page';
+import { waitForProcessInstances } from '../../helpers/api-helper';
+import { fetchStoredSedDocuments } from '../../helpers/mock-helper';
+import { BRUKERNAVN_VALID } from '../../pages/shared/constants';
+
+/**
+ * EU/EØS - Inngående A003 (annet land utpekt) → REGISTRERT_UNNTAK
+ *
+ * Gap: eos-inngaaende-a003-annet-land-utpekt-registrert-unntak (Tier 1). Dette er
+ * den volum-mest-brukte udekkede flyten i prod: REGISTRERING_UNNTAK_GODKJENN står
+ * for ~19 % av alt prosessarbeid, og utfallet REGISTRERT_UNNTAK for ~85 % av alle
+ * vedtaksutfall. Den er den OMVENDTE grenen av
+ * eu-eos-inngaaende-a003-norge-utpekt-a012.spec.ts: der peker A003 ut Norge
+ * (→ A012 / FASTSATT_LOVVALGSLAND); her peker A003 ut et ANNET EU/EØS-land, og
+ * saksbehandler godkjenner/registrerer at Norge dermed ikke er kompetent
+ * (→ REGISTRERT_UNNTAK, personen unntas norsk trygd).
+ *
+ * Scenario (primær happy-path, varsleUtland=false → ingen utgående SED):
+ * 1. Injiser en inngående A003 med lovvalgsland = SE (et annet land enn NO). Dette
+ *    oppretter en behandling med tema BESLUTNING_LOVVALG_ANNET_LAND for testpersonen.
+ * 2. Åpne behandlingen og fullfør annet-land-grenen (bare 2 steg, ikke 4 som
+ *    Norge-grenen): Vurdering[Godkjenn] → Godkjenn utpeking[Bekreft].
+ * 3. Verifiser ende-til-ende:
+ *    - behandlingsresultat REGISTRERT_UNNTAK / utfall_registrering_unntak GODKJENT
+ *    - en lovvalgsperiode til det andre landet (SE), art.13(1)(a), INNVILGET,
+ *      medlemskapstype UNNTATT, knyttet til en MEDL-periode
+ *    - REGISTRERING_UNNTAK_GODKJENN fullført uten feilede prosessinstanser
+ *    - MEDL-perioden er opprettet med det andre landet som lovvalgsland (SWE),
+ *      foreløpig lovvalg (FORL) / uavklart status (UAVK) — behandlingen ender som
+ *      MIDLERTIDIG_LOVVALGSBESLUTNING (ikke AVSLUTTET)
+ *    - INGEN utgående A012 sendes (varsleUtland=false sender ingen SED)
+ *
+ * Live-verifisert 2026-06-14 (Playwright MCP, behandling 101, lovvalgsland SE → MEDL SWE).
+ */
+test.describe('EU/EØS - Inngående A003 (annet land utpekt)', () => {
+  test('skal godkjenne at et annet land er utpekt og registrere unntak (uten SED)', async ({ page, request }) => {
+    test.setTimeout(240000);
+
+    // === DEL A: Inngående A003 (lovvalgsland=SE) oppretter annet-land-behandling ===
+    console.log('📝 Del A: Injiserer inngående A003 (annet land utpekt, lovvalgsland=SE)...');
+    const sed = new SedHelper(request);
+    const result = await sed.sendSed({
+      sedType: 'A003',
+      bucType: 'LA_BUC_02',
+      lovvalgsland: 'SE',
+      artikkel: '13_1_a',
+      // opprettBucIRina ikke nødvendig: varsleUtland=false sender ingen SED, så
+      // melosys-api trenger ingen åpen BUC i RINA-store for denne flyten.
+    });
+    expect(result.success, `Send A003 feilet: ${result.message}`).toBe(true);
+    await waitForProcessInstances(request, 60);
+
+    const auth = new AuthHelper(page);
+    await auth.login();
+    const hovedside = new HovedsidePage(page);
+    const utpeking = new EuEosUtpekingPage(page);
+
+    // Åpne den nyopprettede annet-land-behandlingen for testpersonen.
+    await hovedside.goto();
+    await hovedside.åpneBehandling(`${BRUKERNAVN_VALID} -`);
+    await page.waitForLoadState('networkidle').catch(() => {});
+
+    // Snapshot A012-tilstand FØR godkjenning (primær path skal IKKE sende noen SED).
+    const a012Før = await fetchStoredSedDocuments(request, 'A012');
+
+    // === DEL B: Godkjenn at annet land er utpekt og registrer unntaket ===
+    console.log('📝 Del B: Godkjenner lovvalgsbeslutningen og registrerer unntak...');
+    await utpeking.godkjennUtpekingAnnetLand({ varsleUtland: false });
+
+    console.log('📝 Del B: Venter på at REGISTRERING_UNNTAK_GODKJENN fullfører (kaster ved feilede instanser)...');
+    await waitForProcessInstances(request, 90);
+
+    // === DEL C: Verifiser REGISTRERT_UNNTAK + MEDL-overføring + ingen SED ===
+    await utpeking.assertions.verifiserRegistrertUnntakIverksatt(request, {
+      lovvalgsland: 'SE',
+      medlLovvalgsland: 'SWE',
+    });
+
+    const a012Etter = await fetchStoredSedDocuments(request, 'A012');
+    expect(
+      a012Etter.length,
+      'Ingen utgående A012 skal sendes når varsleUtland=false'
+    ).toBe(a012Før.length);
+
+    console.log('✅ Inngående A003 (annet land utpekt) → REGISTRERT_UNNTAK verifisert ende-til-ende');
+  });
+});


### PR DESCRIPTION
Ny e2e-test for den volum-mest-brukte udekkede flyten i prod: en inngående A003 peker ut et annet EU/EØS-land (lovvalgsland=SE), og saksbehandler godkjenner/registrerer at Norge dermed ikke er kompetent (REGISTRERT_UNNTAK).

REGISTRERING_UNNTAK_GODKJENN står for ~19 % av alt prosessarbeid og REGISTRERT_UNNTAK for ~85 % av alle vedtaksutfall, men flyten var helt udekket av e2e. Dette er den omvendte grenen av den eksisterende «Norge utpekt → A012»-testen. Annet-land-grenen har bare 2 steg (Vurdering → Godkjenn utpeking) — ingen Inngang/Virksomhet — og behandlingen ender som MIDLERTIDIG_LOVVALGSBESLUTNING (ikke AVSLUTTET), så en dedikert assertion brukes i stedet for verifiserBehandlingSluttilstand.

- Ny spec `tests/eu-eos/eu-eos-inngaaende-a003-annet-land-utpekt-registrert-unntak.spec.ts`
- Utvider `EuEosUtpekingPage` med annet-land-grenen (`godkjennUtpekingAnnetLand` m.fl.)
- Ny assertion `verifiserRegistrertUnntakIverksatt`: REGISTRERT_UNNTAK/GODKJENT, lovvalgsperiode SE/art.13(1)(a)/INNVILGET/UNNTATT, REGISTRERING_UNNTAK_GODKJENN FERDIG uten feilede instanser, MEDL-overføring (SWE/FORL/UAVK/medlem), og 0 utgående A012 (varsleUtland=false)

## Testing
- [x] Kjørt lokalt mot full docker-stack: 1 passed (13.6s), docker-logger rene
- [x] `npm run check:tests` OK (ingen vakuøse assertions)
- [x] Fase A live-verifisert via Playwright MCP (DB + MEDL-sluttilstand bekreftet)
- [x] E2E på CI (kjøres etter push)

## Notes
A004/A012-avklaring: `varsleUtland=true` → utgående **A012** (EessiService.sendGodkjenningArbeidFlereLand sender SedType.A012, ikke A004; UI-label «Send A012» er korrekt). A004 er kun avvis-grenen. Primær happy-path bruker `varsleUtland=false` → ingen SED, så `opprettBucIRina` er ikke nødvendig.