### PR TITLE
NOJIRA P5b: e2e A010 førstegang → REGISTRERT_UNNTAK (øvrige)

### DIFF
--- a/helpers/sed-helper.ts
+++ b/helpers/sed-helper.ts
@@ -477,6 +477,21 @@ export const SED_SCENARIOS = {
   } as SedConfig,
 
   /**
+   * A010 provisional determination from Germany
+   * Triggers: MOTTAK_SED → REGISTRERING_UNNTAK_NY_SAK → REGISTRERING_UNNTAK_GODKJENN
+   * Søsken-temaet til A009: samme automatiske registreringsmaskineri
+   * (UnntaksperiodeSedRuter), men ruter til REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE
+   * (A009 → _UTSTASJONERING). Ender automatisk som REGISTRERT_UNNTAK i mottaket.
+   */
+  A010_FRA_TYSKLAND: {
+    bucType: 'LA_BUC_02',
+    sedType: 'A010',
+    landkode: 'DE',
+    avsenderId: 'DE:DRV',
+    lovvalgsland: 'DE',
+  } as SedConfig,
+
+  /**
    * A001 application from Denmark
    * Triggers: MOTTAK_SED → new application handling
    */

--- a/tests/core/sed-mottak.spec.ts
+++ b/tests/core/sed-mottak.spec.ts
@@ -197,6 +197,60 @@ test.describe('SED Mottak', () => {
     console.log('✅ A009 routed + journalført + automatisk REGISTRERT_UNNTAK iverksatt');
   });
 
+  test('skal håndtere A010 og automatisk registrere unntak fra norsk trygd – øvrige (REGISTRERT_UNNTAK)', async ({ page, request }) => {
+    // P5b (REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE, ~9,8k/12mo): søsken-temaet til
+    // A009/P4. A010 (øvrige tilfeller) registrerer unntaket fra norsk trygd HELT
+    // AUTOMATISK i mottaket — nøyaktig samme maskineri som A009 (UnntaksperiodeSedRuter,
+    // gjelderSedTyper() = {A009, A010}), men ruter til behandlingstema
+    // REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE i stedet for _UTSTASJONERING. Fase A-repro
+    // 2026-06-15 (behandling 147, A010 fra DE) bekreftet identisk sluttilstand som A009:
+    // MOTTAK_SED + REGISTRERING_UNNTAK_NY_SAK + REGISTRERING_UNNTAK_GODKJENN alle FERDIG
+    // uten UI, behandlingsresultat REGISTRERT_UNNTAK / GODKJENT, lovvalg DE / UNNTATT.
+    // Denne testen vokter den distinkte A010-grenen (egen tema-mapping i
+    // hentBehandlingstema + eget regelsett i UnntaksperiodeKontrollsett) — en regresjon
+    // der fanges ikke av A009-testen. Ingen mock-endring: A010 går gjennom det generiske
+    // /lag-melosys-eessi-melding-endepunktet på lik linje med A009.
+    console.log('📝 Step 1: Sending A010 provisional determination from Germany...');
+    const result = await sedHelper.sendSed(SED_SCENARIOS.A010_FRA_TYSKLAND);
+
+    expect(result.success, `Send SED failed: ${result.message}`).toBe(true);
+    console.log(`   ✅ SED sent: sedId=${result.sedId}`);
+
+    console.log('📝 Step 2: Waiting for process to complete...');
+    const processResult = await awaitProcessInstances(request, {
+      timeoutSeconds: 60,
+      expectedInstances: 1,
+    });
+
+    console.log(`   Status: ${processResult.status}, Message: ${processResult.message}`);
+    expect(processResult.success, `Process failed: ${processResult.message}`).toBe(true);
+
+    // P2: A010 rutes til registrering av unntak fra norsk trygd – øvrige (≠ A009 _UTSTASJONERING)
+    console.log('📝 Step 3: Verifying A010 routed to REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE...');
+    const ruting = await verifiserSedRutetTilTema({
+      forventetTema: 'REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE',
+      rutingProsess: 'REGISTRERING_UNNTAK_NY_SAK',
+    });
+
+    // P3: A010 skal journalføres som INNGAAENDE EESSI-journalpost
+    await verifiserInngaaendeSedJournalfoert(request, {
+      saksnummer: ruting.saksnummer,
+      sedType: 'A010',
+    });
+
+    // P5b: det automatiske utfallet skal være et REGISTRERT_UNNTAK. Gjenbruker samme
+    // page-uavhengige POM som A009/P4 — A010 kommer fra Tyskland, så lovvalget overføres
+    // til DE (MEDL-register: DEU).
+    console.log('📝 Step 4: Verifying automatic REGISTRERT_UNNTAK end-state...');
+    const unntakAssertions = new EuEosUtpekingAssertions(page);
+    await unntakAssertions.verifiserRegistrertUnntakIverksatt(request, {
+      lovvalgsland: 'DE',
+      medlLovvalgsland: 'DEU',
+    });
+
+    console.log('✅ A010 routed (ØVRIGE) + journalført + automatisk REGISTRERT_UNNTAK iverksatt');
+  });
+
   test('skal håndtere A001 søknad fra Danmark', async ({ request }) => {
     console.log('📝 Step 1: Sending A001 application from Denmark...');
     const result = await sedHelper.sendSed(SED_SCENARIOS.A001_FRA_DANMARK);


### PR DESCRIPTION
## Hva
Lukker **siste celle** i E2E-gap-plan P5: `REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE × FØRSTEGANG` (~9,8k/12mo). Søsken-temaet til A009/P4 (`_UTSTASJONERING`).

## Fase A (verify-don't-trust) — GO
Live-repro 2026-06-15 (behandling 147, A010 fra DE injisert mot lokal stack):
- BEH_TEMA `REGISTRERING_UNNTAK_NORSK_TRYGD_ØVRIGE`, FØRSTEGANG, MIDLERTIDIG_LOVVALGSBESLUTNING
- BEHANDLINGSRESULTAT `REGISTRERT_UNNTAK` / GODKJENT, lovvalg DE / ART13_1A / INNVILGET / UNNTATT
- MOTTAK_SED + REGISTRERING_UNNTAK_NY_SAK + REGISTRERING_UNNTAK_GODKJENN alle FERDIG (automatisk, ingen UI)

A010 bruker **nøyaktig samme maskineri som A009** (`UnntaksperiodeSedRuter`, `gjelderSedTyper()={A009,A010}`); eneste forskjell er tema-labelen (`_ØVRIGE` vs `_UTSTASJONERING`) + eget regelsett i `UnntaksperiodeKontrollsett`. **Mock-blokkeren i planen var en falsk premiss** — A010 går gjennom det eksisterende generiske `/lag-melosys-eessi-melding`-endepunktet uten endring. ⇒ GO som tynt sluttilstands-løft (som P4), ingen mock-PR.

## Endringer
- `helpers/sed-helper.ts`: ny `SED_SCENARIOS.A010_FRA_TYSKLAND` (speiler `A009_FRA_TYSKLAND`)
- `tests/core/sed-mottak.spec.ts`: ny test som verifiserer ruting til `_ØVRIGE`, journalføring (A010), og automatisk `REGISTRERT_UNNTAK` (DE/DEU) via gjenbrukt `verifiserRegistrertUnntakIverksatt`. Vokter den distinkte A010-grenen som A009-testen ikke dekker.

## Test
- `check:tests` grønn
- Lokalt: hele `sed-mottak.spec.ts` grønn 13/13 (inkl. ny A010 + @eessi-søsken), rene docker-logger
- /code-review (high): ingen funn (de to «race»-kandidatene er pre-eksisterende delt-infra-mønster, umulige under workers=1 + fullyParallel=false + DB-wipe-per-test)

> Ærlig verdivurdering: inkrementell bug-fangst er lav (parallell maskineri til A009), men kost ~null og lukker P5-planen rent med en regresjonsvakt på egen tema-gren. Etter denne er hele den volum-vektede gap-planen (P1–P5) komplett.