### PR TITLE
NOJIRA P5a: e2e nyvurdering av inngående annet-land → REGISTRERT_UNNTAK

### DIFF
--- a/pages/behandling/eu-eos-utpeking.assertions.ts
+++ b/pages/behandling/eu-eos-utpeking.assertions.ts
@@ -115,6 +115,40 @@ export class EuEosUtpekingAssertions {
   }
 
   /**
+   * Verifiser at det er opprettet en NY_VURDERING-behandling på et annet-land-tema
+   * (BESLUTNING_LOVVALG_ANNET_LAND), bygget oppå et allerede registrert
+   * førstegangs-unntak.
+   *
+   * Beviser at vi faktisk traff NV-grenen — ikke kjørte førstegang på nytt — slik at
+   * den etterfølgende `verifiserRegistrertUnntakIverksatt` (som tar nyeste rad)
+   * verifiserer NV-behandlingens sluttilstand, ikke førstegangens.
+   *
+   * Live-verifisert 2026-06-15 (behandling 144 NY_VURDERING, oppå behandling 143 FØRSTEGANG).
+   */
+  async verifiserNyVurderingAnnetLandOpprettet(): Promise<void> {
+    await withDatabase(async (db) => {
+      // Nyeste behandling skal være nyvurderingen, med annet-land-temaet arvet fra førstegang.
+      const nyeste = await db.queryOne<{ BEH_TYPE: string; BEH_TEMA: string }>(
+        `SELECT beh_type, beh_tema FROM behandling ORDER BY id DESC FETCH FIRST 1 ROWS ONLY`, {});
+      expect(nyeste, 'Forventet en behandling').not.toBeNull();
+      expect(nyeste!.BEH_TYPE, 'Nyeste behandling skal være en nyvurdering (NY_VURDERING)').toBe('NY_VURDERING');
+      expect(nyeste!.BEH_TEMA, 'NV-behandlingen skal arve annet-land-temaet (BESLUTNING_LOVVALG_ANNET_LAND)')
+        .toBe('BESLUTNING_LOVVALG_ANNET_LAND');
+
+      // Forutsetning: NV bygger oppå en førstegangsbehandling som allerede står med REGISTRERT_UNNTAK.
+      const forstegang = await db.queryOne<{ RESULTAT_TYPE: string }>(
+        `SELECT br.resultat_type FROM behandlingsresultat br
+         JOIN behandling b ON b.id = br.behandling_id
+         WHERE b.beh_type = 'FØRSTEGANG'
+         ORDER BY b.id DESC FETCH FIRST 1 ROWS ONLY`, {});
+      expect(forstegang, 'Forventet en førstegangsbehandling som NV bygger på').not.toBeNull();
+      expect(forstegang!.RESULTAT_TYPE, 'Førstegangsbehandlingen skal stå med REGISTRERT_UNNTAK')
+        .toBe('REGISTRERT_UNNTAK');
+      console.log('✅ NY_VURDERING opprettet på BESLUTNING_LOVVALG_ANNET_LAND (oppå REGISTRERT_UNNTAK førstegang)');
+    });
+  }
+
+  /**
    * Verifiser at en godkjent «annet land utpekt»-utpeking (BESLUTNING_LOVVALG_ANNET_LAND)
    * ble iverksatt som et REGISTRERT_UNNTAK:
    *  - behandlingsresultat: RESULTAT_TYPE REGISTRERT_UNNTAK, utfall_registrering_unntak GODKJENT

--- a/tests/eu-eos/eu-eos-inngaaende-a003-annet-land-nyvurdering.spec.ts
+++ b/tests/eu-eos/eu-eos-inngaaende-a003-annet-land-nyvurdering.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '../../fixtures';
+import { AuthHelper } from '../../helpers/auth-helper';
+import { SedHelper } from '../../helpers/sed-helper';
+import { HovedsidePage } from '../../pages/hovedside.page';
+import { OpprettNySakPage } from '../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import { EuEosUtpekingPage } from '../../pages/behandling/eu-eos-utpeking.page';
+import { waitForProcessInstances } from '../../helpers/api-helper';
+import { BRUKERNAVN_VALID, USER_ID_VALID } from '../../pages/shared/constants';
+
+/**
+ * EU/EØS - Nyvurdering av inngående A003 (annet land utpekt) → REGISTRERT_UNNTAK
+ *
+ * Gap (P5a): heatmap-cellen `BESLUTNING_LOVVALG_ANNET_LAND × NY_VURDERING` (~10,2k/12mo).
+ * P1 (#278) dekker FØRSTEGANG-grenen (inngående A003 annet land → REGISTRERT_UNNTAK);
+ * NY_VURDERING-grenen var udekket. Cellen var dessuten en FALSK ✅ funnet ved
+ * verifiseringen 2026-06-14: den eksisterende `eu-eos-12.1-nyvurdering-medl-overforing`
+ * er UTSENDT_ARBEIDSTAKER (art. 12(1)), IKKE inngående annet land. Denne testen lukker
+ * NV-grenen og retter den feiletiketten.
+ *
+ * Fase A (verify-don't-trust, live-repro 2026-06-15):
+ *  - NV-grenen for annet land er MANUELL: NV-behandlingen lander på SAMME 2-stegs
+ *    utpeking-wizard som førstegang (Vurder lovvalgsbeslutningen → Godkjenn utpeking),
+ *    så `godkjennUtpekingAnnetLand` gjenbrukes uendret.
+ *  - NV-behandlingen får `BEH_TYPE=NY_VURDERING` + `BEH_TEMA=BESLUTNING_LOVVALG_ANNET_LAND`
+ *    (discriminator mot førstegangens `FØRSTEGANG`), og sin EGEN
+ *    `REGISTRERING_UNNTAK_GODKJENN` → REGISTRERT_UNNTAK.
+ *  - MEDL oppdateres in-place: NV-lovvalgsperioden deler samme `medlperiode_id` som
+ *    førstegang. `verifiserRegistrertUnntakIverksatt` (nyeste rad) treffer NV-radene.
+ *
+ * Scenario (varsleUtland=false → ingen utgående SED, som P1):
+ *  - Del A: etabler førstegangs-saken (P1-stegene) → REGISTRERT_UNNTAK.
+ *  - Del B: opprett en nyvurdering og bekreft at NV-grenen (riktig tema) ble truffet.
+ *  - Del C: fullfør NV-grenen og verifiser at unntaket re-registreres ende-til-ende.
+ */
+test.describe('EU/EØS - Nyvurdering av inngående A003 (annet land utpekt)', () => {
+  test('skal nyvurdere en registrert annet-land-sak og re-registrere unntaket', async ({ page, request }) => {
+    test.setTimeout(300000);
+
+    const auth = new AuthHelper(page);
+    const hovedside = new HovedsidePage(page);
+    const opprettSak = new OpprettNySakPage(page);
+    const utpeking = new EuEosUtpekingPage(page);
+
+    // === DEL A: Etabler førstegangs-saken (inngående A003 annet land → REGISTRERT_UNNTAK) ===
+    console.log('📝 Del A: Injiserer inngående A003 (annet land utpekt, lovvalgsland=SE)...');
+    const sed = new SedHelper(request);
+    const result = await sed.sendSed({
+      sedType: 'A003',
+      bucType: 'LA_BUC_02',
+      lovvalgsland: 'SE',
+      artikkel: '13_1_a',
+      // varsleUtland=false sender ingen SED → ingen åpen BUC i RINA-store nødvendig.
+    });
+    expect(result.success, `Send A003 feilet: ${result.message}`).toBe(true);
+    await waitForProcessInstances(request, 60);
+
+    await auth.login();
+    await hovedside.goto();
+    await hovedside.åpneBehandling(`${BRUKERNAVN_VALID} -`);
+    await page.waitForLoadState('networkidle').catch(() => {});
+
+    console.log('📝 Del A: Godkjenner utpekingen og registrerer førstegangs-unntaket...');
+    await utpeking.godkjennUtpekingAnnetLand({ varsleUtland: false });
+    await waitForProcessInstances(request, 90);
+
+    // === DEL B: Opprett nyvurdering og bekreft at NV-grenen (riktig tema) ble truffet ===
+    console.log('📝 Del B: Oppretter nyvurdering...');
+    await hovedside.goto();
+    await hovedside.klikkOpprettNySak();
+    await opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD');
+    await waitForProcessInstances(request, 30);
+
+    // Hele poenget med cellen: NV-behandlingen skal ha annet-land-temaet — ikke UTSENDT.
+    await utpeking.assertions.verifiserNyVurderingAnnetLandOpprettet();
+
+    // Åpne den nye NV-behandlingen (åpneBehandling tar nyeste lenke, med reload-retry).
+    await hovedside.goto();
+    await hovedside.åpneBehandling(`${BRUKERNAVN_VALID} -`);
+    await page.waitForLoadState('networkidle').catch(() => {});
+
+    // === DEL C: Fullfør NV-grenen og verifiser re-registrert unntak ende-til-ende ===
+    console.log('📝 Del C: Godkjenner lovvalgsbeslutningen på nytt i nyvurderingen...');
+    await utpeking.godkjennUtpekingAnnetLand({ varsleUtland: false });
+
+    console.log('📝 Del C: Venter på at NV-ens REGISTRERING_UNNTAK_GODKJENN fullfører...');
+    await waitForProcessInstances(request, 90);
+
+    // Gjenbruk P1-assertionen — tar nyeste rad = NV-behandlingens sluttilstand.
+    await utpeking.assertions.verifiserRegistrertUnntakIverksatt(request, {
+      lovvalgsland: 'SE',
+      medlLovvalgsland: 'SWE',
+    });
+
+    console.log('✅ Nyvurdering av inngående A003 (annet land) → REGISTRERT_UNNTAK verifisert ende-til-ende');
+  });
+});


### PR DESCRIPTION
## P5a — Nyvurdering av inngående annet-land-sak → REGISTRERT_UNNTAK

Lukker heatmap-cellen `BESLUTNING_LOVVALG_ANNET_LAND × NY_VURDERING` (~10,2k/12mo)
fra E2E gap-plan P5. Cellen var en **falsk ✅** funnet ved volum-verifiseringen
2026-06-14: den eksisterende `eu-eos-12.1-nyvurdering-medl-overforing` er
`UTSENDT_ARBEIDSTAKER` (art. 12(1)), *ikke* inngående annet land. P1 (#278) dekker
førstegangs-grenen; denne testen dekker nyvurderings-grenen og retter feiletiketten.

### Fase A — verify-don't-trust (live-repro 2026-06-15)
- **Manuell gren:** NV-behandlingen lander på samme 2-stegs utpeking-wizard som
  førstegang → `godkjennUtpekingAnnetLand` gjenbrukes uendret.
- **Discriminator:** NV får `BEH_TYPE=NY_VURDERING` + `BEH_TEMA=BESLUTNING_LOVVALG_ANNET_LAND`
  (vs førstegangens `FØRSTEGANG`), og sin egen `REGISTRERING_UNNTAK_GODKJENN` → `REGISTRERT_UNNTAK`.
- **MEDL in-place:** NV-lovvalgsperioden deler samme `medlperiode_id` som førstegang;
  `verifiserRegistrertUnntakIverksatt` (nyeste rad) treffer NV-radene.

### Endringer
- Ny test `tests/eu-eos/eu-eos-inngaaende-a003-annet-land-nyvurdering.spec.ts`
  (Del A førstegang via P1-steg → Del B opprett NV + discriminator-assert → Del C fullfør NV + sluttilstand).
- Ny POM-assert `verifiserNyVurderingAnnetLandOpprettet` i `eu-eos-utpeking.assertions.ts`.

### Verifisering
- `npm run check:tests` grønn.
- Lokal kjøring grønn (`REGISTRERING_UNNTAK_GODKJENN: 2` → begge grener kjørt).
- CI (workflow_dispatch) verifiseres separat før merge.
