### PR TITLE
NOJIRA P2/P3: assertion-løft på sed-mottak (ruting + journalføring)

### DIFF
--- a/pages/shared/sed-mottak.assertions.ts
+++ b/pages/shared/sed-mottak.assertions.ts
@@ -1,0 +1,158 @@
+import { APIRequestContext, expect } from '@playwright/test';
+import { withDatabase } from '../../helpers/db-helper';
+import { fetchStoredJournalposter, JournalpostInfo } from '../../helpers/mock-helper';
+
+/**
+ * Gjenbrukbare verifikasjoner for SED-mottaks-kjeden (MOTTAK_SED) — det største
+ * enkelt-prosesstypet i produksjon (~37 % av alt prosessarbeid).
+ *
+ * Tidligere stoppet sed-mottak-testene på «fagsak/oppgave finnes». Disse to
+ * funksjonene løfter dem til å bevise at den innkommende SED-en faktisk
+ *  (P2) RUTES til riktig utfall — en behandling med riktig BEH_TEMA + at rutingens
+ *       oppfølgingsprosess er FERDIG og ingen prosessinstans har FEILET — og
+ *  (P3) JOURNALFØRES — at det ble opprettet en INNGAAENDE EESSI-journalpost i SAF.
+ *
+ * En feilruting (feil tema, feil/uteblitt oppfølgingsprosess, FEILET prosess) eller
+ * manglende journalpost får testen til å feile.
+ */
+
+export interface SedRutingForventning {
+  /**
+   * Forventet BEHANDLING.BEH_TEMA som SED-en skal rutes til (rutingsutfallet).
+   * Live-verifisert 2026-06-15:
+   *  - A003, lovvalgsland ≠ NO → BESLUTNING_LOVVALG_ANNET_LAND
+   *  - A003, lovvalgsland = NO → BESLUTNING_LOVVALG_NORGE
+   *  - A009                    → REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING
+   *  - A001                    → ANMODNING_OM_UNNTAK_HOVEDREGEL
+   */
+  forventetTema: string;
+  /**
+   * En PROSESS_TYPE som rutingen MÅ ha opprettet og fullført for behandlingen
+   * (f.eks. ARBEID_FLERE_LAND_NY_SAK for A003, REGISTRERING_UNNTAK_NY_SAK for A009,
+   * ANMODNING_OM_UNNTAK_MOTTAK_NY_SAK for A001) — selve beviset på at SED-en ble
+   * rutet videre og ikke bare mottatt.
+   */
+  rutingProsess: string;
+  /** Forventet BEHANDLING.BEH_TYPE (default FØRSTEGANG). */
+  forventetBehType?: string;
+}
+
+export interface SedRutingResultat {
+  behandlingId: number;
+  saksnummer: string;
+}
+
+/**
+ * P2 — verifiser at en innkommende SED ble RUTET til riktig utfall i melosys-api.
+ *
+ * Asserterer (alt biter):
+ *  - det ble opprettet nøyaktig forventet behandling med riktig BEH_TEMA + BEH_TYPE
+ *  - MOTTAK_SED-prosessen er FERDIG (selve mottaket fullført)
+ *  - rutingens oppfølgingsprosess (`rutingProsess`) er FERDIG for behandlingen
+ *  - INGEN prosessinstans er FEILET
+ *
+ * Databasen renses før hver test (cleanup-fixture), så nyeste behandling (høyest ID)
+ * = denne testens behandling — samme konvensjon som de øvrige POM-ene.
+ *
+ * Kolonner live-verifisert 2026-06-15:
+ *  - BEHANDLING(ID, STATUS, BEH_TYPE, BEH_TEMA, SAKSNUMMER)
+ *  - PROSESSINSTANS(PROSESS_TYPE, STATUS, BEHANDLING_ID)  [MOTTAK_SED har BEHANDLING_ID = null]
+ *
+ * @returns behandlingId + saksnummer for den rutede behandlingen (brukes til journalpost-oppslag)
+ */
+export async function verifiserSedRutetTilTema(
+  forventet: SedRutingForventning
+): Promise<SedRutingResultat> {
+  return await withDatabase(async (db) => {
+    const beh = await db.queryOne<{ ID: number; BEH_TYPE: string; BEH_TEMA: string; SAKSNUMMER: string }>(
+      `SELECT ID, BEH_TYPE, BEH_TEMA, SAKSNUMMER FROM BEHANDLING ORDER BY ID DESC FETCH FIRST 1 ROWS ONLY`
+    );
+    expect(beh, 'Forventet en behandling opprettet av SED-mottaket').not.toBeNull();
+    expect(beh!.BEH_TEMA, `SED skal rutes til tema ${forventet.forventetTema}`).toBe(forventet.forventetTema);
+    expect(
+      beh!.BEH_TYPE,
+      `Behandlingstype skal være ${forventet.forventetBehType ?? 'FØRSTEGANG'}`
+    ).toBe(forventet.forventetBehType ?? 'FØRSTEGANG');
+    console.log(`✅ Behandling ${beh!.ID} (${beh!.SAKSNUMMER}) rutet til tema ${beh!.BEH_TEMA}`);
+
+    // === Ingen feilede prosessinstanser ===
+    const feilede = await db.query<{ PROSESS_TYPE: string }>(
+      `SELECT prosess_type FROM prosessinstans WHERE status = 'FEILET'`
+    );
+    expect(feilede, `Forventet ingen feilede prosessinstanser, fant: ${JSON.stringify(feilede)}`).toHaveLength(0);
+
+    // === MOTTAK_SED selv er FERDIG (knyttes ikke til behandling — BEHANDLING_ID = null) ===
+    const mottak = await db.queryOne<{ STATUS: string }>(
+      `SELECT status FROM prosessinstans WHERE prosess_type = 'MOTTAK_SED'
+       ORDER BY registrert_dato DESC FETCH FIRST 1 ROWS ONLY`
+    );
+    expect(mottak, 'Forventet en MOTTAK_SED-prosessinstans').not.toBeNull();
+    expect(mottak!.STATUS, 'MOTTAK_SED skal være FERDIG').toBe('FERDIG');
+
+    // === Rutingens oppfølgingsprosess er FERDIG for behandlingen ===
+    const ruting = await db.queryOne<{ STATUS: string }>(
+      `SELECT status FROM prosessinstans WHERE prosess_type = :pt AND behandling_id = :id
+       ORDER BY registrert_dato DESC FETCH FIRST 1 ROWS ONLY`,
+      { pt: forventet.rutingProsess, id: beh!.ID }
+    );
+    expect(
+      ruting,
+      `Forventet en ${forventet.rutingProsess}-prosessinstans for behandling ${beh!.ID} (rutingsutfallet)`
+    ).not.toBeNull();
+    expect(ruting!.STATUS, `${forventet.rutingProsess} skal være FERDIG`).toBe('FERDIG');
+    console.log(`✅ MOTTAK_SED + ${forventet.rutingProsess} FERDIG, ingen feilede prosessinstanser`);
+
+    return { behandlingId: beh!.ID, saksnummer: beh!.SAKSNUMMER };
+  });
+}
+
+/**
+ * P3 — verifiser journalførings-bivirkningen: at SED-mottaket faktisk produserte en
+ * INNGAAENDE EESSI-journalpost i SAF-mocken, knyttet til sakens saksnummer.
+ *
+ * Dekker MOTTAK_SED_JOURNALFØRING / SED_MOTTAK_FERDIGSTILL_JOURNALPOST-bivirkningen
+ * (~15 % av prod-volumet) — at journalføringen er REELL, ikke antatt. Asserterer
+ * journalposttype (INNGAAENDE), kanal (EESSI), journalstatus (J), sakId-tilknytning
+ * og at tittelen gjenspeiler SED-typen.
+ *
+ * Journalposten opprettes som del av mottaket, men finnes via kort poll for å
+ * unngå sjeldne race-er. Live-verifisert 2026-06-15 (tittel «A003 - Mottatt fra SE»).
+ *
+ * @param request    - Playwright APIRequestContext
+ * @param forventet.saksnummer - behandlingens saksnummer (fra verifiserSedRutetTilTema)
+ * @param forventet.sedType    - SED-typen som skal gjenspeiles i tittelen (f.eks. 'A003')
+ */
+export async function verifiserInngaaendeSedJournalfoert(
+  request: APIRequestContext,
+  forventet: { saksnummer: string; sedType: string; timeoutMs?: number }
+): Promise<JournalpostInfo> {
+  const timeoutMs = forventet.timeoutMs ?? 15000;
+  const deadline = Date.now() + timeoutMs;
+
+  let inngaaende: JournalpostInfo | undefined;
+  while (Date.now() < deadline) {
+    const jps = await fetchStoredJournalposter(request);
+    inngaaende = jps.find(
+      (jp) =>
+        jp.journalposttype === 'INNGAAENDE' &&
+        jp.kanal === 'EESSI' &&
+        jp.sakId === forventet.saksnummer
+    );
+    if (inngaaende) break;
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+
+  expect(
+    inngaaende,
+    `Forventet en INNGAAENDE EESSI-journalpost for sak ${forventet.saksnummer}`
+  ).toBeTruthy();
+  expect(inngaaende!.journalStatus, 'Journalposten skal være journalført (status J)').toBe('J');
+  expect(
+    inngaaende!.tittel,
+    `Journalpost-tittelen skal gjenspeile SED-typen ${forventet.sedType}`
+  ).toContain(forventet.sedType);
+  console.log(
+    `✅ INNGAAENDE EESSI-journalpost ${inngaaende!.journalpostId} for ${forventet.saksnummer}: "${inngaaende!.tittel}"`
+  );
+  return inngaaende!;
+}

--- a/tests/core/sed-mottak.spec.ts
+++ b/tests/core/sed-mottak.spec.ts
@@ -4,6 +4,11 @@ import { SedHelper, SED_SCENARIOS, EESSI_SED_SCENARIOS, SedHendelseConfig } from
 import { withDatabase } from '../../helpers/db-helper';
 import { HovedsidePage } from '../../pages/hovedside.page';
 import { SokPage } from '../../pages/sok/sok.page';
+import {
+  verifiserSedRutetTilTema,
+  verifiserInngaaendeSedJournalfoert,
+} from '../../pages/shared/sed-mottak.assertions';
+import { fetchStoredJournalposter } from '../../helpers/mock-helper';
 
 /**
  * Test suite for SED (Structured Electronic Document) intake flow
@@ -90,7 +95,21 @@ test.describe('SED Mottak', () => {
     }
 
     expect(processResult.success, `Process failed: ${processResult.message}`).toBe(true);
-    console.log('✅ MOTTAK_SED process completed successfully');
+
+    // P2: verifiser at A003 (annet land enn NO) faktisk RUTES til riktig utfall —
+    // en behandling med tema BESLUTNING_LOVVALG_ANNET_LAND + ARBEID_FLERE_LAND_NY_SAK FERDIG
+    console.log('📝 Step 3: Verifying SED routed to correct outcome...');
+    const ruting = await verifiserSedRutetTilTema({
+      forventetTema: 'BESLUTNING_LOVVALG_ANNET_LAND',
+      rutingProsess: 'ARBEID_FLERE_LAND_NY_SAK',
+    });
+
+    // P3: verifiser at mottaket faktisk journalførte SED-en (INNGAAENDE EESSI-journalpost)
+    await verifiserInngaaendeSedJournalfoert(request, {
+      saksnummer: ruting.saksnummer,
+      sedType: 'A003',
+    });
+    console.log('✅ MOTTAK_SED routed + journalført correctly');
   });
 
   test('skal opprette fagsak ved mottak av A003 fra Sverige', async ({ request }) => {
@@ -108,25 +127,21 @@ test.describe('SED Mottak', () => {
 
     expect(processResult.success, `Process failed: ${processResult.message}`).toBe(true);
 
-    console.log('📝 Step 3: Verifying fagsak was created in database...');
-    await withDatabase(async (db) => {
-      // Check for recently created fagsak
-      const fagsaker = await db.query(
-        `SELECT f.SAKSNUMMER, f.GSAK_SAKSNUMMER, f.STATUS, f.REGISTRERT_DATO
-         FROM FAGSAK f
-         WHERE f.REGISTRERT_DATO > SYSDATE - INTERVAL '5' MINUTE
-         ORDER BY f.REGISTRERT_DATO DESC`
-      );
-
-      // Prosessen er fullført, så fagsak SKAL finnes — hard assert (ikke gated på if)
-      expect(fagsaker.length, 'Forventet minst én fagsak opprettet ved SED-mottak').toBeGreaterThan(0);
-      console.log(`   ✅ Fagsak found: SAKSNUMMER=${fagsaker[0].SAKSNUMMER}, GSAK=${fagsaker[0].GSAK_SAKSNUMMER}`);
-
-      // Verify process completed
-      expect(processResult.success).toBe(true);
+    // P2: A003 fra Sverige (lovvalgsland SE ≠ NO) skal rutes til BESLUTNING_LOVVALG_ANNET_LAND
+    // og ARBEID_FLERE_LAND_NY_SAK skal være FERDIG — ikke bare at «en fagsak finnes».
+    console.log('📝 Step 3: Verifying SED routed to BESLUTNING_LOVVALG_ANNET_LAND...');
+    const ruting = await verifiserSedRutetTilTema({
+      forventetTema: 'BESLUTNING_LOVVALG_ANNET_LAND',
+      rutingProsess: 'ARBEID_FLERE_LAND_NY_SAK',
     });
 
-    console.log('✅ A003 from Sweden processed successfully');
+    // P3: SED-en skal journalføres (INNGAAENDE EESSI-journalpost knyttet til saken)
+    await verifiserInngaaendeSedJournalfoert(request, {
+      saksnummer: ruting.saksnummer,
+      sedType: 'A003',
+    });
+
+    console.log('✅ A003 from Sweden routed + journalført');
   });
 
   test('skal håndtere A009 informasjonsforespørsel', async ({ request }) => {
@@ -145,7 +160,20 @@ test.describe('SED Mottak', () => {
     console.log(`   Status: ${processResult.status}, Message: ${processResult.message}`);
     expect(processResult.success, `Process failed: ${processResult.message}`).toBe(true);
 
-    console.log('✅ A009 information request processed');
+    // P2: A009 (informasjonsforespørsel) rutes til registrering av unntak fra norsk trygd
+    console.log('📝 Step 3: Verifying A009 routed to REGISTRERING_UNNTAK...');
+    const ruting = await verifiserSedRutetTilTema({
+      forventetTema: 'REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING',
+      rutingProsess: 'REGISTRERING_UNNTAK_NY_SAK',
+    });
+
+    // P3: A009 skal journalføres som INNGAAENDE EESSI-journalpost
+    await verifiserInngaaendeSedJournalfoert(request, {
+      saksnummer: ruting.saksnummer,
+      sedType: 'A009',
+    });
+
+    console.log('✅ A009 information request routed + journalført');
   });
 
   test('skal håndtere A001 søknad fra Danmark', async ({ request }) => {
@@ -164,7 +192,20 @@ test.describe('SED Mottak', () => {
     console.log(`   Status: ${processResult.status}, Message: ${processResult.message}`);
     expect(processResult.success, `Process failed: ${processResult.message}`).toBe(true);
 
-    console.log('✅ A001 application processed');
+    // P2: A001 (søknad om unntak / anmodning) rutes til ANMODNING_OM_UNNTAK_HOVEDREGEL
+    console.log('📝 Step 3: Verifying A001 routed to ANMODNING_OM_UNNTAK...');
+    const ruting = await verifiserSedRutetTilTema({
+      forventetTema: 'ANMODNING_OM_UNNTAK_HOVEDREGEL',
+      rutingProsess: 'ANMODNING_OM_UNNTAK_MOTTAK_NY_SAK',
+    });
+
+    // P3: A001 skal journalføres som INNGAAENDE EESSI-journalpost
+    await verifiserInngaaendeSedJournalfoert(request, {
+      saksnummer: ruting.saksnummer,
+      sedType: 'A001',
+    });
+
+    console.log('✅ A001 application routed + journalført');
   });
 
   test('skal håndtere tilpasset SED konfigurasjon', async ({ request }) => {
@@ -199,7 +240,21 @@ test.describe('SED Mottak', () => {
     });
 
     expect(processResult.success, `Process failed: ${processResult.message}`).toBe(true);
-    console.log('✅ Custom SED configuration processed');
+
+    // P2: tilpasset A003 (lovvalgsland FI ≠ NO) rutes til BESLUTNING_LOVVALG_ANNET_LAND
+    console.log('📝 Step 3: Verifying custom A003 routed correctly...');
+    const ruting = await verifiserSedRutetTilTema({
+      forventetTema: 'BESLUTNING_LOVVALG_ANNET_LAND',
+      rutingProsess: 'ARBEID_FLERE_LAND_NY_SAK',
+    });
+
+    // P3: SED-en skal journalføres
+    await verifiserInngaaendeSedJournalfoert(request, {
+      saksnummer: ruting.saksnummer,
+      sedType: 'A003',
+    });
+
+    console.log('✅ Custom SED configuration routed + journalført');
   });
 
   test('skal verifisere at SED fører til oppgave i systemet', async ({ page, request }) => {
@@ -218,6 +273,16 @@ test.describe('SED Mottak', () => {
     });
 
     expect(processResult.success, `Process failed: ${processResult.message}`).toBe(true);
+
+    // P2/P3: bekreft at SED-en ble rutet riktig OG journalført FØR vi sjekker UI-søkbarhet
+    const ruting = await verifiserSedRutetTilTema({
+      forventetTema: 'BESLUTNING_LOVVALG_ANNET_LAND',
+      rutingProsess: 'ARBEID_FLERE_LAND_NY_SAK',
+    });
+    await verifiserInngaaendeSedJournalfoert(request, {
+      saksnummer: ruting.saksnummer,
+      sedType: 'A003',
+    });
 
     // Step 3: Login and verify case is accessible
     console.log('📝 Step 3: Logging in to verify case...');
@@ -279,7 +344,35 @@ test.describe('SED Mottak', () => {
     }
 
     expect(processResult.success, `Processes failed: ${processResult.message}`).toBe(true);
-    console.log('✅ Multiple SED types handled successfully');
+
+    // P2: ingen av de 3 SED-ene skal ha gitt en FEILET prosessinstans
+    console.log('📝 Verifying no failed process instances...');
+    await withDatabase(async (db) => {
+      const feilede = await db.query(
+        `SELECT prosess_type FROM prosessinstans WHERE status = 'FEILET'`
+      );
+      expect(
+        feilede.length,
+        `Forventet ingen feilede prosessinstanser, fant: ${JSON.stringify(feilede)}`
+      ).toBe(0);
+    });
+
+    // P3: hver av de 3 SED-typene skal ha gitt en INNGAAENDE EESSI-journalpost
+    console.log('📝 Verifying each SED was journalført...');
+    const journalposter = await fetchStoredJournalposter(request);
+    const inngaaende = journalposter.filter(
+      (jp) => jp.journalposttype === 'INNGAAENDE' && jp.kanal === 'EESSI'
+    );
+    for (const { name } of sedConfigs) {
+      const found = inngaaende.find((jp) => (jp.tittel ?? '').includes(name));
+      expect(found, `Forventet INNGAAENDE EESSI-journalpost for ${name}`).toBeTruthy();
+    }
+    expect(
+      inngaaende.length,
+      'Forventet minst én INNGAAENDE EESSI-journalpost per SED'
+    ).toBeGreaterThanOrEqual(sedConfigs.length);
+
+    console.log('✅ Multiple SED types handled + journalført successfully');
   });
 
   test('skal verifisere prosessinstanser i databasen', async ({ request }) => {
@@ -297,43 +390,22 @@ test.describe('SED Mottak', () => {
 
     expect(processResult.success, `Process failed: ${processResult.message}`).toBe(true);
 
-    console.log('📝 Step 3: Verifying process instance in database...');
-    await withDatabase(async (db) => {
-      // Query for recent MOTTAK_SED process instances
-      // Note: Table is PROSESSINSTANS (not PROSESS_INSTANS)
-      const prosessinstanser = await db.query(
-        `SELECT PI.UUID, PI.PROSESS_TYPE, PI.STATUS, PI.SIST_FULLFORT_STEG, PI.REGISTRERT_DATO
-         FROM PROSESSINSTANS PI
-         WHERE PI.PROSESS_TYPE = 'MOTTAK_SED'
-         AND PI.REGISTRERT_DATO > SYSDATE - INTERVAL '5' MINUTE
-         ORDER BY PI.REGISTRERT_DATO DESC`
-      );
-
-      console.log(`   Found ${prosessinstanser.length} recent MOTTAK_SED process instance(s)`);
-
-      // Hard assert: prosessen er fullført, så MOTTAK_SED-instansen SKAL finnes (ikke gated på if)
-      expect(prosessinstanser.length, 'Forventet minst én MOTTAK_SED prosessinstans').toBeGreaterThan(0);
-
-      if (prosessinstanser.length > 0) {
-        const latest = prosessinstanser[0];
-        console.log(`   Latest: UUID=${latest.UUID}, Status=${latest.STATUS}, LastStep=${latest.SIST_FULLFORT_STEG}`);
-        expect(latest.STATUS).toBe('FERDIG');
-      } else {
-        console.log('   ⚠️ No MOTTAK_SED process instances found');
-        // Check all recent process instances
-        const allRecent = await db.query(
-          `SELECT PI.UUID, PI.PROSESS_TYPE, PI.STATUS
-           FROM PROSESSINSTANS PI
-           WHERE PI.REGISTRERT_DATO > SYSDATE - INTERVAL '5' MINUTE`
-        );
-        console.log(`   All recent process instances: ${allRecent.length}`);
-        for (const pi of allRecent) {
-          console.log(`      - ${pi.PROSESS_TYPE}: ${pi.STATUS}`);
-        }
-      }
+    // P2: bekreft full ruting i databasen — MOTTAK_SED FERDIG + behandling med riktig tema
+    // + ARBEID_FLERE_LAND_NY_SAK FERDIG (ingen FEILET). Erstatter den tidligere
+    // MOTTAK_SED-status-sjekken med en hard ende-til-ende rutingsassert.
+    console.log('📝 Step 3: Verifying process instances + routing in database...');
+    const ruting = await verifiserSedRutetTilTema({
+      forventetTema: 'BESLUTNING_LOVVALG_ANNET_LAND',
+      rutingProsess: 'ARBEID_FLERE_LAND_NY_SAK',
     });
 
-    console.log('✅ Process instance verification complete');
+    // P3: journalføringen skal også finnes
+    await verifiserInngaaendeSedJournalfoert(request, {
+      saksnummer: ruting.saksnummer,
+      sedType: 'A003',
+    });
+
+    console.log('✅ Process instance + routing verification complete');
   });
 });
 


### PR DESCRIPTION
## Hva

Assertion-løft på **MOTTAK_SED**-kjeden — det største enkelt-prosesstypet i produksjon (~37 % av alt prosessarbeid) + **MOTTAK_SED_JOURNALFØRING** (~15 %). `tests/core/sed-mottak.spec.ts` stoppet på «fagsak/oppgave finnes» og verifiserte **ikke** at den innkommende SED-en faktisk ble RUTET til riktig utfall eller JOURNALFØRT.

## Hvorfor

Volum-vektet dekningsplan (P1–P4) løfter reell dekning fra ~72 % til ~96 % av prod-volumet. P1 (REGISTRERING_UNNTAK_GODKJENN, PR #278) er merget. Dette er **P2 + P3** i samme PR.

## Endringer

Ny gjenbrukbar modul `pages/shared/sed-mottak.assertions.ts`:
- **`verifiserSedRutetTilTema()`** (P2): behandling med riktig `BEH_TEMA`, `MOTTAK_SED` + rutingens oppfølgingsprosess `FERDIG`, ingen `FEILET` prosessinstans.
- **`verifiserInngaaendeSedJournalfoert()`** (P3): `INNGAAENDE` EESSI-journalpost knyttet til saken, status `J`, tittel gjenspeiler SED-typen.

Ruting **live-verifisert 2026-06-15** (verify-don't-trust):

| SED | BEH_TEMA | ruting-prosess |
|---|---|---|
| A003 lovvalgsland≠NO | `BESLUTNING_LOVVALG_ANNET_LAND` | `ARBEID_FLERE_LAND_NY_SAK` |
| A003 lovvalgsland=NO | `BESLUTNING_LOVVALG_NORGE` | `ARBEID_FLERE_LAND_NY_SAK` |
| A009 | `REGISTRERING_UNNTAK_NORSK_TRYGD_UTSTASJONERING` | `REGISTRERING_UNNTAK_NY_SAK` |
| A001 | `ANMODNING_OM_UNNTAK_HOVEDREGEL` | `ANMODNING_OM_UNNTAK_MOTTAK_NY_SAK` |

Discriminatoren (A003 NO vs ≠NO → ulikt tema) beviser at en feilruting faktisk fanges.

7 direkte-path-tester styrket; sekvens-testen asserterer nå journalpost per SED-type + ingen FEILET. Erstatter løs «fagsak finnes»-spørring og død if/else-gren med harde rutingsasserts. `@eessi`-testene urørt.

## Verifisering

- Lokalt: **8/8 direkte-path passed** (1.2m), docker-logger rene.
- `npm run check:tests` OK (ingen vacuous asserts).
- CI dispatches separat (E2E er dispatch-only).