### PR TITLE
Løft svake assertions (PR A): årsavregning-DB, trygdeavgift-beløp, lovvalg-sluttilstand

### DIFF
--- a/pages/behandling/aarsavregning.assertions.ts
+++ b/pages/behandling/aarsavregning.assertions.ts
@@ -1,5 +1,6 @@
 import { Page, expect } from '@playwright/test';
 import { assertErrors } from '../../utils/assertions';
+import { withDatabase } from '../../helpers/db-helper';
 
 /**
  * Assertion methods for AarsavregningPage
@@ -132,4 +133,128 @@ export class AarsavregningAssertions {
       `✅ Sum-tabell: endelig ${forventet.endeligBeregnet} / innbetalt ${forventet.innbetalt} / differanse ${forventet.differanse}`
     );
   }
+}
+
+/**
+ * Forventninger til en auto-opprettet årsavregnings-behandlings DB-sluttilstand.
+ *
+ * Kjernen som ALLTID asserteres (og som biter) er at det finnes en
+ * ÅRSAVREGNING-behandling som er AVSLUTTET, har et behandlingsresultat, en
+ * AARSAVREGNING-rad, og at alle dens prosessinstanser er FERDIG. Alt annet er
+ * valgfri innstramming.
+ */
+export interface AarsavregningBehandlingForventning {
+  /** Forventet BEHANDLING.BEH_TYPE. Default 'ÅRSAVREGNING'. */
+  behType?: string;
+  /**
+   * Forventet BEHANDLING.STATUS. Default 'AVSLUTTET' (for en iverksatt
+   * årsavregning). For en AUTO-opprettet, men ennå ikke saksbehandlet
+   * årsavregning (FTRL-pensjonist-flyten) er den 'UNDER_BEHANDLING'.
+   */
+  forventetStatus?: string;
+  /**
+   * Assert BEHANDLINGSRESULTAT.RESULTAT_TYPE = denne (f.eks. FASTSATT_TRYGDEAVGIFT,
+   * eller IKKE_FASTSATT for en auto-opprettet men ikke iverksatt årsavregning).
+   * Utelates → kun at et behandlingsresultat finnes.
+   */
+  forventetResultatType?: string;
+  /** Assert AARSAVREGNING.AAR = dette året (f.eks. 2024). Utelates → AAR ikke sjekket. */
+  forventetAar?: number;
+  /**
+   * Prosess_typer som MÅ finnes (og være FERDIG) på årsavregningen.
+   * Default: ingen krav om spesifikke typer (kun at alle som finnes er FERDIG).
+   */
+  forventedeProsesser?: string[];
+}
+
+/**
+ * Hard DB-sluttilstands-verifisering for en auto-opprettet årsavregning.
+ *
+ * Beviser at årsavregningen ikke bare dukket opp som en UI-lenke / et job-count,
+ * men faktisk ble iverksatt: behandlingen er ÅRSAVREGNING + AVSLUTTET, har et
+ * behandlingsresultat, det finnes en AARSAVREGNING-rad, og alle prosessinstanser
+ * er FERDIG (ingen feilede/hengende). Modellert på den sterke lokale helperen i
+ * eos-pensjonist-aarsavregning-uten-grunnlag.spec.ts og på
+ * pages/shared/behandling-sluttilstand.assertions.ts.
+ *
+ * Forutsetter at prosessinstansene er ferdige; kall `waitForProcessInstances(...)`
+ * (som kaster på feilede instanser) FØR denne i testen.
+ *
+ * Kolonnenavn er live-verifisert (jf. discovery 2026-06-11):
+ *  - BEHANDLING(ID, STATUS, BEH_TYPE)
+ *  - BEHANDLINGSRESULTAT(RESULTAT_TYPE, BEHANDLING_ID)
+ *  - AARSAVREGNING(AAR, BEHANDLINGSRESULTAT_ID)
+ *  - PROSESSINSTANS(PROSESS_TYPE, STATUS, BEHANDLING_ID)
+ *
+ * @param behandlingId BEHANDLING.ID for årsavregningen (typisk lest ut av
+ *   `behandlingID`-URL-paramet etter at årsavregnings-lenken er åpnet).
+ * @returns BEHANDLING.ID som string
+ */
+export async function verifiserAarsavregningBehandling(
+  behandlingId: string,
+  forventet: AarsavregningBehandlingForventning = {}
+): Promise<string> {
+  const behType = forventet.behType ?? 'ÅRSAVREGNING';
+  const forventetStatus = forventet.forventetStatus ?? 'AVSLUTTET';
+
+  return await withDatabase(async (db) => {
+    const behandling = await db.queryOne<{ ID: number; STATUS: string; BEH_TYPE: string }>(
+      'SELECT ID, STATUS, BEH_TYPE FROM BEHANDLING WHERE ID = :id',
+      { id: behandlingId }
+    );
+    expect(behandling, 'Forventet årsavregningsbehandling i DB').not.toBeNull();
+    expect(behandling!.BEH_TYPE, `Behandlingen skal være ${behType}`).toBe(behType);
+    expect(behandling!.STATUS, `Behandlingen skal være ${forventetStatus}`).toBe(forventetStatus);
+    const id = behandling!.ID;
+    console.log(`✅ Årsavregningsbehandling ${id}: ${behType} / ${forventetStatus}`);
+
+    const resultat = await db.queryOne<{ RESULTAT_TYPE: string }>(
+      'SELECT RESULTAT_TYPE FROM BEHANDLINGSRESULTAT WHERE BEHANDLING_ID = :id',
+      { id }
+    );
+    expect(resultat, 'Forventet behandlingsresultat i DB').not.toBeNull();
+    if (forventet.forventetResultatType) {
+      expect(
+        resultat!.RESULTAT_TYPE,
+        `Resultat skal være ${forventet.forventetResultatType}`
+      ).toBe(forventet.forventetResultatType);
+    }
+    console.log(`✅ Behandlingsresultat: ${resultat!.RESULTAT_TYPE}`);
+
+    // BEHANDLINGSRESULTAT har behandling_id som PK (pk_resultat), så
+    // AARSAVREGNING.BEHANDLINGSRESULTAT_ID er behandlingens ID direkte.
+    const aarsavregning = await db.queryOne<{ AAR: number }>(
+      'SELECT AAR FROM AARSAVREGNING WHERE BEHANDLINGSRESULTAT_ID = :id',
+      { id }
+    );
+    expect(aarsavregning, 'Forventet AARSAVREGNING-rad i DB').not.toBeNull();
+    if (forventet.forventetAar !== undefined) {
+      expect(
+        Number(aarsavregning!.AAR),
+        `Årsavregningen skal gjelde ${forventet.forventetAar}`
+      ).toBe(forventet.forventetAar);
+    }
+    console.log(`✅ AARSAVREGNING-rad funnet (år ${aarsavregning!.AAR})`);
+
+    const prosesser = await db.query<{ PROSESS_TYPE: string; STATUS: string }>(
+      'SELECT PROSESS_TYPE, STATUS FROM PROSESSINSTANS WHERE BEHANDLING_ID = :id',
+      { id }
+    );
+    expect(
+      prosesser.length,
+      'Forventet minst én prosessinstans for årsavregningen'
+    ).toBeGreaterThan(0);
+    for (const p of prosesser) {
+      expect(p.STATUS, `Prosess ${p.PROSESS_TYPE} skal være FERDIG`).toBe('FERDIG');
+    }
+    for (const type of forventet.forventedeProsesser ?? []) {
+      expect(
+        prosesser.some((p) => p.PROSESS_TYPE === type),
+        `Forventet prosessinstans ${type} på årsavregningsbehandlingen`
+      ).toBe(true);
+    }
+    console.log(`✅ ${prosesser.length} prosessinstanser FERDIG på årsavregningen`);
+
+    return String(id);
+  });
 }

--- a/pages/trygdeavgift/eu-eos-pensjonist-trygdeavgift.assertions.ts
+++ b/pages/trygdeavgift/eu-eos-pensjonist-trygdeavgift.assertions.ts
@@ -1,4 +1,5 @@
 import { Page, expect } from '@playwright/test';
+import type { Trygdeavgiftsperiode } from './eu-eos-pensjonist-trygdeavgift.page';
 
 /**
  * Assertion-metoder for EuEosPensjonistTrygdeavgiftPage
@@ -62,5 +63,102 @@ export class EuEosPensjonistTrygdeavgiftAssertions {
   async verifiserSammenslåtteInntektskilderMarkering(): Promise<void> {
     await expect(this.page.getByRole('cell', { name: '***' })).toBeVisible();
     await expect(this.page.getByText('*** Mer enn en inntekt')).toBeVisible();
+  }
+
+  /**
+   * Verifiserer det FAKTISKE beregnede avgiftsbeløpet fra
+   * `BeregnetTrygdeavgift`-responsen (ikke bare UI-markeringen):
+   *  - minst én periode finnes
+   *  - hver periode har `beregningsregel === forventetRegel`
+   *  - `avgiftPerMd > 0` (det beregnes faktisk en avgift)
+   *  - intern konsistens: avgiftPerMd ≈ bruttoinntektPerMd × sats
+   *    (sats-enkodingen utledes av verdien selv — en trygdeavgiftssats angitt i
+   *    prosent er > 1, en brøk er ≤ 1 — så testen tåler at API-et bytter enkoding;
+   *    toleranse er romslig nok til avrunding/min.beløp-gulv).
+   *
+   * @param perioder  trygdeavgiftsperioder fra page.hentTrygdeavgiftsperioder()
+   * @param forventetRegel  'ORDINÆR' | 'TJUEFEM_PROSENT_REGEL'
+   * @param bruttoinntektPerMd  månedsinntekten testen la inn (for konsistenssjekk)
+   */
+  verifiserBeregnetAvgift(
+    perioder: Trygdeavgiftsperiode[],
+    forventetRegel: 'ORDINÆR' | 'TJUEFEM_PROSENT_REGEL',
+    bruttoinntektPerMd: number,
+  ): void {
+    expect(perioder.length, 'Forventet minst én trygdeavgiftsperiode i beregningen').toBeGreaterThan(
+      0,
+    );
+
+    for (const p of perioder) {
+      expect(p.beregningsregel, `Periode skal bruke beregningsregel ${forventetRegel}`).toBe(
+        forventetRegel,
+      );
+      expect(
+        p.avgiftPerMd,
+        'Det skal være beregnet en positiv månedlig avgift (avgiftPerMd)',
+      ).toBeGreaterThan(0);
+
+      expect(p.avgiftssats, 'Perioden skal ha en avgiftssats').not.toBeNull();
+      const sats = p.avgiftssats as number;
+      const satsSomBrøk = sats > 1 ? sats / 100 : sats;
+      const forventetAvgift = bruttoinntektPerMd * satsSomBrøk;
+      // Romslig relativ toleranse (5 %) for å tåle avrunding og evt. min.beløp-gulv,
+      // men streng nok til å fange feil enhet / feil størrelsesorden.
+      const toleranse = Math.max(forventetAvgift * 0.05, 1);
+      expect(
+        Math.abs(p.avgiftPerMd - forventetAvgift),
+        `avgiftPerMd (${p.avgiftPerMd}) skal være konsistent med sats ${p.avgiftssats} × ${bruttoinntektPerMd} ≈ ${forventetAvgift.toFixed(2)}`,
+      ).toBeLessThanOrEqual(toleranse);
+    }
+
+    console.log(
+      `✅ Beregnet avgift (${forventetRegel}): ${perioder
+        .map((p) => `${p.avgiftPerMd} kr/md @ sats ${p.avgiftssats}`)
+        .join(', ')}`,
+    );
+  }
+
+  /**
+   * Verifiserer det FAKTISKE beløpet bak 25%-regel-markeringen.
+   *
+   * 25%-regelen oppgir IKKE en avgiftssats i responsen (avgiftssats === null) —
+   * avgiften beregnes som 25 % av differansen, ikke som sats × inntekt. Derfor:
+   *  - hver periode har `beregningsregel === 'TJUEFEM_PROSENT_REGEL'`
+   *  - `avgiftPerMd > 0`
+   *  - taket er aktivt: `avgiftPerMd` er VESENTLIG under hva ordinær sats
+   *    (`ordinærSatsProsent`, f.eks. 5.1 %) × inntekt ville gitt.
+   *
+   * @param perioder  trygdeavgiftsperioder fra page.hentTrygdeavgiftsperioder()
+   * @param bruttoinntektPerMd  månedsinntekten testen la inn
+   * @param ordinærSatsProsent  ordinær trygdeavgiftssats i prosent (kalibrert, f.eks. 5.1)
+   */
+  verifiser25ProsentRegelAvgift(
+    perioder: Trygdeavgiftsperiode[],
+    bruttoinntektPerMd: number,
+    ordinærSatsProsent: number,
+  ): void {
+    expect(perioder.length, 'Forventet minst én trygdeavgiftsperiode i beregningen').toBeGreaterThan(
+      0,
+    );
+
+    const ordinærAvgift = bruttoinntektPerMd * (ordinærSatsProsent / 100);
+    for (const p of perioder) {
+      expect(p.beregningsregel, 'Periode skal bruke 25%-regelen').toBe('TJUEFEM_PROSENT_REGEL');
+      expect(
+        p.avgiftPerMd,
+        'Det skal være beregnet en positiv månedlig avgift (avgiftPerMd)',
+      ).toBeGreaterThan(0);
+      // Taket skal faktisk begrense: minst 20 % lavere enn ordinær sats ville gitt.
+      expect(
+        p.avgiftPerMd,
+        `25%-regelen skal begrense avgiften (${p.avgiftPerMd}) godt under ordinær sats × inntekt (${ordinærAvgift.toFixed(0)})`,
+      ).toBeLessThan(ordinærAvgift * 0.8);
+    }
+
+    console.log(
+      `✅ 25%-regel-avgift: ${perioder
+        .map((p) => `${p.avgiftPerMd} kr/md (ordinær ville gitt ~${ordinærAvgift.toFixed(0)})`)
+        .join(', ')}`,
+    );
   }
 }

--- a/pages/trygdeavgift/eu-eos-pensjonist-trygdeavgift.page.ts
+++ b/pages/trygdeavgift/eu-eos-pensjonist-trygdeavgift.page.ts
@@ -3,6 +3,24 @@ import { BasePage } from '../shared/base.page';
 import { EuEosPensjonistTrygdeavgiftAssertions } from './eu-eos-pensjonist-trygdeavgift.assertions';
 
 /**
+ * En trygdeavgiftsperiode fra `BeregnetTrygdeavgift`-responsen
+ * (PUT …/trygdeavgift/eos-pensjonist/beregning). Speiler
+ * melosys-web src/services/modules/trygdeavgift.ts.
+ */
+export interface Trygdeavgiftsperiode {
+  avgiftssats: number | null;
+  avgiftPerMd: number;
+  beregningsregel?: 'ORDINÆR' | 'TJUEFEM_PROSENT_REGEL' | 'MINSTEBELØP';
+  harSammenslåtteInntektskilder?: boolean;
+  [key: string]: unknown;
+}
+
+export interface BeregnetTrygdeavgift {
+  trygdeavgiftsperioder: Trygdeavgiftsperiode[];
+  [key: string]: unknown;
+}
+
+/**
  * Page Object for Trygdeavgift-steget for EU/EØS Pensjonist
  * (helseutgiftDekkesPeriode/vurderingTrygdeavgift)
  *
@@ -20,6 +38,12 @@ import { EuEosPensjonistTrygdeavgiftAssertions } from './eu-eos-pensjonist-trygd
  */
 export class EuEosPensjonistTrygdeavgiftPage extends BasePage {
   readonly assertions: EuEosPensjonistTrygdeavgiftAssertions;
+
+  /**
+   * Siste fangede beregningsrespons (PUT …/eos-pensjonist/beregning → 200).
+   * Settes av {@link ventPåBeregning}; les den via {@link hentSisteBeregning}.
+   */
+  private sisteBeregning: BeregnetTrygdeavgift | null = null;
 
   private readonly skattepliktigGroup = this.page.getByRole('group', { name: 'Skattepliktig' });
 
@@ -107,7 +131,11 @@ export class EuEosPensjonistTrygdeavgiftPage extends BasePage {
     });
   }
 
-  async ventPåBeregning(action: () => Promise<void>): Promise<void> {
+  /**
+   * Kjører `action`, venter på beregnings-PUT-en (200) den trigger, fanger
+   * responsbody-en (`BeregnetTrygdeavgift`) i {@link sisteBeregning} og returnerer den.
+   */
+  async ventPåBeregning(action: () => Promise<void>): Promise<BeregnetTrygdeavgift> {
     const beregningResponsePromise = this.page.waitForResponse(
       (resp) =>
         resp.url().includes('eos-pensjonist/beregning') &&
@@ -116,7 +144,30 @@ export class EuEosPensjonistTrygdeavgiftPage extends BasePage {
       { timeout: 15000 },
     );
     await action();
-    await beregningResponsePromise;
+    const resp = await beregningResponsePromise;
+    const body = (await resp.json()) as BeregnetTrygdeavgift;
+    this.sisteBeregning = body;
+    return body;
+  }
+
+  /**
+   * Returnerer den sist fangede beregningsresponsen. Kaster hvis ingen beregning
+   * er fanget enda (kall {@link fyllInnBruttoinntektMedApiVent} e.l. først).
+   */
+  hentSisteBeregning(): BeregnetTrygdeavgift {
+    if (!this.sisteBeregning) {
+      throw new Error(
+        'Ingen beregningsrespons er fanget enda — kall fyllInnBruttoinntektMedApiVent/ventPåBeregning først.',
+      );
+    }
+    return this.sisteBeregning;
+  }
+
+  /**
+   * Bekvemmelighet: trygdeavgiftsperiodene fra siste beregning.
+   */
+  hentTrygdeavgiftsperioder(): Trygdeavgiftsperiode[] {
+    return this.hentSisteBeregning().trygdeavgiftsperioder ?? [];
   }
 
   async klikkLeggTilInntekt(): Promise<void> {

--- a/tests/aarsavregning/aarsavregning-ikke-skattepliktig.spec.ts
+++ b/tests/aarsavregning/aarsavregning-ikke-skattepliktig.spec.ts
@@ -13,6 +13,8 @@ import {USER_ID_VALID} from '../../pages/shared/constants';
 import {UnleashHelper} from "../../helpers/unleash-helper";
 import {AdminApiHelper, waitForProcessInstances} from '../../helpers/api-helper';
 import {expect} from "@playwright/test";
+import {withDatabase} from '../../helpers/db-helper';
+import {verifiserAarsavregningBehandling} from '../../pages/behandling/aarsavregning.assertions';
 
 
 test.describe('Årsavregning - Ikke-skattepliktige saker', () => {
@@ -21,10 +23,6 @@ test.describe('Årsavregning - Ikke-skattepliktige saker', () => {
         const auth = new AuthHelper(page);
         const unleash = new UnleashHelper(request);
         await unleash.disableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
-
-        // Log what the frontend API returns (for debugging)
-        console.log('📊 Logging frontend toggle states after disabling toggle:');
-        await unleash.logFrontendToggleStates();
 
         await auth.login();
 
@@ -109,6 +107,34 @@ test.describe('Årsavregning - Ikke-skattepliktige saker', () => {
         );
 
         expect(response.antallProsessert).toBe(1);
+
+        // Lukk etterslepende auto-prosesser (opprett-behandling + brev) før DB-asserten,
+        // så «alle prosesser FERDIG» ikke blir CI-flaky.
+        await waitForProcessInstances(page.request, 60);
+
+        // Jobben OPPRETTER (men iverksetter ikke) en ÅRSAVREGNING-behandling.
+        // Cleanup-fixturen renser DB per test, så det finnes nøyaktig én slik
+        // behandling — verifiser at den faktisk nådde forventet DB-tilstand
+        // (OPPRETTET + behandlingsresultat + AARSAVREGNING-rad + alle prosesser
+        // FERDIG), ikke bare at job-count ble 1.
+        const aarsavregningBehandlingId = await withDatabase(async (db) => {
+            const rad = await db.queryOne<{ ID: number }>(
+                "SELECT ID FROM BEHANDLING WHERE BEH_TYPE = 'ÅRSAVREGNING' ORDER BY ID DESC FETCH FIRST 1 ROWS ONLY",
+                {}
+            );
+            expect(rad, 'Forventet en auto-opprettet ÅRSAVREGNING-behandling i DB').not.toBeNull();
+            return String(rad!.ID);
+        });
+
+        // Jobben oppretter (ikke iverksetter) årsavregningen, så sluttilstanden er
+        // OPPRETTET / IKKE_FASTSATT (verifisert live) med auto-opprett- og
+        // brev-prosessene FERDIG og en AARSAVREGNING-rad for 2024.
+        await verifiserAarsavregningBehandling(aarsavregningBehandlingId, {
+            forventetStatus: 'OPPRETTET',
+            forventetResultatType: 'IKKE_FASTSATT',
+            forventetAar: 2024,
+            forventedeProsesser: ['OPPRETT_NY_BEHANDLING_AARSAVREGNING'],
+        });
 
         console.log('✅ Workflow completed successfully!');
     });

--- a/tests/aarsavregning/ftrl-pensjonist-aarsavregning.spec.ts
+++ b/tests/aarsavregning/ftrl-pensjonist-aarsavregning.spec.ts
@@ -7,6 +7,7 @@ import { LovvalgPage } from '../../pages/behandling/lovvalg.page';
 import { VedtakPage } from '../../pages/vedtak/vedtak.page';
 import { USER_ID_VALID, SAKSTYPER, SAKSTEMA, BEHANDLINGSTEMA, AARSAK, FORRIGE_AAR } from '../../pages/shared/constants';
 import { waitForProcessInstances } from '../../helpers/api-helper';
+import { verifiserAarsavregningBehandling } from '../../pages/behandling/aarsavregning.assertions';
 
 /**
  * Komplett saksflyt for FTRL Pensjonist - Automatisk årsavregning
@@ -91,6 +92,33 @@ test.describe('FTRL Pensjonist - Automatisk årsavregning', () => {
       new RegExp(`${USER_ID_VALID}.*Pensjonist.*Årsavregning`)
     );
     await expect(aarsavregningLink).toBeVisible({ timeout: 15000 });
-    console.log('✅ Årsavregning-behandling er automatisk opprettet');
+
+    // Åpne årsavregningen for å lese ut behandlingID fra URL-en, og verifiser at
+    // den auto-opprettede behandlingen faktisk eksisterer i riktig DB-tilstand
+    // — ikke bare at en lenke ble synlig.
+    //
+    // NB: denne flyten FATTER ikke årsavregningsvedtak; behandlingen auto-opprettes
+    // og venter på saksbehandler. Sluttilstanden er derfor UNDER_BEHANDLING /
+    // IKKE_FASTSATT (verifisert live), men auto-opprett- og brev-prosessene er FERDIG
+    // og det finnes en AARSAVREGNING-rad for foregående år.
+    await aarsavregningLink.click();
+    await page.waitForURL(/behandlingID=\d+/, { timeout: 15000 });
+    const behandlingId = new URL(page.url()).searchParams.get('behandlingID');
+    if (!behandlingId) {
+      throw new Error(`Fant ikke behandlingID i årsavregnings-URL-en: ${page.url()}`);
+    }
+
+    // Lukk evt. etterslepende auto-prosesser (brev) på den nyopprettede
+    // årsavregningen før DB-asserten, slik at «alle prosesser FERDIG» ikke blir
+    // CI-flaky om brev-prosessen henger litt etter at lenken dukket opp.
+    await waitForProcessInstances(page.request, 60);
+
+    await verifiserAarsavregningBehandling(behandlingId, {
+      forventetStatus: 'UNDER_BEHANDLING',
+      forventetResultatType: 'IKKE_FASTSATT',
+      forventetAar: Number(FORRIGE_AAR),
+      forventedeProsesser: ['OPPRETT_NY_BEHANDLING_AARSAVREGNING'],
+    });
+    console.log('✅ Årsavregning-behandling er automatisk opprettet (UNDER_BEHANDLING)');
   });
 });

--- a/tests/eu-eos/eu-eos-art11-3b-medlemskap-offentlig-tjenesteperson.spec.ts
+++ b/tests/eu-eos/eu-eos-art11-3b-medlemskap-offentlig-tjenesteperson.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '../../fixtures';
+import { test, expect } from '../../fixtures';
 import { AuthHelper } from '../../helpers/auth-helper';
 import { HovedsidePage } from '../../pages/hovedside.page';
 import { OpprettNySakPage } from '../../pages/opprett-ny-sak/opprett-ny-sak.page';
@@ -15,6 +15,8 @@ import {
   FORRIGE_AAR,
 } from '../../pages/shared/constants';
 import { waitForProcessInstances } from '../../helpers/api-helper';
+import { verifiserBehandlingSluttilstand } from '../../pages/shared/behandling-sluttilstand.assertions';
+import { withDatabase } from '../../helpers/db-helper';
 
 /**
  * Komplett saksflyt for EØS Medlemskap Lovvalg - Offentlig tjenesteperson art.11(3)(b)
@@ -107,7 +109,29 @@ test.describe('EØS Medlemskap Lovvalg - Offentlig tjenesteperson 11.3b', () => 
     await hovedside.goto();
 
     await hovedside.åpneBehandling(behandlingLenke);
+
+    // Interim-oppførsel (gated på MELOSYS-7828): årsavregning kan ikke opprettes enda.
     await behandling.assertions.verifiserKanIkkeÅrsavregneEnda();
     console.log('✅ Bekreftet: Årsavregning kan ikke opprettes for denne sakstypen (enda)');
+
+    // Uavhengig av 7828: selve LOVVALGSVEDTAKET (FØRSTEGANG-behandlingen) SKAL ha nådd
+    // sin DB-sluttilstand. NB: URL-paramet behandlingID peker på den auto-opprettede
+    // ÅRSAVREGNING-behandlingen (UNDER_BEHANDLING) etter re-åpning, så vi slår opp
+    // FØRSTEGANG-behandlingen direkte i DB (cleanup-fixturen gir nøyaktig én per test).
+    const lovvalgBehandlingId = await withDatabase(async (db) => {
+      const rad = await db.queryOne<{ ID: number }>(
+        "SELECT ID FROM BEHANDLING WHERE BEH_TYPE = 'FØRSTEGANG' ORDER BY ID DESC FETCH FIRST 1 ROWS ONLY",
+        {}
+      );
+      expect(rad, 'Forventet en FØRSTEGANG-lovvalgsbehandling i DB').not.toBeNull();
+      return String(rad!.ID);
+    });
+
+    await verifiserBehandlingSluttilstand({
+      behandlingId: lovvalgBehandlingId,
+      forventetResultatType: 'FASTSATT_LOVVALGSLAND',
+      forventetIverksettProsess: 'IVERKSETT_VEDTAK_EOS',
+    });
+    console.log('✅ Lovvalgsvedtaket er AVSLUTTET og iverksatt i DB');
   });
 });

--- a/tests/eu-eos/eu-eos-pensjonist-trygdeavgift.spec.ts
+++ b/tests/eu-eos/eu-eos-pensjonist-trygdeavgift.spec.ts
@@ -20,6 +20,12 @@ import { hentMinstebeløp } from '../../helpers/trygdeavgift-beregning-helper';
 
 // Låst til 2026 for å unngå G-avhengig flakiness ved kalenderårsskifte.
 const TESTÅR = 2026;
+
+// Kalibrert mot ekte beregningsrespons: ordinær avgiftssats er ~5.1 %. 25%-regelen
+// oppgir ingen sats (avgiftssats=null) og gir et tak vesentlig under ordinær sats ×
+// inntekt — derfor trenger 25%-asserten en kjent ordinær sats som sammenligningsanker.
+// (verifiserBeregnetAvgift utleder selv prosent-vs-brøk fra responsverdien.)
+const ORDINÆR_SATS_PROSENT = 5.1;
 const helÅrFra = `01.01.${TESTÅR}`;
 const helÅrTil = `31.12.${TESTÅR}`;
 
@@ -116,6 +122,14 @@ test.describe('EU/EØS Pensjonist - Trygdeavgift beregningsresultat', () => {
     await trygdeavgift.assertions.verifiserTrygdeavgiftsTabellSynlig();
     await trygdeavgift.assertions.verifiser25ProsentRegelMarkering();
     await trygdeavgift.assertions.verifiserInfomeldingMinstebeløpIkkeSynlig();
+
+    // Verifiser TALLET bak 25%-regel-markeringen: regelen er aktiv i responsen,
+    // avgiften er positiv, og taket begrenser den vesentlig under ordinær sats.
+    trygdeavgift.assertions.verifiser25ProsentRegelAvgift(
+      trygdeavgift.hentTrygdeavgiftsperioder(),
+      Number(månedsinntektFor25ProsentRegel),
+      ORDINÆR_SATS_PROSENT,
+    );
   });
 
   // Sammenslåtte inntektskilder → *** i inntektskilde-kolonnen og fotnote
@@ -168,9 +182,18 @@ test.describe('EU/EØS Pensjonist - Trygdeavgift beregningsresultat', () => {
     await trygdeavgift.ventPåSideLastet();
     await trygdeavgift.velgIkkeSkattepliktig();
     await trygdeavgift.velgInntektskilde(INNTEKTSKILDE.PENSJON);
-    await trygdeavgift.fyllInnBruttoinntektMedApiVent('200000');
+    const ordinærBruttoPerMd = 200000;
+    await trygdeavgift.fyllInnBruttoinntektMedApiVent(String(ordinærBruttoPerMd));
 
     await trygdeavgift.assertions.verifiserTrygdeavgiftsTabellSynlig();
     await trygdeavgift.assertions.verifiserInfomeldingMinstebeløpIkkeSynlig();
+
+    // Sannheten testen handler om er TALLET, ikke markeringen: verifiser at det
+    // faktisk ble beregnet en positiv ordinær avgift, konsistent med sats × inntekt.
+    trygdeavgift.assertions.verifiserBeregnetAvgift(
+      trygdeavgift.hentTrygdeavgiftsperioder(),
+      'ORDINÆR',
+      ordinærBruttoPerMd,
+    );
   });
 });


### PR DESCRIPTION
## Hva
Løfter de svakeste regresjonsvaktene fra [testsuite-oversikten 2026-06-20] — **assertion-styrke, ikke et dekningshull**. PR A dekker P1 + P2 i arbeidsplanen. Ingen mock-endring.

### P1 · Årsavregning child-behandling DB-assert
Begge testene `waitForProcessInstances` allerede, men asserterte kun en UI-lenke / et jobb-antall — selve den auto-opprettede årsavregning-behandlingen ble aldri verifisert i DB.
- Ny gjenbrukbar `verifiserAarsavregningBehandling(...)` (`pages/behandling/aarsavregning.assertions.ts`): asserterer BEH_TYPE + status + behandlingsresultat + `AARSAVREGNING`-rad + alle prosessinstanser `FERDIG`.
- **Premiss-korreksjon (live-verifisert):** begge flytene auto-**oppretter** (men iverksetter ikke) årsavregningen → status er `UNDER_BEHANDLING` (ftrl) / `OPPRETTET` (batch-jobb), ikke `AVSLUTTET`. Helper-en er derfor status/resultat-konfigurerbar.
- `ftrl-pensjonist-aarsavregning`: lenke-synlighet → DB-assert (behandlingID leses fra URL).
- `aarsavregning-ikke-skattepliktig`: DB-assert etter jobben; fjernet debug `logFrontendToggleStates`.

### P2 · Trygdeavgift-beløp + lovvalg-sluttilstand
- `eu-eos-pensjonist-trygdeavgift`: `ventPåBeregning` fanger nå beregningsresponsen; nye asserts på faktisk **`avgiftPerMd`** + `beregningsregel` (ORDINÆR / 25%-regel-tak). Sats-enkoding (prosent vs. brøk) utledes av verdien.
- `eu-eos-art11-3b`: **lovvalgsvedtakets** sluttilstand hard-asserteres med `verifiserBehandlingSluttilstand` (AVSLUTTET + FASTSATT_LOVVALGSLAND + IVERKSETT_VEDTAK_EOS). Interim "kan ikke årsavregne enda" beholdt (gated på MELOSYS-7828).

## Robusthet
`/code-review` (high) → la til ekstra `waitForProcessInstances` før DB-assertene (lukker brev-prosess-race på CI), ryddet misvisende kommentar, fjernet skjør sats-flagg.

## Verifisert
- Lokalt: 7 passed (alle 4 specs), reproduserbart grønt.
- `npm run check:tests` grønn; `tsc` rent for endrede filer.
- CI-dispatch (`E2E Tests`) — se kjøring lenket under.