### PR TITLE
8148 E2E-test: automatisk innhentingsbrev i saksbehandlingsflyt

### DIFF
--- a/specs/aarsavregning-innhentingsbrev-saksbehandlingsflyt.md
+++ b/specs/aarsavregning-innhentingsbrev-saksbehandlingsflyt.md
@@ -60,17 +60,27 @@ Gitt at saksbehandler manuelt oppretter en årsavregningsbehandling på saken
  Så skal Melosys ikke sende brevet «Innhenting av inntektsopplysninger»
 ```
 
+## Scenario 4 — EØS-pensjonist er unntatt
+
+```gherkin
+Gitt at saksbehandler fatter vedtak i en saksbehandlingsflyt for en EØS-pensjonist
+  Og vedtaket medfører en endring for et tidligere inntektsår X
+  Og Melosys automatisk oppretter en årsavregningsbehandling for år X
+ Når årsavregningsbehandlingen opprettes
+ Så skal Melosys ikke sende brevet «Innhenting av inntektsopplysninger» (EØS-pensjonister er unntatt)
+```
+
 ## Akseptansekriterier (det fagperson signerer av på)
 
 - [ ] Når Melosys automatisk oppretter årsavregningsbehandling som følge av vedtak i saksbehandlingsflyten, og bruker ikke har fullmektig FULLMEKTIG_SØKNAD registrert, sendes brevet «Innhenting av inntektsopplysninger» automatisk til bruker
 - [ ] Når Melosys automatisk oppretter årsavregningsbehandling som følge av vedtak i saksbehandlingsflyten, og bruker **har** fullmektig FULLMEKTIG_SØKNAD registrert, sendes brevet automatisk til fullmektig
 - [ ] Når saksbehandler manuelt oppretter en årsavregningsbehandling, sendes det **ikke** noe innhentingsbrev automatisk
 - [ ] Brevutsending skjer for FTRL yrkesaktiv, FTRL pensjonist og EØS offentlig tjenesteperson (minst disse tre sakstype-flytene)
-- [ ] EØS-pensjonister er **ikke** inkludert i denne historien — de skal ikke motta brev via denne funksjonaliteten per nå
+- [x] EØS-pensjonister er **ikke** inkludert i denne historien — de skal ikke motta brev via denne funksjonaliteten per nå *(e2e-verifisert negativt, scenario 4)*
 
 ## Kjente avgrensninger (ikke dekket her)
 
-- **EØS-pensjonister** — krever særskilt brevtekst; dekkes i separat oppgave (jf. kommentar fra Yvonne 19. juni 2026).
+- **EØS-pensjonister, særskilt brevtekst** — at de skal motta et *annet* innhentingsbrev med egen tekst dekkes i separat oppgave (jf. Yvonne 19. juni 2026). Denne speken verifiserer kun *negativt* (scenario 4) at de **ikke** får standard-innhentingsbrevet via 8148-funksjonaliteten.
 - **FTRL pensjonist og EØS offentlig tjenesteperson som sakstype-flyter:** AC-et nevner disse i tillegg til FTRL yrkesaktiv. Denne speken binder **FTRL yrkesaktiv** som den kjørbare flyten (samme valg som søsteroppgaven 8122). De øvrige sakstype-flytene er regresjons-utvidelser når de respektive auto-opprettelses­flytene er prodsatt (EØS offentlig tjenesteperson = [MELOSYS-7828](https://nav.atlassian.net/browse/MELOSYS-7828), i akseptanse test).
 - **Skattemeldingslytting og «ikke skattepliktige»-jobben** som trigger — dekkes av [MELOSYS-8122](https://nav.atlassian.net/browse/MELOSYS-8122) (samme brev, annen trigger). Denne speken dekker **kun saksbehandlingsflyt-triggeren**.
 - **Fullmektig-mottaker (scenario 2):** bundet som `test.fixme` — det finnes ingen e2e-fikstur for å registrere en `FULLMEKTIG_SØKNAD`-fullmakt på saken (se binding). Å fake oppsettet ville gitt falsk dekning.
@@ -175,6 +185,25 @@ opprettelsen.
 - **Negativ assertion:** ingen `INNHENTING_AV_INNTEKTSOPPLYSNINGER`-brev-prosessinstans skal finnes
   etter at opprettelses-prosessinstansene er FERDIG (`verifiserIngenInnhentingsbrev`).
 
+### Scenario 4 (kjørbar negativ) — EØS-pensjonist-unntak
+
+Samme flyt-SHAPE som scenario 1 (saksbehandlingsflyt som auto-oppretter årsavregning for tidligere
+år), men for sakstypen **EØS-pensjonist** — der FTRL ville sendt brev, skal EØS-pensjonist ikke få
+det. Isolerer dermed selve sakstype-unntaket (`skalSendeInnhentingsbrev`).
+
+Gjenbruker den eksisterende EØS-pensjonist-fiksturen
+`setupPensjonistUtenGrunnlagMedAutoAarsavregning` (`tests/eu-eos/pensjonist-aarsavregning-setup.ts`):
+EØS-pensjonist førstegangsbehandling med HELE perioden i et tidligere år (01.04–05.04.2024) og
+default toggle-state → trygdeavgift fastsettes ikke på førstegangen, og årsavregningen auto-opprettes
+ved «Bekreft og send» (`OPPRETT_NY_BEHANDLING_AARSAVREGNING`). Etter at fiksturen returnerer er
+auto-opprettelsens prosessinstanser FERDIG (den venter 60 s) og årsavregningsvedtaket er ennå ikke
+fattet.
+
+- **Negativ assertion:** `verifiserIngenInnhentingsbrev()` — filtrerer eksakt på
+  `INNHENTING_AV_INNTEKTSOPPLYSNINGER`, så den treffer **kun** innhentingsbrevet og lures ikke av
+  EØS-pensjonistens førstegangs-resultatbrev (annen brevmal). Verifisert ikke-vakuøs lokalt: flyten
+  produserer 1 `OPPRETT_OG_DISTRIBUER_BREV` (resultatbrev), men 0 innhentingsbrev.
+
 ### Scenario 2 (test.fixme) — fullmektig-mottaker
 
 Bundet som `test.fixme` — identisk begrunnelse som 8122: det finnes ingen e2e-fikstur for å
@@ -227,7 +256,8 @@ treffer aktive prosessinstanser.
 `BEHANDLINGSTEMA`, `BEHANDLINGSTYPE`, `AARSAK`)
 **Hjelpere:** `helpers/api-helper.ts` (`waitForProcessInstances`),
 `helpers/db-helper.ts` (`withDatabase`), `helpers/pg-db-helper.ts` (`withFaktureringDatabase`),
-`helpers/date-helper.ts` (`TestPeriods`), `helpers/unleash-helper.ts` (`UnleashHelper`)
+`helpers/date-helper.ts` (`TestPeriods`), `helpers/unleash-helper.ts` (`UnleashHelper`),
+`tests/eu-eos/pensjonist-aarsavregning-setup.ts` (`setupPensjonistUtenGrunnlagMedAutoAarsavregning`, scenario 4)
 
 ### Endringslogg (teknisk binding)
 
@@ -239,5 +269,9 @@ treffer aktive prosessinstanser.
   `8148-auto-innhentingsbrev-flyt` (e27eb7287a), deretter CI grønn (run 27821184762, `2 passed`,
   `test_grep=MELOSYS-8148`) mot feature-image `melosys-api:8148-auto-innhentingsbrev-flyt-e27eb7287a`.
   Status → verified.
+- 2026-06-19 (tillegg): Lagt til scenario 4 (EØS-pensjonist-unntak, kjørbar negativ) etter spørsmål
+  fra Rune — AC «bortsett fra EØS pensjonister» var dokumentert som avgrensning men ikke e2e-dekket.
+  Gjenbruker `setupPensjonistUtenGrunnlagMedAutoAarsavregning`; ikke-vakuøs (1 resultatbrev, 0
+  innhentingsbrev). Grønn lokalt 19.4s mot samme e27eb7287a-build.
 </content>
 </invoke>

--- a/specs/aarsavregning-innhentingsbrev-saksbehandlingsflyt.md
+++ b/specs/aarsavregning-innhentingsbrev-saksbehandlingsflyt.md
@@ -25,7 +25,7 @@ oppgave). Brevet skal **ikke** sendes når saksbehandler **manuelt** oppretter e
 
 *Hjemmel: skatteforvaltningsforskriften § 2-13-2 og folketrygdloven § 23-3.*
 *Søsteroppgave: [MELOSYS-8122](https://nav.atlassian.net/browse/MELOSYS-8122) (samme brev, men trigget av skattemeldingslytting / ikke-skattepliktig-jobben) — brukes som implementasjonsmønster.*
-*Kilde: [Årsavregning — nav-wiki](file:///Users/rune/source/private/huginn/huginn-nav/wiki/concepts/Årsavregning.md), [Årsavregning - manuell støtte i flyt — Confluence](https://confluence.adeo.no/spaces/TEESSI/pages/704517663), [Mottakere av brev — Confluence](https://confluence.adeo.no/spaces/TEESSI/pages/395304999)*
+*Kilde: [Årsavregning - manuell støtte i flyt — Confluence](https://confluence.adeo.no/spaces/TEESSI/pages/704517663), [Mottakere av brev — Confluence](https://confluence.adeo.no/spaces/TEESSI/pages/395304999)*
 
 ## Scenario 1 — Automatisk opprettet årsavregning, bruker uten fullmektig
 
@@ -95,18 +95,18 @@ Gitt at saksbehandler fatter vedtak i en saksbehandlingsflyt for en EØS-pensjon
 > og skal brukes **ordrett**. Ikke "korriger" dem mot eksempelverdier i POM-ens JSDoc — samme
 > dropdown bruker ulike koder i ulike flyter.
 
-> **Status-merknad:** Auto-utsending av innhentingsbrevet ved *automatisk* opprettelse av
-> årsavregning i saksbehandlingsflyten er **ikke implementert i melosys-api ennå** (MELOSYS-8148 er
-> i «Utvikle og teste»). Søsteroppgaven [MELOSYS-8122](https://nav.atlassian.net/browse/MELOSYS-8122)
-> (samme brev, annen trigger) er i akseptanse test og er implementasjonsmønsteret. Brev-assertionen
-> i scenario 1 forventes derfor **rød** til feature-branchen lander; selve trigger-flyten (sak →
-> vedtak → ny vurdering for tidligere år → auto-opprettet årsavregning) er grønn i dag. Dette er en
-> akseptanse-test skrevet *foran* implementasjonen, etter samme mønster som
+> **Status-merknad:** Auto-utsendingen av innhentingsbrevet ved *automatisk* opprettelse av
+> årsavregning i saksbehandlingsflyten er implementert på melosys-api-feature-branchen
+> `8148-auto-innhentingsbrev-flyt` (MELOSYS-8148 i «Utvikle og teste»). Scenario 1 er **verifisert
+> grønn** mot feature-image-et `melosys-api:8148-auto-innhentingsbrev-flyt-e27eb7287a` (CI run
+> 27821184762, 2 passed), men vil være **rød mot main/`latest`** til melosys-api-branchen er merget.
+> Søsteroppgaven [MELOSYS-8122](https://nav.atlassian.net/browse/MELOSYS-8122) (samme brev, annen
+> trigger) er implementasjonsmønsteret. Dette er en akseptanse-test skrevet *foran* prodsetting,
+> etter samme mønster som
 > [`aarsavregning-innhentingsbrev-automatisk.md`](aarsavregning-innhentingsbrev-automatisk.md) (8122)
 > og [`aarsavregning-oppgave-skatteaar-i-beskrivelse.md`](aarsavregning-oppgave-skatteaar-i-beskrivelse.md) (8123).
-> Testen er **ikke** `@known-error`-tagget (det er for kjente bugs som ikke fikses): den kjøres
-> grønn mot feature-image-et når melosys-api-branchen lander, akkurat som 8122/8123 ble verifisert
-> mot sine feature-images. Scenario 3 (manuell → ingen brev) er grønn allerede i dag.
+> Testen er **ikke** `@known-error`-tagget (det er for kjente bugs som ikke fikses). Scenario 3
+> (manuell → ingen brev) og scenario 4 (EØS-pensjonist-unntak) er grønne også mot main.
 
 ### Forhold til MELOSYS-8123 og MELOSYS-8122
 
@@ -280,5 +280,9 @@ treffer aktive prosessinstanser.
   `MedlemskapBestemmelsekonverter.kt:19`). Test-logikken (brev FERDIG) var grønn begge forsøk; uten
   taggen feilet docker-log-fixturen sporadisk (CI run 27825161737 forsøk 1). sc3/sc4 forblir strenge.
   Pre-eksisterende ERROR-logging flagget til api-peer som egen NOJIRA-opprydding.
-</content>
-</invoke>
+- 2026-06-28: Fjernet `@expect-docker-errors` fra scenario 1 — den pre-eksisterende GUI-race-ERROR-en
+  (`Finner ingen bestemmelse for :` ved NV-lovvalgssteget) er ryddet opp på melosys-api-siden, så
+  docker-log-fixturen kan igjen være streng på alle fire scenariene. Samtidig adressert Copilot-review
+  på PR #284: `ORDER BY REGISTRERT_DATO DESC` i brev-spørringen (deterministisk «fersk» rad),
+  avsluttende `waitForProcessInstances` i scenario 3, oppdatert status-merknad (verifisert grønn mot
+  feature-image), og fjernet lokal `file://`-kildelenke.

--- a/specs/aarsavregning-innhentingsbrev-saksbehandlingsflyt.md
+++ b/specs/aarsavregning-innhentingsbrev-saksbehandlingsflyt.md
@@ -1,7 +1,7 @@
 ---
 jira: MELOSYS-8148
 epic: MELOSYS-7080 — Støtte til endringer i medlemskap og trygdeavgift for tidligere år
-status: implemented  # testen er skrevet; brev-assertions er røde til feature-branchen lander (se status-merknad i binding)
+status: verified  # CI grønn mot melosys-api:8148-auto-innhentingsbrev-flyt-e27eb7287a (run 27821184762, 2 passed)
 test: tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-saksbehandlingsflyt.spec.ts
 toggles: {}          # default-state; per-trigger-koreografi av melosys.faktureringskomponenten.ikke-tidligere-perioder er testmekanikk (se binding)
 tags: [årsavregning, brev, innhenting, saksbehandlingsflyt, ny-vurdering, fullmektig, ftrl]
@@ -235,5 +235,9 @@ treffer aktive prosessinstanser.
   via ny vurdering) og 8122 brev-assertion. Scenario 1 kjørbar (mottaker=bruker), scenario 3 kjørbar
   (manuell → ingen brev), scenario 2 `test.fixme` (ingen fullmakt-fikstur). Brev-assertion korrekt
   rød til melosys-api-feature lander.
+- 2026-06-19: Verifisert grønn. Lokalt (sc1 57.5s, sc3 11.9s) mot melosys-api host-build av
+  `8148-auto-innhentingsbrev-flyt` (e27eb7287a), deretter CI grønn (run 27821184762, `2 passed`,
+  `test_grep=MELOSYS-8148`) mot feature-image `melosys-api:8148-auto-innhentingsbrev-flyt-e27eb7287a`.
+  Status → verified.
 </content>
 </invoke>

--- a/specs/aarsavregning-innhentingsbrev-saksbehandlingsflyt.md
+++ b/specs/aarsavregning-innhentingsbrev-saksbehandlingsflyt.md
@@ -1,0 +1,239 @@
+---
+jira: MELOSYS-8148
+epic: MELOSYS-7080 — Støtte til endringer i medlemskap og trygdeavgift for tidligere år
+status: implemented  # testen er skrevet; brev-assertions er røde til feature-branchen lander (se status-merknad i binding)
+test: tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-saksbehandlingsflyt.spec.ts
+toggles: {}          # default-state; per-trigger-koreografi av melosys.faktureringskomponenten.ikke-tidligere-perioder er testmekanikk (se binding)
+tags: [årsavregning, brev, innhenting, saksbehandlingsflyt, ny-vurdering, fullmektig, ftrl]
+analysis_trace_id: cf7e6d7a-23d6-4c1e-93aa-cb65bcf75f8c
+---
+
+# Automatisk innhentingsbrev ved årsavregning i saksbehandlingsflyten
+
+## Forretningsregel
+
+Når endelig trygdeavgift skal fastsettes (skatteforvaltningsforskriften § 2-13-2), kreves faktisk
+inntekt for inntektsåret som grunnlag. Når Melosys i en **saksbehandlingsflyt** automatisk
+oppretter en årsavregningsbehandling for et **tidligere år X** — fordi saksbehandler fatter et
+vedtak som endrer en periode tilbake i tid — skal systemet umiddelbart innhente nødvendige
+inntektsopplysninger fra bruker. Dette gjøres ved å sende brevet «Innhenting av
+inntektsopplysninger» automatisk til bruker, eller til brukers fullmektig av type
+`FULLMEKTIG_SØKNAD` dersom dette er registrert på saken. Regelen gjelder for alle sakstyper Melosys
+støtter årsavregning for, **med unntak av EØS-pensjonister** (krever særskilt brevtekst, egen
+oppgave). Brevet skal **ikke** sendes når saksbehandler **manuelt** oppretter en
+årsavregningsbehandling — da er inntektsåret ikke valgt ennå.
+
+*Hjemmel: skatteforvaltningsforskriften § 2-13-2 og folketrygdloven § 23-3.*
+*Søsteroppgave: [MELOSYS-8122](https://nav.atlassian.net/browse/MELOSYS-8122) (samme brev, men trigget av skattemeldingslytting / ikke-skattepliktig-jobben) — brukes som implementasjonsmønster.*
+*Kilde: [Årsavregning — nav-wiki](file:///Users/rune/source/private/huginn/huginn-nav/wiki/concepts/Årsavregning.md), [Årsavregning - manuell støtte i flyt — Confluence](https://confluence.adeo.no/spaces/TEESSI/pages/704517663), [Mottakere av brev — Confluence](https://confluence.adeo.no/spaces/TEESSI/pages/395304999)*
+
+## Scenario 1 — Automatisk opprettet årsavregning, bruker uten fullmektig
+
+```gherkin
+Gitt at saksbehandler fatter vedtak i en saksbehandlingsflyt
+  Og vedtaket medfører en endring for et tidligere inntektsår X
+  Og Melosys automatisk oppretter en årsavregningsbehandling for år X
+  Og bruker ikke har en fullmektig av type FULLMEKTIG_SØKNAD registrert på saken
+ Når årsavregningsbehandlingen opprettes
+ Så skal brevet «Innhenting av inntektsopplysninger» sendes automatisk til bruker
+  Og brevet skal gjelde for inntektsåret X
+```
+
+## Scenario 2 — Automatisk opprettet årsavregning, bruker med fullmektig
+
+```gherkin
+Gitt at saksbehandler fatter vedtak i en saksbehandlingsflyt
+  Og vedtaket medfører en endring for et tidligere inntektsår X
+  Og Melosys automatisk oppretter en årsavregningsbehandling for år X
+  Og bruker har en fullmektig av type FULLMEKTIG_SØKNAD registrert på saken
+ Når årsavregningsbehandlingen opprettes
+ Så skal brevet «Innhenting av inntektsopplysninger» sendes automatisk til brukers fullmektig
+  Og brevet skal gjelde for inntektsåret X
+```
+
+## Scenario 3 — Manuell opprettelse av årsavregning
+
+```gherkin
+Gitt at saksbehandler manuelt oppretter en årsavregningsbehandling på saken
+  Og inntektsåret er ikke valgt på opprettelsestidspunktet
+ Når årsavregningsbehandlingen opprettes
+ Så skal Melosys ikke sende brevet «Innhenting av inntektsopplysninger»
+```
+
+## Akseptansekriterier (det fagperson signerer av på)
+
+- [ ] Når Melosys automatisk oppretter årsavregningsbehandling som følge av vedtak i saksbehandlingsflyten, og bruker ikke har fullmektig FULLMEKTIG_SØKNAD registrert, sendes brevet «Innhenting av inntektsopplysninger» automatisk til bruker
+- [ ] Når Melosys automatisk oppretter årsavregningsbehandling som følge av vedtak i saksbehandlingsflyten, og bruker **har** fullmektig FULLMEKTIG_SØKNAD registrert, sendes brevet automatisk til fullmektig
+- [ ] Når saksbehandler manuelt oppretter en årsavregningsbehandling, sendes det **ikke** noe innhentingsbrev automatisk
+- [ ] Brevutsending skjer for FTRL yrkesaktiv, FTRL pensjonist og EØS offentlig tjenesteperson (minst disse tre sakstype-flytene)
+- [ ] EØS-pensjonister er **ikke** inkludert i denne historien — de skal ikke motta brev via denne funksjonaliteten per nå
+
+## Kjente avgrensninger (ikke dekket her)
+
+- **EØS-pensjonister** — krever særskilt brevtekst; dekkes i separat oppgave (jf. kommentar fra Yvonne 19. juni 2026).
+- **FTRL pensjonist og EØS offentlig tjenesteperson som sakstype-flyter:** AC-et nevner disse i tillegg til FTRL yrkesaktiv. Denne speken binder **FTRL yrkesaktiv** som den kjørbare flyten (samme valg som søsteroppgaven 8122). De øvrige sakstype-flytene er regresjons-utvidelser når de respektive auto-opprettelses­flytene er prodsatt (EØS offentlig tjenesteperson = [MELOSYS-7828](https://nav.atlassian.net/browse/MELOSYS-7828), i akseptanse test).
+- **Skattemeldingslytting og «ikke skattepliktige»-jobben** som trigger — dekkes av [MELOSYS-8122](https://nav.atlassian.net/browse/MELOSYS-8122) (samme brev, annen trigger). Denne speken dekker **kun saksbehandlingsflyt-triggeren**.
+- **Fullmektig-mottaker (scenario 2):** bundet som `test.fixme` — det finnes ingen e2e-fikstur for å registrere en `FULLMEKTIG_SØKNAD`-fullmakt på saken (se binding). Å fake oppsettet ville gitt falsk dekning.
+- **Brevinnhold og brevmal** — malens tekst er ikke i scope; mal «Innhenting av inntektsopplysninger v.2» eksisterer fra før (brevmal-identifikator `INNHENTING_AV_INNTEKTSOPPLYSNINGER`).
+
+---
+
+## Teknisk binding
+*(for testagenten — domeneleseren kan stoppe over linjen)*
+
+> **Verbatim-regel:** verdier merket `(verbatim)` er flyt-spesifikke `selectOption`-argumenter
+> og skal brukes **ordrett**. Ikke "korriger" dem mot eksempelverdier i POM-ens JSDoc — samme
+> dropdown bruker ulike koder i ulike flyter.
+
+> **Status-merknad:** Auto-utsending av innhentingsbrevet ved *automatisk* opprettelse av
+> årsavregning i saksbehandlingsflyten er **ikke implementert i melosys-api ennå** (MELOSYS-8148 er
+> i «Utvikle og teste»). Søsteroppgaven [MELOSYS-8122](https://nav.atlassian.net/browse/MELOSYS-8122)
+> (samme brev, annen trigger) er i akseptanse test og er implementasjonsmønsteret. Brev-assertionen
+> i scenario 1 forventes derfor **rød** til feature-branchen lander; selve trigger-flyten (sak →
+> vedtak → ny vurdering for tidligere år → auto-opprettet årsavregning) er grønn i dag. Dette er en
+> akseptanse-test skrevet *foran* implementasjonen, etter samme mønster som
+> [`aarsavregning-innhentingsbrev-automatisk.md`](aarsavregning-innhentingsbrev-automatisk.md) (8122)
+> og [`aarsavregning-oppgave-skatteaar-i-beskrivelse.md`](aarsavregning-oppgave-skatteaar-i-beskrivelse.md) (8123).
+> Testen er **ikke** `@known-error`-tagget (det er for kjente bugs som ikke fikses): den kjøres
+> grønn mot feature-image-et når melosys-api-branchen lander, akkurat som 8122/8123 ble verifisert
+> mot sine feature-images. Scenario 3 (manuell → ingen brev) er grønn allerede i dag.
+
+### Forhold til MELOSYS-8123 og MELOSYS-8122
+
+MELOSYS-8148 = **8123 sin Trigger 3** (saksbehandlingsflyt som berører tidligere år) **+ 8122 sin
+brev-assertion**. Trigger-koreografien (ny vurdering som endrer perioden til kun forrige år, slik at
+`OppretteÅrsavregningVedEndring` auto-oppretter årsavregningen) er *byte-for-byte* den samme som
+den tredje testen i `tests/utenfor-avtaleland/workflows/arsavregning-oppgave-aar-i-beskrivelse.spec.ts`.
+Brev-assertionen (`verifiserInnhentingsbrevSendt`) er den samme som i
+`aarsavregning-innhentingsbrev-automatisk.spec.ts` (8122-branchen). Det eneste nye i 8148 er at
+disse to kombineres: saksbehandlingsflyt-triggeren skal produsere innhentingsbrevet.
+
+### Skatteår X i testene
+
+`FORRIGE_AAR` (konstant i `pages/shared/constants.ts`, `inneværende år − 1`).
+
+### Scenario 1 (kjørbar) — saksbehandlingsflyt via ny vurdering
+
+Endringen som berører tidligere år gjøres som **ny vurdering** (= NV-mønsteret, prod-realistisk
+«endring som berører tidligere år»). Førstegangsvedtaket gjelder *inneværende* år; NV endrer
+perioden til *kun forrige år* slik at `OppretteÅrsavregningVedEndring` (NV-grenen,
+`årMedEndringer = {forrige år}`) auto-oppretter årsavregningen — som igjen skal utløse
+innhentingsbrevet.
+
+**Felles forutsetning (førstegangsvedtak, inneværende år):** vedtatt FTRL-sak med trygdeavgift som
+betales til NAV (ikke-skattepliktig). Samme oppskrift som
+`opprettVedtattIkkeSkattepliktigSak` i 8122/8123:
+
+- bruker: `USER_ID_VALID` (`30056928150`, "TRIVIELL KARAFFEL"; aktørId i mock: `1111111111111`)
+- `OpprettNySakPage.opprettStandardSak(USER_ID_VALID)` (FTRL / MEDLEMSKAP_LOVVALG / YRKESAKTIV / SØKNAD)
+- `MedlemskapPage`: `velgPeriode(...)` med **`TestPeriods.currentYearPeriod`** (inneværende år) ·
+  `velgLand('Afghanistan')` · `velgTrygdedekning('FTRL_2_9_FØRSTE_LEDD_C_HELSE_PENSJON')` **(verbatim)** ·
+  `klikkBekreftOgFortsett()`
+- `ArbeidsforholdPage.fyllUtArbeidsforhold('Ståles Stål AS')`
+- `LovvalgPage`: `velgBestemmelse('FTRL_KAP2_2_8_FØRSTE_LEDD_A')` **(verbatim)** ·
+  `svarJaPaaFørsteSpørsmål()` · Ja på "Har søker vært medlem i minst" og "Har søker nær tilknytning til" ·
+  `klikkBekreftOgFortsett()`
+- `ResultatPeriodePage.fyllUtResultatPeriode('INNVILGET')`
+- `TrygdeavgiftPage`: `ventPåSideLastet()` · `velgSkattepliktig(false)` ·
+  `velgInntektskilde('INNTEKT_FRA_UTLANDET')` **(verbatim)** · `velgBetalesAga(false)` ·
+  `fyllInnBruttoinntektMedApiVent('100000')` · `klikkBekreftOgFortsett()`
+- `VedtakPage.klikkFattVedtak()` · `waitForProcessInstances(page.request, 30)`
+
+**Toggle-koreografi** (`UnleashHelper`, toggle `melosys.faktureringskomponenten.ikke-tidligere-perioder`):
+- toggle **AV** under førstegangsvedtaket for inneværende år (forrige-års-UI-et / faktureringen
+  krever det),
+- deretter sett faktura-radene til `BESTILT` via `withFaktureringDatabase`
+  (`UPDATE faktura SET status = 'BESTILT'`) — NV-avregningen går ellers ikke gjennom,
+- toggle **PÅ** igjen før ny vurdering.
+
+**Ny vurdering (perioden endres til kun forrige år):**
+- `HovedsidePage.klikkOpprettNySak()` · `OpprettNySakPage.opprettNyVurdering(USER_ID_VALID, 'SØKNAD')` ·
+  `waitForProcessInstances(page.request, 30)` · åpne saken på nytt (`getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).first()`)
+- `MedlemskapPage.velgPeriode(...)` med **`TestPeriods.previousYearPeriod`** · `klikkBekreftOgFortsett()`
+- `ArbeidsforholdPage.fyllUtArbeidsforhold('Ståles Stål AS')`
+- `LovvalgPage`: `velgBestemmelse('FTRL_KAP2_2_1')` **(verbatim)** ·
+  `velgBrukersSituasjon('MIDLERTIDIG_ARBEID_2_1_FJERDE_LEDD')` **(verbatim)** ·
+  `svarJaPaaFørsteSpørsmål()` · Ja på "Er søkers arbeidsoppdrag i", "Plikter arbeidsgiver å betale",
+  "Har søker lovlig opphold i" · `klikkBekreftOgFortsett()`
+- `ResultatPeriodePage.klikkBekreftOgFortsett()` · `TrygdeavgiftPage.klikkBekreftOgFortsett()`
+  (resultat/trygdeavgift beholdes fra forrige behandling)
+- `VedtakPage.fattVedtakForNyVurdering('FEIL_I_BEHANDLING')` **(verbatim)** · `waitForProcessInstances(page.request, 30)`
+
+### Scenario 3 (kjørbar) — manuell opprettelse, ingen brev
+
+Manuell opprettelse av en årsavregningsbehandling via «Opprett ny sak» (samme inngang som
+`tests/aarsavregning-ftrl.spec.ts`). Inntektsåret er **ikke** valgt på opprettelsestidspunktet
+(velges først på selve årsavregningssiden). Det skal **ikke** produseres noe innhentingsbrev ved
+opprettelsen.
+
+- `HovedsidePage.goto()` · `HovedsidePage.klikkOpprettNySak()`
+- `OpprettNySakPage`: `fyllInnBrukerID(USER_ID_VALID)` · `velgOpprettNySak()` ·
+  `velgSakstype(SAKSTYPER.FTRL)` · `velgSakstema(SAKSTEMA.MEDLEMSKAP_LOVVALG)` ·
+  `velgBehandlingstema(BEHANDLINGSTEMA.YRKESAKTIV)` · `velgBehandlingstype(BEHANDLINGSTYPE.ÅRSAVREGNING)` ·
+  `velgAarsak(AARSAK.SØKNAD)` · `leggBehandlingIMine()` · `klikkOpprettNyBehandling()`
+- `opprettSak.assertions.verifiserBehandlingOpprettet()` · `waitForProcessInstances(page.request, 30)`
+- **Negativ assertion:** ingen `INNHENTING_AV_INNTEKTSOPPLYSNINGER`-brev-prosessinstans skal finnes
+  etter at opprettelses-prosessinstansene er FERDIG (`verifiserIngenInnhentingsbrev`).
+
+### Scenario 2 (test.fixme) — fullmektig-mottaker
+
+Bundet som `test.fixme` — identisk begrunnelse som 8122: det finnes ingen e2e-fikstur for å
+registrere en `FULLMEKTIG_SØKNAD`-fullmakt på saken. Fullmakten ligger i melosys-api sin
+`fullmakt`-tabell (`Fullmakt` → `aktoer_id`, `type`) og krever en `Aktoer` med rolle `FULLMEKTIG`
+knyttet til fagsaken. Oppsett-sti for senere aktivering (DB-injeksjon via `withDatabase`): insert i
+`AKTOER` med FULLMEKTIG-rolle på fagsaken + insert i `FULLMAKT(aktoer_id, type='FULLMEKTIG_SØKNAD')`,
+deretter samme NV-trigger og assert at brevets `DATA` inneholder fullmektigens fnr i stedet for
+brukerens.
+
+### Mottaker-akse: bruker vs. fullmektig
+
+Mottakerlogikken ligger i `melosys-api` `BrevmottakerService.avklarMottakereForBruker()`:
+`fagsak.finnFullmektig(Fullmaktstype.FULLMEKTIG_SØKNAD)` — finnes en fullmektig, sendes brevet
+**kun** til fullmektig; ellers er `INNHENTING_AV_INNTEKTSOPPLYSNINGER → Mottakerliste(BRUKER)` default.
+Testbruker `USER_ID_VALID` har ingen registrert fullmakt → mottaker = bruker (scenario 1).
+
+### Assertions (binder «Så»-linjene)
+
+Brevet verifiseres via `PROSESSINSTANS` i Oracle (`withDatabase`), samme mønster som 8122 og
+vedtaksbrev-verifiseringen i `tests/eu-eos/eu-eos-12.1-iverksetting-mottaker-kjede.spec.ts`.
+Opprettelsen er asynkron (NV-vedtak → auto-årsavregning → prosessinstans) → poll til en fersk
+brev-prosessinstans for innhentingsbrevet finnes:
+
+- brev-prosess: `PROSESS_TYPE IN ('SEND_BREV','OPPRETT_OG_DISTRIBUER_BREV')` med
+  `REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE` og `DATA` som inneholder
+  `INNHENTING_AV_INNTEKTSOPPLYSNINGER` ← **selve akseptansekriteriet** («brevet er sendt»)
+- `STATUS === 'FERDIG'` (brevet er produsert, journalført og distribuert)
+- **mottaker (scenario 1):** brev-prosessens `DATA` inneholder brukerens identifikator ← «til
+  bruker». Det er uavklart om `DATA` lagrer fnr eller aktørId (feature ikke implementert ennå) →
+  assertionen godtar at **minst én** av `USER_ID_VALID` (`30056928150`) og aktørId `1111111111111`
+  står i `DATA`. Eksakt identifikator pinnes når feature-branchen lander.
+  Helper-signatur: `verifiserInnhentingsbrevSendt(mottakerIdentifikatorer: string[])`.
+- **«brevet skal gjelde for inntektsåret X»:** behandlings-/avregningsåret er `FORRIGE_AAR` (NV
+  endret perioden til kun forrige år) — soft/format-robust delkriterium; den bærende assertionen er
+  brevmal-treffet + mottaker + FERDIG. Pinnes når feature lander og `DATA`-formatet er kjent.
+- **scenario 3 (negativ):** `verifiserIngenInnhentingsbrev()` — etter at opprettelses-prosess­instansene
+  er FERDIG skal **ingen** brev-prosessinstans med `INNHENTING_AV_INNTEKTSOPPLYSNINGER` finnes.
+
+> **Robusthet:** `verifiserInnhentingsbrevSendt` matcher brevmal-strengen og mottaker som
+> delstrenger i `DATA` (samme JS-`includes`-mønster som 8122 og eu-eos-12.1). Når feature-branchen
+> lander kan eksakt prosesstype/`DATA`-felt måtte finjusteres — brevmal-treffet er det bærende.
+
+Avslutt hver test med `waitForProcessInstances(page.request, 30)` slik at cleanup-fixturen ikke
+treffer aktive prosessinstanser.
+
+**Page Objects:** `HovedsidePage`, `OpprettNySakPage`, `MedlemskapPage`, `ArbeidsforholdPage`,
+`LovvalgPage`, `ResultatPeriodePage`, `TrygdeavgiftPage`, `VedtakPage`
+**Konstanter:** `pages/shared/constants.ts` (`USER_ID_VALID`, `FORRIGE_AAR`, `SAKSTYPER`, `SAKSTEMA`,
+`BEHANDLINGSTEMA`, `BEHANDLINGSTYPE`, `AARSAK`)
+**Hjelpere:** `helpers/api-helper.ts` (`waitForProcessInstances`),
+`helpers/db-helper.ts` (`withDatabase`), `helpers/pg-db-helper.ts` (`withFaktureringDatabase`),
+`helpers/date-helper.ts` (`TestPeriods`), `helpers/unleash-helper.ts` (`UnleashHelper`)
+
+### Endringslogg (teknisk binding)
+
+- 2026-06-19: Spec opprettet for MELOSYS-8148 som kombinasjon av 8123 Trigger 3 (saksbehandlingsflyt
+  via ny vurdering) og 8122 brev-assertion. Scenario 1 kjørbar (mottaker=bruker), scenario 3 kjørbar
+  (manuell → ingen brev), scenario 2 `test.fixme` (ingen fullmakt-fikstur). Brev-assertion korrekt
+  rød til melosys-api-feature lander.
+</content>
+</invoke>

--- a/specs/aarsavregning-innhentingsbrev-saksbehandlingsflyt.md
+++ b/specs/aarsavregning-innhentingsbrev-saksbehandlingsflyt.md
@@ -273,5 +273,12 @@ treffer aktive prosessinstanser.
   fra Rune — AC «bortsett fra EØS pensjonister» var dokumentert som avgrensning men ikke e2e-dekket.
   Gjenbruker `setupPensjonistUtenGrunnlagMedAutoAarsavregning`; ikke-vakuøs (1 resultatbrev, 0
   innhentingsbrev). Grønn lokalt 19.4s mot samme e27eb7287a-build.
+- 2026-06-19 (de-flak): Tagget KUN scenario 1 med `@expect-docker-errors`. NV-lovvalgssteget trigger
+  en pre-eksisterende, transient GUI-race urelatert til 8148: web kaller
+  `/api/medlemskapsperioder/trygdedekning/lovlige-kombinasjoner` med tom bestemmelse ved form-render →
+  api kaster `RuntimeException: Finner ingen bestemmelse for :` på ERROR (kilde bekreftet av api-peer:
+  `MedlemskapBestemmelsekonverter.kt:19`). Test-logikken (brev FERDIG) var grønn begge forsøk; uten
+  taggen feilet docker-log-fixturen sporadisk (CI run 27825161737 forsøk 1). sc3/sc4 forblir strenge.
+  Pre-eksisterende ERROR-logging flagget til api-peer som egen NOJIRA-opprydding.
 </content>
 </invoke>

--- a/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-saksbehandlingsflyt.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-saksbehandlingsflyt.spec.ts
@@ -1,0 +1,299 @@
+import {expect, test} from '../../../fixtures';
+import type {Page} from '@playwright/test';
+import {AuthHelper} from '../../../helpers/auth-helper';
+import {HovedsidePage} from '../../../pages/hovedside.page';
+import {OpprettNySakPage} from '../../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import {MedlemskapPage} from '../../../pages/behandling/medlemskap.page';
+import {ArbeidsforholdPage} from '../../../pages/behandling/arbeidsforhold.page';
+import {LovvalgPage} from '../../../pages/behandling/lovvalg.page';
+import {ResultatPeriodePage} from '../../../pages/behandling/resultat-periode.page';
+import {TrygdeavgiftPage} from '../../../pages/trygdeavgift/trygdeavgift.page';
+import {VedtakPage} from '../../../pages/vedtak/vedtak.page';
+import {
+    AARSAK,
+    BEHANDLINGSTEMA,
+    BEHANDLINGSTYPE,
+    FORRIGE_AAR,
+    SAKSTEMA,
+    SAKSTYPER,
+    USER_ID_VALID,
+} from '../../../pages/shared/constants';
+import {UnleashHelper} from '../../../helpers/unleash-helper';
+import {waitForProcessInstances} from '../../../helpers/api-helper';
+import {TestPeriods} from '../../../helpers/date-helper';
+import {withDatabase} from '../../../helpers/db-helper';
+import {withFaktureringDatabase} from '../../../helpers/pg-db-helper';
+
+/**
+ * MELOSYS-8148: Automatisk sende innhentingsbrev ved opprettelse av årsavregning i flytene
+ *
+ * Spec: specs/aarsavregning-innhentingsbrev-saksbehandlingsflyt.md
+ *
+ * MELOSYS-8148 = MELOSYS-8123 sin Trigger 3 (saksbehandlingsflyt som berører tidligere år, gjort
+ * som ny vurdering) + MELOSYS-8122 sin brev-assertion. Når Melosys i en saksbehandlingsflyt
+ * automatisk oppretter en årsavregningsbehandling for et tidligere år, skal brevet "Innhenting av
+ * inntektsopplysninger" (brevmal INNHENTING_AV_INNTEKTSOPPLYSNINGER) sendes automatisk — til
+ * bruker når ingen fullmektig er registrert, til fullmektig (FULLMEKTIG_SØKNAD) ellers. Ved
+ * MANUELL opprettelse skal brevet IKKE sendes (året er ikke valgt på opprettelsestidspunktet).
+ *
+ * STATUS: Auto-utsending av brevet i saksbehandlingsflyten er ikke implementert i melosys-api ennå
+ * (MELOSYS-8148 er i «Utvikle og teste»). Brev-assertionen i scenario 1 er derfor korrekt RØD til
+ * feature-branchen lander; selve trigger-flyten (sak → vedtak → NV for tidligere år → auto-opprettet
+ * årsavregning) er grønn i dag. Søsteroppgaven MELOSYS-8122 (samme brev, annen trigger) er
+ * implementasjonsmønsteret. Se status-merknaden i speken.
+ */
+
+/** AktørId for USER_ID_VALID (30056928150) i PDL-mocken — brevets mottaker uten fullmektig */
+const AKTOER_ID_VALID = '1111111111111';
+
+/** Brevmal-identifikator slik den står i SEND_BREV/brevbestilling-DATA (melosys-api Produserbaredokumenter) */
+const BREVMAL_INNHENTING = 'INNHENTING_AV_INNTEKTSOPPLYSNINGER';
+
+type BrevRad = {DATA: string; STATUS: string; PROSESS_TYPE: string};
+
+/** Henter en fersk innhentingsbrev-prosessinstans, eller undefined hvis ingen finnes. */
+async function hentInnhentingsbrev(): Promise<BrevRad | undefined> {
+    return await withDatabase(async (db) => {
+        const rader = await db.query<BrevRad>(
+            `SELECT PI.DATA, PI.STATUS, PI.PROSESS_TYPE
+             FROM PROSESSINSTANS PI
+             WHERE PI.PROSESS_TYPE IN ('SEND_BREV', 'OPPRETT_OG_DISTRIBUER_BREV')
+               AND PI.REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE`,
+            {}
+        );
+        return rader.find((r) => (r.DATA || '').includes(BREVMAL_INNHENTING));
+    });
+}
+
+/**
+ * Felles forutsetning for scenario 1: vedtatt FTRL-sak med trygdeavgift som betales til NAV
+ * (ikke-skattepliktig). Førstegangsvedtaket gjelder INNEVÆRENDE år — den tidligere-års-endringen
+ * gjøres etterpå som ny vurdering. Identisk med opprettVedtattIkkeSkattepliktigSak i 8122/8123.
+ *
+ * Toggle melosys.faktureringskomponenten.ikke-tidligere-perioder må være AV under opprettelsen.
+ */
+async function opprettVedtattSakInneværendeÅr(page: Page): Promise<void> {
+    const hovedside = new HovedsidePage(page);
+    const opprettSak = new OpprettNySakPage(page);
+    const medlemskap = new MedlemskapPage(page);
+    const arbeidsforhold = new ArbeidsforholdPage(page);
+    const lovvalg = new LovvalgPage(page);
+    const resultatPeriode = new ResultatPeriodePage(page);
+    const trygdeavgift = new TrygdeavgiftPage(page);
+    const vedtak = new VedtakPage(page);
+
+    const periode = TestPeriods.currentYearPeriod;
+
+    console.log('📝 Oppretter sak (inneværende år)...');
+    await hovedside.gotoOgOpprettNySak();
+    await opprettSak.opprettStandardSak(USER_ID_VALID);
+    await opprettSak.assertions.verifiserBehandlingOpprettet();
+
+    await waitForProcessInstances(page.request, 30);
+    await hovedside.goto();
+    await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).click();
+
+    console.log(`📝 Medlemskap (${periode.start} - ${periode.end})...`);
+    await medlemskap.velgPeriode(periode.start, periode.end);
+    await medlemskap.velgLand('Afghanistan');
+    await medlemskap.velgTrygdedekning('FTRL_2_9_FØRSTE_LEDD_C_HELSE_PENSJON');
+    await medlemskap.klikkBekreftOgFortsett();
+
+    console.log('📝 Arbeidsforhold...');
+    await arbeidsforhold.fyllUtArbeidsforhold('Ståles Stål AS');
+
+    console.log('📝 Lovvalg...');
+    await lovvalg.velgBestemmelse('FTRL_KAP2_2_8_FØRSTE_LEDD_A');
+    await lovvalg.svarJaPaaFørsteSpørsmål();
+    await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker vært medlem i minst');
+    await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker nær tilknytning til');
+    await lovvalg.klikkBekreftOgFortsett();
+
+    console.log('📝 Resultat...');
+    await resultatPeriode.fyllUtResultatPeriode('INNVILGET');
+
+    console.log('📝 Trygdeavgift (ikke-skattepliktig)...');
+    await trygdeavgift.ventPåSideLastet();
+    await trygdeavgift.velgSkattepliktig(false);
+    await trygdeavgift.velgInntektskilde('INNTEKT_FRA_UTLANDET');
+    await trygdeavgift.velgBetalesAga(false);
+    await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
+    await trygdeavgift.klikkBekreftOgFortsett();
+
+    console.log('📝 Fatter førstegangsvedtak...');
+    await vedtak.klikkFattVedtak();
+    await waitForProcessInstances(page.request, 30);
+}
+
+/**
+ * Binder «Så»-linjene i scenario 1: poller PROSESSINSTANS til en fersk brev-prosessinstans for
+ * innhentingsbrevet finnes, og verifiserer at den er FERDIG og adressert til forventet mottaker.
+ *
+ * @param mottakerIdentifikatorer mulige mottaker-identifikatorer (fnr og/eller aktørId). Det er
+ *   uavklart om brevets DATA lagrer fnr eller aktørId (feature ikke implementert ennå) —
+ *   assertionen godtar derfor at minst én av dem står i DATA. Eksakt identifikator pinnes når
+ *   feature-branchen lander.
+ */
+async function verifiserInnhentingsbrevSendt(mottakerIdentifikatorer: string[]): Promise<void> {
+    // Opprettelsen er asynkron (NV-vedtak → auto-årsavregning → prosessinstans).
+    await expect
+        .poll(async () => (await hentInnhentingsbrev()) !== undefined, {
+            message: `Venter på brev-prosessinstans for ${BREVMAL_INNHENTING}`,
+            timeout: 30_000,
+        })
+        .toBe(true);
+
+    const brev = (await hentInnhentingsbrev())!;
+    console.log(`🔍 Innhentingsbrev: prosess=${brev.PROSESS_TYPE}, status=${brev.STATUS}`);
+
+    // «Så skal brevet "Innhenting av inntektsopplysninger" sendes automatisk»
+    expect(brev.STATUS, 'Innhentingsbrevet skal være produsert og distribuert (FERDIG)').toBe(
+        'FERDIG'
+    );
+
+    // «... til bruker» — mottakeren skal stå i brevets DATA. Godtar fnr ELLER aktørId siden
+    // eksakt identifikator-format er uavklart til feature lander.
+    const dataHarMottaker = mottakerIdentifikatorer.some((id) => (brev.DATA || '').includes(id));
+    expect(
+        dataHarMottaker,
+        `Brevet skal være adressert til bruker (en av ${mottakerIdentifikatorer.join(' / ')})`
+    ).toBe(true);
+}
+
+/**
+ * Binder «Så»-linjen i scenario 3 (negativ): etter at opprettelses-prosessinstansene er FERDIG
+ * skal det IKKE finnes noen innhentingsbrev-prosessinstans. Manuell opprettelse trigger ikke
+ * brevet (året er ikke valgt på opprettelsestidspunktet).
+ */
+async function verifiserIngenInnhentingsbrev(): Promise<void> {
+    const brev = await hentInnhentingsbrev();
+    expect(
+        brev,
+        'Manuell opprettelse skal IKKE produsere innhentingsbrev (året er ikke valgt enda)'
+    ).toBeUndefined();
+}
+
+test.describe('Automatisk innhentingsbrev ved årsavregning i saksbehandlingsflyten (MELOSYS-8148)', () => {
+    test('saksbehandlingsflyt for tidligere år uten fullmektig sender innhentingsbrev til bruker', async ({
+        page,
+        request,
+    }) => {
+        test.setTimeout(240_000);
+        const auth = new AuthHelper(page);
+        const unleash = new UnleashHelper(request);
+
+        // Endringen som berører tidligere år gjøres som ny vurdering: førstegangsvedtaket gjelder
+        // inneværende år (toggle AV — fakturering må akseptere serien), NV endrer perioden til kun
+        // forrige år med toggle PÅ slik at OppretteÅrsavregningVedEndring auto-oppretter
+        // årsavregningen — som igjen skal utløse innhentingsbrevet.
+        await unleash.disableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+        await auth.login();
+
+        await opprettVedtattSakInneværendeÅr(page);
+
+        // Fakturaene må være BESTILT for at NV-avregningen skal gå gjennom
+        await withFaktureringDatabase(async (db) => {
+            const updated = await db.execute("UPDATE faktura SET status = 'BESTILT'");
+            console.log(`📝 Satte ${updated} faktura-rader til BESTILT`);
+        });
+
+        await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+
+        // Ny vurdering: perioden endres til kun forrige år
+        const hovedside = new HovedsidePage(page);
+        const opprettSak = new OpprettNySakPage(page);
+        const medlemskap = new MedlemskapPage(page);
+        const arbeidsforhold = new ArbeidsforholdPage(page);
+        const lovvalg = new LovvalgPage(page);
+        const resultatPeriode = new ResultatPeriodePage(page);
+        const trygdeavgift = new TrygdeavgiftPage(page);
+        const vedtak = new VedtakPage(page);
+
+        console.log('📝 Oppretter ny vurdering...');
+        await hovedside.klikkOpprettNySak();
+        await opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD');
+        await waitForProcessInstances(page.request, 30);
+
+        await hovedside.goto();
+        await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).first().click();
+
+        const periodeNV = TestPeriods.previousYearPeriod;
+        console.log(`📝 NV medlemskap (${periodeNV.start} - ${periodeNV.end})...`);
+        await medlemskap.velgPeriode(periodeNV.start, periodeNV.end);
+        await medlemskap.klikkBekreftOgFortsett();
+
+        await arbeidsforhold.fyllUtArbeidsforhold('Ståles Stål AS');
+
+        console.log('📝 NV lovvalg (FTRL 2-1 fjerde ledd)...');
+        await lovvalg.velgBestemmelse('FTRL_KAP2_2_1');
+        await lovvalg.velgBrukersSituasjon('MIDLERTIDIG_ARBEID_2_1_FJERDE_LEDD');
+        await lovvalg.svarJaPaaFørsteSpørsmål();
+        await lovvalg.svarJaPaaSpørsmålIGruppe('Er søkers arbeidsoppdrag i');
+        await lovvalg.svarJaPaaSpørsmålIGruppe('Plikter arbeidsgiver å betale');
+        await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker lovlig opphold i');
+        await lovvalg.klikkBekreftOgFortsett();
+
+        // Resultat og trygdeavgift beholdes fra forrige behandling
+        await resultatPeriode.klikkBekreftOgFortsett();
+        await trygdeavgift.klikkBekreftOgFortsett();
+
+        console.log('📝 Fatter vedtak for ny vurdering...');
+        await vedtak.fattVedtakForNyVurdering('FEIL_I_BEHANDLING');
+        await waitForProcessInstances(page.request, 30);
+
+        // «brevet skal gjelde for inntektsåret X» — NV endret perioden til kun FORRIGE_AAR, så den
+        // auto-opprettede årsavregningen (og brevet) gjelder FORRIGE_AAR.
+        console.log(`📨 Verifiserer innhentingsbrev for inntektsår ${FORRIGE_AAR}...`);
+        await verifiserInnhentingsbrevSendt([USER_ID_VALID, AKTOER_ID_VALID]);
+        await waitForProcessInstances(page.request, 30);
+    });
+
+    test('manuell opprettelse av årsavregning sender ikke innhentingsbrev', async ({page}) => {
+        test.setTimeout(120_000);
+        const auth = new AuthHelper(page);
+        await auth.login();
+
+        const hovedside = new HovedsidePage(page);
+        const opprettSak = new OpprettNySakPage(page);
+
+        // Manuell opprettelse av en årsavregningsbehandling via «Opprett ny sak». Året velges
+        // først på selve årsavregningssiden — på opprettelsestidspunktet er det ikke valgt.
+        console.log('📝 Oppretter årsavregningsbehandling manuelt...');
+        await hovedside.goto();
+        await hovedside.klikkOpprettNySak();
+        await opprettSak.fyllInnBrukerID(USER_ID_VALID);
+        await opprettSak.velgOpprettNySak();
+        await opprettSak.velgSakstype(SAKSTYPER.FTRL);
+        await opprettSak.velgSakstema(SAKSTEMA.MEDLEMSKAP_LOVVALG);
+        await opprettSak.velgBehandlingstema(BEHANDLINGSTEMA.YRKESAKTIV);
+        await opprettSak.velgBehandlingstype(BEHANDLINGSTYPE.ÅRSAVREGNING);
+        await opprettSak.velgAarsak(AARSAK.SØKNAD);
+        await opprettSak.leggBehandlingIMine();
+        await opprettSak.klikkOpprettNyBehandling();
+        await opprettSak.assertions.verifiserBehandlingOpprettet();
+
+        // La opprettelses-prosessinstansene bli ferdige før vi sjekker fravær av brev.
+        await waitForProcessInstances(page.request, 30);
+
+        // «Så skal Melosys ikke sende brevet "Innhenting av inntektsopplysninger"»
+        console.log('🔍 Verifiserer at ingen innhentingsbrev ble sendt...');
+        await verifiserIngenInnhentingsbrev();
+    });
+
+    // Scenario 2 — mottaker = fullmektig (FULLMEKTIG_SØKNAD).
+    //
+    // Bundet som fixme: det finnes ingen e2e-fikstur for å registrere en FULLMEKTIG_SØKNAD-fullmakt
+    // på saken (identisk begrunnelse som MELOSYS-8122). Fullmakten ligger i melosys-api sin egen
+    // `fullmakt`-tabell (Fullmakt → aktoer_id, type) og krever en Aktoer med rolle FULLMEKTIG
+    // knyttet til fagsaken. Oppsett-sti for senere aktivering (DB-injeksjon via withDatabase):
+    // insert i AKTOER med FULLMEKTIG-rolle på fagsaken + insert i FULLMAKT(aktoer_id,
+    // type='FULLMEKTIG_SØKNAD'), deretter samme NV-trigger og assert at brevets DATA inneholder
+    // fullmektigens fnr i stedet for brukerens. Å fake oppsettet ville gitt falsk dekning — derfor
+    // fixme til fiksturen finnes. Se speken.
+    test.fixme(
+        'saksbehandlingsflyt for tidligere år med fullmektig sender innhentingsbrev til fullmektig',
+        async () => {
+            // Krever FULLMEKTIG_SØKNAD-fikstur — se kommentar over og speken.
+        }
+    );
+});

--- a/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-saksbehandlingsflyt.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-saksbehandlingsflyt.spec.ts
@@ -37,11 +37,11 @@ import {setupPensjonistUtenGrunnlagMedAutoAarsavregning} from '../../eu-eos/pens
  * bruker når ingen fullmektig er registrert, til fullmektig (FULLMEKTIG_SØKNAD) ellers. Ved
  * MANUELL opprettelse skal brevet IKKE sendes (året er ikke valgt på opprettelsestidspunktet).
  *
- * STATUS: Auto-utsending av brevet i saksbehandlingsflyten er ikke implementert i melosys-api ennå
- * (MELOSYS-8148 er i «Utvikle og teste»). Brev-assertionen i scenario 1 er derfor korrekt RØD til
- * feature-branchen lander; selve trigger-flyten (sak → vedtak → NV for tidligere år → auto-opprettet
- * årsavregning) er grønn i dag. Søsteroppgaven MELOSYS-8122 (samme brev, annen trigger) er
- * implementasjonsmønsteret. Se status-merknaden i speken.
+ * STATUS: Verifisert grønn mot feature-image melosys-api:8148-auto-innhentingsbrev-flyt-e27eb7287a
+ * (CI run 27821184762, 2 passed). Auto-utsendingen er implementert på melosys-api-feature-branchen
+ * (MELOSYS-8148 i «Utvikle og teste») — scenario 1 er derfor grønn mot feature-image-et, men vil
+ * være RØD mot main/latest til melosys-api-branchen er merget. Søsteroppgaven MELOSYS-8122 (samme
+ * brev, annen trigger) er implementasjonsmønsteret. Se status-merknaden i speken.
  */
 
 /** AktørId for USER_ID_VALID (30056928150) i PDL-mocken — brevets mottaker uten fullmektig */
@@ -59,7 +59,8 @@ async function hentInnhentingsbrev(): Promise<BrevRad | undefined> {
             `SELECT PI.DATA, PI.STATUS, PI.PROSESS_TYPE
              FROM PROSESSINSTANS PI
              WHERE PI.PROSESS_TYPE IN ('SEND_BREV', 'OPPRETT_OG_DISTRIBUER_BREV')
-               AND PI.REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE`,
+               AND PI.REGISTRERT_DATO > SYSDATE - INTERVAL '10' MINUTE
+             ORDER BY PI.REGISTRERT_DATO DESC`,
             {}
         );
         return rader.find((r) => (r.DATA || '').includes(BREVMAL_INNHENTING));
@@ -175,16 +176,7 @@ async function verifiserIngenInnhentingsbrev(): Promise<void> {
 }
 
 test.describe('Automatisk innhentingsbrev ved årsavregning i saksbehandlingsflyten (MELOSYS-8148)', () => {
-    // @expect-docker-errors: NV-flyten trigger en pre-eksisterende, transient GUI-race som er
-    // URELATERT til 8148 (8148 endrer kun saga-steget OppretteÅrsavregningVedEndring, ingen
-    // GUI/medlemskap/lovvalg-endepunkt). Ved render av NV-lovvalgssteget kaller web
-    // `/api/medlemskapsperioder/trygdedekning/lovlige-kombinasjoner` før en bestemmelse er valgt →
-    // melosys-api logger `RuntimeException: Finner ingen bestemmelse for :` på ERROR (GUI
-    // ExceptionMapper). Selve test-logikken (brevet sendes, FERDIG) er upåvirket og grønn; uten
-    // taggen feiler docker-log-fixturen sporadisk på denne ERROR-en (verifisert: CI run 27825161737
-    // forsøk 1, behandling 2, requestURI .../lovlige-kombinasjoner). Kun sc1 tagges — sc3/sc4
-    // forblir strenge.
-    test('saksbehandlingsflyt for tidligere år uten fullmektig sender innhentingsbrev til bruker @expect-docker-errors', async ({
+    test('saksbehandlingsflyt for tidligere år uten fullmektig sender innhentingsbrev til bruker', async ({
         page,
         request,
     }) => {
@@ -288,6 +280,9 @@ test.describe('Automatisk innhentingsbrev ved årsavregning i saksbehandlingsfly
         // «Så skal Melosys ikke sende brevet "Innhenting av inntektsopplysninger"»
         console.log('🔍 Verifiserer at ingen innhentingsbrev ble sendt...');
         await verifiserIngenInnhentingsbrev();
+
+        // Avslutt med waitForProcessInstances slik at cleanup-fixturen ikke treffer aktive prosesser.
+        await waitForProcessInstances(page.request, 30);
     });
 
     // Scenario 4 (kjørbar negativ) — EØS-pensjonist-UNNTAK.

--- a/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-saksbehandlingsflyt.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-saksbehandlingsflyt.spec.ts
@@ -23,6 +23,7 @@ import {waitForProcessInstances} from '../../../helpers/api-helper';
 import {TestPeriods} from '../../../helpers/date-helper';
 import {withDatabase} from '../../../helpers/db-helper';
 import {withFaktureringDatabase} from '../../../helpers/pg-db-helper';
+import {setupPensjonistUtenGrunnlagMedAutoAarsavregning} from '../../eu-eos/pensjonist-aarsavregning-setup';
 
 /**
  * MELOSYS-8148: Automatisk sende innhentingsbrev ved opprettelse av årsavregning i flytene
@@ -278,6 +279,40 @@ test.describe('Automatisk innhentingsbrev ved årsavregning i saksbehandlingsfly
         // «Så skal Melosys ikke sende brevet "Innhenting av inntektsopplysninger"»
         console.log('🔍 Verifiserer at ingen innhentingsbrev ble sendt...');
         await verifiserIngenInnhentingsbrev();
+    });
+
+    // Scenario 4 (kjørbar negativ) — EØS-pensjonist-UNNTAK.
+    //
+    // AC: «bortsett fra EØS pensjonister» — de skal IKKE motta innhentingsbrev via denne
+    // funksjonaliteten per nå (krever særskilt brevtekst, egen oppgave, jf. Yvonne 2026-06-19).
+    // Dette er det samme flyt-SHAPE-et som scenario 1 (en saksbehandlingsflyt der Melosys
+    // auto-oppretter en årsavregning for et tidligere år), men for sakstypen EØS-pensjonist —
+    // der FTRL ville sendt brev (sc1), skal EØS-pensjonist IKKE få det. Isolerer dermed selve
+    // sakstype-unntaket (skalSendeInnhentingsbrev) på samme flyt.
+    //
+    // Trigger: EØS-pensjonist førstegangsbehandling med HELE perioden i et tidligere år (2024)
+    // og default toggle-state → trygdeavgift fastsettes ikke på førstegangen, og årsavregningen
+    // auto-opprettes ved «Bekreft og send» (prosess OPPRETT_NY_BEHANDLING_AARSAVREGNING). Gjenbruk
+    // av setupPensjonistUtenGrunnlagMedAutoAarsavregning (tests/eu-eos). Etter at setup returnerer
+    // er auto-opprettelsens prosessinstanser FERDIG (setup venter 60s) og årsavregningsvedtaket er
+    // ennå IKKE fattet — så et evt. innhentingsbrev ville vært synlig her, men resultatbrevet
+    // (annen brevmal) er det ikke. verifiserIngenInnhentingsbrev filtrerer eksakt på
+    // INNHENTING_AV_INNTEKTSOPPLYSNINGER, så den treffer kun innhentingsbrevet.
+    test('EØS-pensjonist auto-årsavregning i saksbehandlingsflyt sender ikke innhentingsbrev', async ({
+        page,
+    }) => {
+        test.setTimeout(240_000);
+        const auth = new AuthHelper(page);
+        await auth.login();
+
+        console.log('📝 EØS-pensjonist saksbehandlingsflyt → auto-opprettet årsavregning (2024)...');
+        await setupPensjonistUtenGrunnlagMedAutoAarsavregning(page);
+
+        // «Så skal Melosys ikke sende brevet "Innhenting av inntektsopplysninger"» (EØS-pensjonist-unntak)
+        console.log('🔍 Verifiserer at EØS-pensjonist IKKE fikk innhentingsbrev...');
+        await verifiserIngenInnhentingsbrev();
+
+        await waitForProcessInstances(page.request, 30);
     });
 
     // Scenario 2 — mottaker = fullmektig (FULLMEKTIG_SØKNAD).

--- a/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-saksbehandlingsflyt.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-saksbehandlingsflyt.spec.ts
@@ -175,7 +175,16 @@ async function verifiserIngenInnhentingsbrev(): Promise<void> {
 }
 
 test.describe('Automatisk innhentingsbrev ved årsavregning i saksbehandlingsflyten (MELOSYS-8148)', () => {
-    test('saksbehandlingsflyt for tidligere år uten fullmektig sender innhentingsbrev til bruker', async ({
+    // @expect-docker-errors: NV-flyten trigger en pre-eksisterende, transient GUI-race som er
+    // URELATERT til 8148 (8148 endrer kun saga-steget OppretteÅrsavregningVedEndring, ingen
+    // GUI/medlemskap/lovvalg-endepunkt). Ved render av NV-lovvalgssteget kaller web
+    // `/api/medlemskapsperioder/trygdedekning/lovlige-kombinasjoner` før en bestemmelse er valgt →
+    // melosys-api logger `RuntimeException: Finner ingen bestemmelse for :` på ERROR (GUI
+    // ExceptionMapper). Selve test-logikken (brevet sendes, FERDIG) er upåvirket og grønn; uten
+    // taggen feiler docker-log-fixturen sporadisk på denne ERROR-en (verifisert: CI run 27825161737
+    // forsøk 1, behandling 2, requestURI .../lovlige-kombinasjoner). Kun sc1 tagges — sc3/sc4
+    // forblir strenge.
+    test('saksbehandlingsflyt for tidligere år uten fullmektig sender innhentingsbrev til bruker @expect-docker-errors', async ({
         page,
         request,
     }) => {


### PR DESCRIPTION
E2E-spec og test for MELOSYS-8148: når Melosys i en saksbehandlingsflyt
automatisk oppretter en årsavregning for et tidligere år, skal brevet
«Innhenting av inntektsopplysninger» sendes automatisk til bruker — ikke ved
manuell opprettelse, og ikke for EØS-pensjonister.

Akseptansetest forankret i domene-spec (spec-drevet). Verifisert grønt lokalt
og i CI mot melosys-api feature-image (branch `8148-auto-innhentingsbrev-flyt`
@ e27eb7287a, api draft-PR #3395).
[MELOSYS-8148](https://jira.adeo.no/browse/MELOSYS-8148)

- Scenario 1: saksbehandlingsflyt (ny vurdering → tidligere år) → innhentingsbrev til bruker
- Scenario 3: manuell opprettelse → ingen brev (negativ)
- Scenario 4: EØS-pensjonist-unntak → ingen brev (negativ, ikke-vakuøs: 1 resultatbrev, 0 innhentingsbrev)
- Scenario 2 (fullmektig): `test.fixme` — mangler FULLMEKTIG_SØKNAD-fikstur

## Testing
- [x] E2E lokalt grønt mot feature-build (sc1 1.1m, sc3 11.9s, sc4 19.4s)
- [x] E2E i CI mot feature-image — run 27821184762 (2 passed); de-flake-rerun 27826265005
- [x] sc1 tagget `@expect-docker-errors` for pre-eksisterende NV-lovvalg GUI-race (`lovlige-kombinasjoner` med tom bestemmelse, `MedlemskapBestemmelsekonverter.kt:19`) — urelatert til 8148
- [x] Avhenger av at api-feature (PR #3395) merges/prodsettes

## Notater
8148 = MELOSYS-8123 Trigger 3 (saksbehandlingsflyt via ny vurdering) + MELOSYS-8122
brev-assertion (PROSESSINSTANS `OPPRETT_OG_DISTRIBUER_BREV` med
`INNHENTING_AV_INNTEKTSOPPLYSNINGER`, FERDIG, mottaker i DATA). Kjøres grønn mot
api feature-image (ikke `@known-error`).