### PR TITLE
E2E-dekning: utvid JaCoCo-kodedekning til alle backend-tjenester

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -646,6 +646,11 @@ jobs:
             else
               echo "⚠️ [$svc] report generation failed"
             fi
+
+            # Reports are written; drop the large extraction artifacts (fat-jar +
+            # unpacked classes) so they don't sit on the runner. Only the
+            # *.exec/*.csv/*.xml/*-html outputs are kept and uploaded.
+            rm -rf "service-coverage/$svc.jar" "service-coverage/$svc-classes"
           done
 
           echo ""
@@ -985,7 +990,9 @@ jobs:
                 method_pct="0.0"
               fi
 
-              echo "| $module | ${line_pct}% | ${branch_pct}% | ${method_pct}% |" >> $GITHUB_STEP_SUMMARY
+              # branch_pct may be "N/A" (no branches) — don't append "%" to it
+              if [ "$branch_pct" = "N/A" ]; then branch_cell="N/A"; else branch_cell="${branch_pct}%"; fi
+              echo "| $module | ${line_pct}% | ${branch_cell} | ${method_pct}% |" >> $GITHUB_STEP_SUMMARY
             done
 
             if [ $((total_line_covered + total_line_missed)) -gt 0 ]; then
@@ -1032,7 +1039,9 @@ jobs:
                   method_pct="0.0"
                 fi
 
-                echo "| $svc | ${line_pct}% | ${branch_pct}% | ${method_pct}% |" >> $GITHUB_STEP_SUMMARY
+                # branch_pct may be "N/A" (no branches) — don't append "%" to it
+                if [ "$branch_pct" = "N/A" ]; then branch_cell="N/A"; else branch_cell="${branch_pct}%"; fi
+                echo "| $svc | ${line_pct}% | ${branch_cell} | ${method_pct}% |" >> $GITHUB_STEP_SUMMARY
               done
             fi
           fi

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -598,6 +598,60 @@ jobs:
           echo "📊 CSV files found:"
           find . -path "*/target/site/jacoco/jacoco.csv" -type f
 
+      - name: Collect JaCoCo coverage from other backend services
+        if: always() && inputs.collect_coverage
+        # Unlike melosys-api (built from source above), the other JVM services get their
+        # .class files extracted straight from each running container's Spring Boot fat-jar
+        # (/app/app.jar → BOOT-INF/classes). This is build-tool agnostic (Maven + Gradle),
+        # needs no per-repo checkout/build, and the classes match the exact image under test.
+        # Each service runs the agent on internal port 6300, mapped to a distinct host port.
+        run: |
+          echo "📊 Collecting E2E coverage from backend services (JAR-extraction method)..."
+          mkdir -p service-coverage
+
+          # service:host-port (container name == service name); see docker-compose.yml
+          SERVICES="melosys-eessi:6301 faktureringskomponenten:6302 melosys-dokgen:6303 melosys-trygdeavgift-beregning:6304 melosys-trygdeavtale:6305 melosys-inngangsvilkar:6306"
+
+          for entry in $SERVICES; do
+            svc="${entry%%:*}"
+            port="${entry##*:}"
+            echo ""
+            echo "──────── $svc (port $port) ────────"
+
+            # 1. Dump runtime coverage from the agent's TCP server
+            if ! java -jar jacoco/jacococli.jar dump \
+                  --address localhost --port "$port" \
+                  --destfile "service-coverage/$svc.exec"; then
+              echo "⚠️ [$svc] dump failed (agent not attached / service down) — skipping"
+              continue
+            fi
+
+            # 2. Extract compiled app classes from the running container's fat-jar
+            if ! docker cp "$svc:/app/app.jar" "service-coverage/$svc.jar"; then
+              echo "⚠️ [$svc] docker cp of /app/app.jar failed — skipping report"
+              continue
+            fi
+            mkdir -p "service-coverage/$svc-classes"
+            ( cd "service-coverage/$svc-classes" && unzip -qo "../$svc.jar" 'BOOT-INF/classes/*' ) \
+              || { echo "⚠️ [$svc] unzip of BOOT-INF/classes failed — skipping report"; continue; }
+
+            # 3. Generate CSV/XML/HTML report from the .exec + extracted classes
+            if java -jar jacoco/jacococli.jar report "service-coverage/$svc.exec" \
+                  --classfiles "service-coverage/$svc-classes/BOOT-INF/classes" \
+                  --csv "service-coverage/$svc.csv" \
+                  --xml "service-coverage/$svc.xml" \
+                  --html "service-coverage/$svc-html" \
+                  --name "$svc"; then
+              echo "✅ [$svc] report generated"
+            else
+              echo "⚠️ [$svc] report generation failed"
+            fi
+          done
+
+          echo ""
+          echo "📋 Service coverage CSVs generated:"
+          ls -1 service-coverage/*.csv 2>/dev/null || echo "  (none — check agent attachment in service logs)"
+
       - name: E2E Coverage Report
         uses: madrapps/jacoco-report@50d3aff4548aa991e6753342d9ba291084e63848 # v1.7.2
         if: github.event_name == 'pull_request'
@@ -617,6 +671,10 @@ jobs:
           path: |
             e2e-coverage.exec
             melosys-api/**/target/site/jacoco/
+            service-coverage/*.exec
+            service-coverage/*.csv
+            service-coverage/*.xml
+            service-coverage/*-html/
           retention-days: 30
 
       - name: Generate test summary
@@ -938,6 +996,45 @@ jobs:
             fi
 
             cd ..
+
+            # --- Per-service coverage (the other backend services the suite drives) ---
+            if ls service-coverage/*.csv >/dev/null 2>&1; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "## 📊 E2E Coverage per Service" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "_Coverage of the other backend services exercised by the E2E suite (classes extracted from each running image)_" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "| Service | Lines | Branches | Methods |" >> $GITHUB_STEP_SUMMARY
+              echo "|---------|-------|----------|---------|" >> $GITHUB_STEP_SUMMARY
+
+              for csv_file in service-coverage/*.csv; do
+                svc=$(basename "$csv_file" .csv)
+                line_covered=$(awk -F',' 'NR>1 {sum+=$9} END {print sum+0}' "$csv_file")
+                line_missed=$(awk -F',' 'NR>1 {sum+=$8} END {print sum+0}' "$csv_file")
+                branch_covered=$(awk -F',' 'NR>1 {sum+=$7} END {print sum+0}' "$csv_file")
+                branch_missed=$(awk -F',' 'NR>1 {sum+=$6} END {print sum+0}' "$csv_file")
+                method_covered=$(awk -F',' 'NR>1 {sum+=$13} END {print sum+0}' "$csv_file")
+                method_missed=$(awk -F',' 'NR>1 {sum+=$12} END {print sum+0}' "$csv_file")
+
+                if [ $((line_covered + line_missed)) -gt 0 ]; then
+                  line_pct=$(awk "BEGIN {printf \"%.1f\", ($line_covered / ($line_covered + $line_missed)) * 100}")
+                else
+                  line_pct="0.0"
+                fi
+                if [ $((branch_covered + branch_missed)) -gt 0 ]; then
+                  branch_pct=$(awk "BEGIN {printf \"%.1f\", ($branch_covered / ($branch_covered + $branch_missed)) * 100}")
+                else
+                  branch_pct="N/A"
+                fi
+                if [ $((method_covered + method_missed)) -gt 0 ]; then
+                  method_pct=$(awk "BEGIN {printf \"%.1f\", ($method_covered / ($method_covered + $method_missed)) * 100}")
+                else
+                  method_pct="0.0"
+                fi
+
+                echo "| $svc | ${line_pct}% | ${branch_pct}% | ${method_pct}% |" >> $GITHUB_STEP_SUMMARY
+              done
+            fi
           fi
 
       - name: Capture complete docker logs

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,11 @@ coverage/
 .nyc_output/
 *.lcov
 
+# E2E JaCoCo coverage runtime artifacts (CI-only; agent jars, exec dumps, extracted classes)
+jacoco/
+service-coverage/
+*.exec
+
 # TypeScript
 *.tsbuildinfo
 .tscache/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,6 +178,8 @@ services:
         condition: service_healthy
     environment:
       SPRING_PROFILES_ACTIVE: local
+      # JaCoCo coverage agent (optional - only set in CI for E2E coverage)
+      JAVA_TOOL_OPTIONS: ${JACOCO_AGENT_OPTS:-}
       SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres:5432/postgres?currentSchema=faktureringskomponenten"
       SPRING_DATASOURCE_USERNAME: postgres
       SPRING_DATASOURCE_PASSWORD: mysecretpassword
@@ -195,16 +197,25 @@ services:
           - faktureringskomponenten.melosys.docker-internal
     ports:
       - "8084:8084"
+      - "6302:6300"  # JaCoCo coverage port
+    volumes:
+      - ./jacoco:/jacoco:ro  # Mount JaCoCo agent (optional, for E2E coverage)
 
   melosys-dokgen:
     image: europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-dokgen:${MELOSYS_DOKGEN_TAG:-latest}
     container_name: melosys-dokgen
+    environment:
+      # JaCoCo coverage agent (optional - only set in CI for E2E coverage)
+      JAVA_TOOL_OPTIONS: ${JACOCO_AGENT_OPTS:-}
     networks:
       melosys.docker-internal:
         aliases:
           - melosys-dokgen.melosys.docker-internal
     ports:
       - "8888:8080"
+      - "6303:6300"  # JaCoCo coverage port
+    volumes:
+      - ./jacoco:/jacoco:ro  # Mount JaCoCo agent (optional, for E2E coverage)
 
   melosys-trygdeavgift-beregning:
     image: europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-trygdeavgift-beregning:${MELOSYS_TRYGDEAVGIFT_TAG:-latest}
@@ -214,6 +225,8 @@ services:
         condition: service_healthy
     environment:
       SPRING_PROFILES_ACTIVE: local
+      # JaCoCo coverage agent (optional - only set in CI for E2E coverage)
+      JAVA_TOOL_OPTIONS: ${JACOCO_AGENT_OPTS:-}
       SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres:5432/postgres?currentSchema=trygdeavgift-beregning"
       SPRING_DATASOURCE_USERNAME: postgres
       SPRING_DATASOURCE_PASSWORD: mysecretpassword
@@ -231,6 +244,9 @@ services:
           - melosys-trygdeavgift-beregning.melosys.docker-internal
     ports:
       - "8095:8095"
+      - "6304:6300"  # JaCoCo coverage port
+    volumes:
+      - ./jacoco:/jacoco:ro  # Mount JaCoCo agent (optional, for E2E coverage)
 
   melosys-api:
     image: europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-api:${MELOSYS_API_TAG:-latest}
@@ -442,6 +458,8 @@ services:
           - melosys-trygdeavtale.melosys.docker-internal
     environment:
       SPRING_PROFILES_ACTIVE: local-docker
+      # JaCoCo coverage agent (optional - only set in CI for E2E coverage)
+      JAVA_TOOL_OPTIONS: ${JACOCO_AGENT_OPTS:-}
       JDBC_URL: jdbc:postgresql://postgres:5432/postgres
       SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres:5432/postgres?currentSchema=melosys-trygdeavtale"
       SPRING_DATASOURCE_USERNAME: postgres
@@ -450,6 +468,9 @@ services:
       ABAC_PDP_ENDPOINT_URL: http://melosys-mock:8083/asm-pdp/authorize
     ports:
       - "8088:8088"
+      - "6305:6300"  # JaCoCo coverage port
+    volumes:
+      - ./jacoco:/jacoco:ro  # Mount JaCoCo agent (optional, for E2E coverage)
 
   melosys-inngangsvilkar:
     image: europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-inngangsvilkar:${MELOSYS_INNGANGSVILKAR_TAG:-latest}
@@ -464,6 +485,8 @@ services:
           - melosys-inngangsvilkar.melosys.docker-internal
     environment:
       SPRING_PROFILES_ACTIVE: local-docker
+      # JaCoCo coverage agent (optional - only set in CI for E2E coverage)
+      JAVA_TOOL_OPTIONS: ${JACOCO_AGENT_OPTS:-}
       JDBC_URL: jdbc:postgresql://postgres:5432/postgres
       SPRING_DATASOURCE_URL: "jdbc:postgresql://postgres:5432/postgres?currentSchema=melosys-inngangsvilkar"
       SPRING_DATASOURCE_USERNAME: postgres
@@ -472,6 +495,9 @@ services:
       ABAC_PDP_ENDPOINT_URL: http://melosys-mock:8083/asm-pdp/authorize
     ports:
       - "8089:8080"
+      - "6306:6300"  # JaCoCo coverage port
+    volumes:
+      - ./jacoco:/jacoco:ro  # Mount JaCoCo agent (optional, for E2E coverage)
 
   # ============================================================================
   # EESSI Integration
@@ -489,8 +515,13 @@ services:
       - unleash
     ports:
       - "8081:8081"
+      - "6301:6300"  # JaCoCo coverage port
+    volumes:
+      - ./jacoco:/jacoco:ro  # Mount JaCoCo agent (optional, for E2E coverage)
     environment:
       SPRING_PROFILES_ACTIVE: local-mock
+      # JaCoCo coverage agent (optional - only set in CI for E2E coverage)
+      JAVA_TOOL_OPTIONS: ${JACOCO_AGENT_OPTS:-}
       # Server port (matches local-mock profile)
       SERVER_PORT: 8081
       # Database configuration

--- a/docs/ci-cd/E2E-COVERAGE.md
+++ b/docs/ci-cd/E2E-COVERAGE.md
@@ -137,6 +137,64 @@ fi
 - Total coverage across all modules
 - Appears after Docker Log Analysis section
 
+## Multi-Service Coverage (all backend services)
+
+The Playwright suite drives the whole stack, not just melosys-api — every UI step fans out
+to the other JVM services. When `collect_coverage=true`, coverage is now collected for **all**
+our backend services, each via a JaCoCo agent on its own host port:
+
+| Service | Host port | JDK | Build |
+|---------|-----------|-----|-------|
+| melosys-api | 6300 | 21 | Maven (built from source — see steps above) |
+| melosys-eessi | 6301 | 21 | (JAR-extraction) |
+| faktureringskomponenten | 6302 | 17 | Gradle (JAR-extraction) |
+| melosys-dokgen | 6303 | 17 | (JAR-extraction) |
+| melosys-trygdeavgift-beregning | 6304 | 17 | (JAR-extraction) |
+| melosys-trygdeavtale | 6305 | 17 | (JAR-extraction) |
+| melosys-inngangsvilkar | 6306 | 17 | (JAR-extraction) |
+
+**Why two methods?** melosys-api keeps its original *build-from-source* path (gives
+source-annotated HTML). The other six are a mix of Maven + Gradle on different JDKs, so
+replicating a source build 6× would be slow and fragile. Instead, for those services we
+**extract the compiled `.class` files directly from each running container's Spring Boot
+fat-jar** and report with the JaCoCo CLI:
+
+1. Every JVM container mounts `./jacoco:/jacoco:ro` and runs the agent on internal port `6300`
+   (shared `JACOCO_AGENT_OPTS`), mapped to a distinct host port (`docker-compose.yml`).
+2. After the suite, the workflow step *"Collect JaCoCo coverage from other backend services"*:
+   - `jacococli dump` from each host port → `service-coverage/<svc>.exec`
+   - `docker cp <svc>:/app/app.jar` → unzip `BOOT-INF/classes` (the service's own code)
+   - `jacococli report` → `service-coverage/<svc>.{csv,xml}` + HTML
+
+This is **build-tool agnostic** and the classes are guaranteed to match the exact image under
+test. Trade-off: the six services get accurate per-class/method/line **counters** (CSV/XML +
+counter-only HTML) but no source-line-annotated HTML (no source checkout). The
+*"📊 E2E Coverage per Service"* job-summary table and the `e2e-coverage-report` artifact
+(`service-coverage/`) carry the numbers.
+
+Each service step is best-effort: a failed dump/extract for one service logs a warning and is
+skipped, never aborting the others or the run.
+
+## Frontend Coverage (melosys-web) — deferred
+
+Frontend coverage is **not** collected yet. melosys-web is a Vite 7 / React 19 app served as a
+minified **production** bundle (Nginx image) with **no sourcemaps**, so Playwright's V8
+coverage would not map back to source — it would be vacuous. Getting meaningful numbers
+requires a build-time-instrumented variant, which lives in melosys-web's own repo/CI.
+
+**Minimal path when prioritized (Option B — `vite-plugin-istanbul`):**
+1. melosys-web `vite.config.ts`: add `vite-plugin-istanbul`, gated on `VITE_COVERAGE=true`.
+2. melosys-web CI: build `VITE_COVERAGE=true pnpm build` → push `melosys-web:coverage-<sha>`
+   (same Nginx Dockerfile).
+3. E2E coverage run: set `MELOSYS_WEB_TAG=coverage-<sha>` (override already exists,
+   `docker-compose.yml`).
+4. Playwright fixture (mirror `fixtures/`): after each test read
+   `await page.evaluate(() => window.__coverage__)` → `.nyc_output/<test>.json`.
+5. Aggregate with `monocart-coverage-reports` (or `nyc report`) → HTML/lcov artifact.
+
+Estimated ~1–1.5 days, cross-repo (most work in melosys-web). Skip the V8/`page.coverage`
+route unless melosys-web ships prod sourcemaps for other reasons.
+
 ## Current Configuration
 
 ### When Coverage Runs


### PR DESCRIPTION
Utvider E2E-kodedekning (`collect_coverage`-input) fra kun melosys-api til **alle våre backend-tjenester**: melosys-eessi, faktureringskomponenten, melosys-dokgen, melosys-trygdeavgift-beregning, melosys-trygdeavtale og melosys-inngangsvilkar.

Playwright-suiten driver hele stacken — hvert UI-steg treffer flere tjenester — men vi hadde til nå null innsyn i hvor mye av de andre tjenestene testene faktisk dekker.

For de seks tjenestene hentes `.class`-filene rett fra hvert kjørende images Spring Boot-fat-jar (`/app/app.jar` → `BOOT-INF/classes`) og rapporteres med `jacococli`. Dette er byggverktøy-agnostisk (fungerer for både Maven og Gradle), krever ingen kildebygg per repo, og klassene matcher eksakt imaget under test. melosys-api beholder sitt eksisterende kildebygg-løp uendret.

- `docker-compose.yml`: hver JVM-tjeneste mounter `./jacoco` og eksponerer egen vertsport (6301–6306; agenten kjører på intern 6300 i alle)
- `e2e-tests.yml`: nytt best-effort steg dumper + rapporterer per tjeneste, ny «📊 E2E Coverage per Service»-tabell i job-summary, `service-coverage/` lagt til artefakt
- `docs/ci-cd/E2E-COVERAGE.md`: multi-tjeneste-seksjon + frontend-utsatt-seksjon; `.gitignore`: jacoco/, service-coverage/, *.exec

Frontend (melosys-web) er **utsatt** denne iterasjonen — minifisert prod-bundle uten sourcemaps gjør Playwright V8-dekning verdiløs; reell vei (vite-plugin-istanbul-image i eget repo) er dokumentert som oppfølging.

## Testing
- [x] E2E-dekningskjøring grønn (run 27821218842, ~1t01m) — alle 6 tjenester ga non-zero line-coverage:

  | Tjeneste | Lines | Bygg |
  |---|---|---|
  | melosys-trygdeavgift-beregning | 81.3% | Maven |
  | melosys-inngangsvilkar | 80.7% | Maven |
  | melosys-trygdeavtale | 77.9% | Maven |
  | faktureringskomponenten | 63.5% | Gradle |
  | melosys-dokgen | 62.4% | Maven |
  | melosys-eessi | 45.5% | Maven |

- [x] `docker compose config` + workflow-YAML validert lokalt
- [x] Normal (uten dekning) kjøring upåvirket — tjenestene starter uten agent

## Notes
Dekning er opt-in (`collect_coverage=true`, kun `workflow_dispatch`). Normale kjøringer er upåvirket: tom `JACOCO_AGENT_OPTS` = ingen agent, ingen overhead.