### PR TITLE
Løft svake assertions (PR B): oppgave-type + kjørbar saksnummer-søk

### DIFF
--- a/tests/core/oppgaver.spec.ts
+++ b/tests/core/oppgaver.spec.ts
@@ -4,6 +4,32 @@ import { HovedsidePage } from '../../pages/hovedside.page';
 import { OpprettNySakPage } from '../../pages/opprett-ny-sak/opprett-ny-sak.page';
 import { OppgaverPage } from '../../pages/oppgaver/oppgaver.page';
 import { USER_ID_VALID } from '../../pages/shared/constants';
+import { fetchOppgaver } from '../../helpers/mock-helper';
+import type { APIRequestContext } from '@playwright/test';
+
+/**
+ * Behandling-oppgaven som opprettes for en ny sak har oppgavetype BEH_SAK_MK
+ * (samme type som svar-anmodning-unntak-assertionen sjekker, MELOSYS-6836-vakten).
+ * Live-verifisert via fetchOppgaver under denne testkjøringen.
+ */
+const BEHANDLING_OPPGAVETYPE = 'BEH_SAK_MK';
+
+/**
+ * Hent behandling-oppgavene (oppgavetype BEH_SAK_MK) fra melosys-mock og assert
+ * at minst én finnes — altså at saken faktisk ga en behandling-oppgave av riktig TYPE,
+ * ikke bare at «en eller annen oppgave» finnes.
+ */
+async function verifiserBehandlingOppgaveAvRiktigType(request: APIRequestContext): Promise<void> {
+  const oppgaver = await fetchOppgaver(request);
+  // Engangslogging av faktiske oppgavetyper for live-verifisering av type-strengen.
+  console.log(`   Oppgavetyper i mock: ${JSON.stringify(oppgaver.map((o) => o.oppgavetype))}`);
+  const behandlingsoppgaver = oppgaver.filter((o) => o.oppgavetype === BEHANDLING_OPPGAVETYPE);
+  expect(
+    behandlingsoppgaver.length,
+    `Opprettet sak skal gi minst én behandling-oppgave av type ${BEHANDLING_OPPGAVETYPE}, fant: ${JSON.stringify(oppgaver.map((o) => o.oppgavetype))}`,
+  ).toBeGreaterThan(0);
+  console.log(`✅ Fant ${behandlingsoppgaver.length} behandling-oppgave(r) av riktig type (${BEHANDLING_OPPGAVETYPE})`);
+}
 
 /**
  * Test suite for task/oppgaver functionality on the main page
@@ -41,7 +67,7 @@ test.describe('Oppgaver', () => {
     console.log('✅ Oppgaver section is visible on forside');
   });
 
-  test('skal vise behandling-oppgave etter opprettelse av sak', async ({ page }) => {
+  test('skal vise behandling-oppgave etter opprettelse av sak', async ({ page, request }) => {
     // Step 1: Create a case (this should create a behandling oppgave)
     console.log('📝 Step 1: Creating a case...');
     await hovedside.gotoOgOpprettNySak();
@@ -54,18 +80,13 @@ test.describe('Oppgaver', () => {
     await hovedside.goto();
     await oppgaver.ventPåOppgaverLastet();
 
-    // Step 3: Check if we have any tasks
-    console.log('📝 Step 3: Checking for tasks...');
-    const behandlingCount = await oppgaver.getBehandlingOppgaveAntall();
-
-    console.log(`   Total behandling oppgaver: ${behandlingCount}`);
-
-    // Saken vi opprettet (lagt i «mine») SKAL gi minst én behandling-oppgave på forsiden.
-    expect(behandlingCount, 'Opprettet sak skal gi en behandling-oppgave').toBeGreaterThan(0);
-    console.log('✅ Found behandling oppgaver as expected');
+    // Step 3: Assert at det faktisk finnes en behandling-oppgave av RIKTIG TYPE (BEH_SAK_MK)
+    // i mock — ikke bare at «en eller annen oppgave» vises på forsiden.
+    console.log('📝 Step 3: Verifying behandling-oppgave of correct type exists...');
+    await verifiserBehandlingOppgaveAvRiktigType(request);
   });
 
-  test('skal kunne navigere til behandling fra oppgave', async ({ page }) => {
+  test('skal kunne navigere til behandling fra oppgave', async ({ page, request }) => {
     // Step 1: Create a case first
     console.log('📝 Step 1: Creating a case...');
     await hovedside.gotoOgOpprettNySak();
@@ -78,32 +99,21 @@ test.describe('Oppgaver', () => {
     await hovedside.goto();
     await oppgaver.ventPåOppgaverLastet();
 
-    // Step 3: Try to find and click on a behandling oppgave
-    console.log('📝 Step 3: Looking for behandling oppgave...');
-    const behandlingCount = await oppgaver.getBehandlingOppgaveAntall();
+    // Step 3: Behandling-oppgaven SKAL finnes (ingen stille søk-fallback). Verifiser at
+    // den faktisk ble opprettet i mock med riktig type før vi klikker på den på forsiden;
+    // testen skal FEILE hvis happy-path ikke kan kjøres.
+    console.log('📝 Step 3: Verifying behandling-oppgave exists before navigating...');
+    await verifiserBehandlingOppgaveAvRiktigType(request);
 
-    if (behandlingCount > 0) {
-      console.log('📝 Step 4: Clicking on behandling oppgave...');
-      await oppgaver.klikkBehandlingOppgaveIndex(0);
+    console.log('📝 Step 4: Clicking on behandling oppgave...');
+    await oppgaver.klikkBehandlingOppgaveIndex(0);
 
-      console.log('📝 Step 5: Verifying navigation...');
-      await oppgaver.assertions.verifiserNavigertTilBehandling();
-      console.log('✅ Successfully navigated to behandling from oppgave');
-    } else {
-      // Try alternative: use the search to find the case
-      console.log('📝 Alternative: No oppgaver visible, using search...');
-      await hovedside.søkEtterBruker(USER_ID_VALID);
-      await page.waitForURL(/\/sok/, { timeout: 5000 });
-
-      // Click on the case from search results
-      await page.getByRole('link', { name: /TRIVIELL KARAFFEL/i }).first().click();
-      await expect(page).toHaveURL(/saksbehandling|behandling/, { timeout: 10000 });
-
-      console.log('✅ Navigated to behandling via search (oppgave list was empty)');
-    }
+    console.log('📝 Step 5: Verifying navigation...');
+    await oppgaver.assertions.verifiserNavigertTilBehandling();
+    console.log('✅ Successfully navigated to behandling from oppgave');
   });
 
-  test('skal vise oppgave-antall', async ({ page }) => {
+  test('skal vise oppgave-antall', async ({ page, request }) => {
     // Step 1: Create a case to ensure we have at least one item
     console.log('📝 Step 1: Creating a case...');
     await hovedside.gotoOgOpprettNySak();
@@ -116,7 +126,7 @@ test.describe('Oppgaver', () => {
     await hovedside.goto();
     await oppgaver.ventPåOppgaverLastet();
 
-    // Step 3: Get task counts
+    // Step 3: Get task counts (UI-tellere logges for kontekst)
     console.log('📝 Step 3: Getting task counts...');
     const journalCount = await oppgaver.getJournalforingOppgaveAntall();
     const behandlingCount = await oppgaver.getBehandlingOppgaveAntall();
@@ -124,8 +134,9 @@ test.describe('Oppgaver', () => {
     console.log(`   Journalføring oppgaver: ${journalCount}`);
     console.log(`   Behandling oppgaver: ${behandlingCount}`);
 
-    // Vi opprettet én sak, så det skal finnes minst én behandling-oppgave (journalCount logges over).
-    expect(behandlingCount, 'Opprettet sak skal gi en behandling-oppgave').toBeGreaterThanOrEqual(1);
+    // Vi opprettet én sak, så det skal finnes en behandling-oppgave av riktig TYPE (BEH_SAK_MK)
+    // i mock — ikke bare et tall > 0 i UI-telleren.
+    await verifiserBehandlingOppgaveAvRiktigType(request);
 
     console.log('✅ Successfully retrieved task counts');
   });

--- a/tests/core/sok-og-navigasjon.spec.ts
+++ b/tests/core/sok-og-navigasjon.spec.ts
@@ -3,6 +3,7 @@ import { AuthHelper } from '../../helpers/auth-helper';
 import { HovedsidePage } from '../../pages/hovedside.page';
 import { OpprettNySakPage } from '../../pages/opprett-ny-sak/opprett-ny-sak.page';
 import { USER_ID_VALID } from '../../pages/shared/constants';
+import { withDatabase } from '../../helpers/db-helper';
 
 /**
  * Test suite for search and navigation functionality
@@ -100,60 +101,46 @@ test.describe('Søk og navigasjon', () => {
     console.log('✅ Successfully navigated to case from search');
   });
 
-  // @manual: happy-path er i praksis unåbar — etter opprettStandardSak + verifiserBehandlingOpprettet
-  // står vi på forsiden (/melosys/$), så saksnummer-regexen mot page.url() blir alltid null og
-  // søke-blokken hoppes over (testen passerte via expect(true)). Hardning krever en pålitelig
-  // saksnummer-kilde (f.eks. DB) + sok.assertions.verifiserSakIResultat(...). Krever lokal kjøring
-  // for å verifisere. Se e2e-audit 2026-06-08.
-  test('skal søke etter sak med saksnummer @manual', async ({ page }) => {
-    // Step 1: Create a case and capture saksnummer
+  // Tidligere @manual: happy-path var unåbar fordi saksnummer ble forsøkt lest fra forside-URL-en
+  // (/melosys/$), som alltid ga null. Nå hentes saksnummer pålitelig fra DB (cleanup-fixture ⇒
+  // nyeste FAGSAK-rad er denne testens sak), så søket faktisk kjøres og verifiseres. Tag fjernet.
+  test('skal søke etter sak med saksnummer', async ({ page }) => {
+    // Step 1: Create a case
     console.log('📝 Step 1: Creating a case...');
     await hovedside.gotoOgOpprettNySak();
     await opprettSak.opprettStandardSak(USER_ID_VALID);
     await opprettSak.assertions.verifiserBehandlingOpprettet();
 
-    // Get saksnummer from URL (format: /FTRL/saksbehandling/2024000001 or /saksbehandling/MEL-XX)
-    const url = page.url();
-    console.log(`   Current URL: ${url}`);
+    // Step 2: Hent saksnummer fra DB (cleanup-fixture ⇒ nyeste rad er denne testens sak)
+    console.log('📝 Step 2: Fetching saksnummer from DB...');
+    const saksnummer = await withDatabase(async (db) => {
+      const rad = await db.queryOne<{ SAKSNUMMER: string }>(
+        `SELECT saksnummer FROM FAGSAK ORDER BY registrert_dato DESC FETCH FIRST 1 ROWS ONLY`,
+        {},
+      );
+      return rad?.SAKSNUMMER ?? null;
+    });
+    expect(saksnummer, 'Forventet et saksnummer i FAGSAK etter opprettet sak').not.toBeNull();
+    console.log(`   Saksnummer: ${saksnummer}`);
 
-    // Try different saksnummer patterns
-    let saksnummer: string | null = null;
-    let match = url.match(/saksbehandling\/(\d{10,})/); // 10+ digit number
-    if (!match) {
-      match = url.match(/saksbehandling\/(MEL-\d+)/); // MEL-XX format
-    }
+    // Step 3: Søk på saksnummer fra forsiden
+    console.log('📝 Step 3: Searching by saksnummer...');
+    await hovedside.goto();
+    await hovedside.søkEtterBruker(saksnummer!);
+    await page.waitForLoadState('networkidle');
 
-    if (match) {
-      saksnummer = match[1];
-      console.log(`   Found saksnummer: ${saksnummer}`);
-    }
+    // Step 4: Søk på saksnummer SKAL gi treff på saken — "Vis behandling"-knappen vises.
+    console.log('📝 Step 4: Verifying saksnummer search found the case...');
+    const visBehandlingButton = page.getByRole('button', { name: 'Vis behandling' });
+    await expect(
+      visBehandlingButton,
+      'Søk på saksnummer skal gi treff på saken',
+    ).toBeVisible({ timeout: 10000 });
 
-    // If we found a saksnummer, search for it
-    if (saksnummer) {
-      // Step 2: Go back and search by saksnummer
-      console.log('📝 Step 2: Searching by saksnummer...');
-      await hovedside.goto();
-      await hovedside.søkEtterBruker(saksnummer);
-      await page.waitForLoadState('networkidle');
-
-      // Step 3: Verify we can navigate to the case
-      console.log('📝 Step 3: Verifying search results...');
-      const visBehandlingButton = page.getByRole('button', { name: 'Vis behandling' });
-      const foundResults = await visBehandlingButton.isVisible({ timeout: 5000 }).catch(() => false);
-
-      if (foundResults) {
-        console.log('✅ Successfully found case by saksnummer search');
-      } else {
-        console.log('ℹ️ Vis behandling not shown (may be navigated directly)');
-      }
-    } else {
-      console.log('⚠️ Could not extract saksnummer from URL');
-    }
-
-    // @manual TODO: happy-path unåbar (saksnummer=null fra forside-URL). Hent saksnummer fra DB
-    // og bruk sok.assertions.verifiserSakIResultat(saksnummer). Inntil da feiler testen tydelig
-    // ved manuell kjøring i stedet for å passere tomt.
-    expect(saksnummer, 'Kunne ikke hente saksnummer (se @manual-merknad over)').not.toBeNull();
+    // ... og knappen SKAL navigere til behandlingen.
+    await hovedside.klikkVisBehandling();
+    await expect(page).toHaveURL(/saksbehandling|behandling/, { timeout: 10000 });
+    console.log('✅ Successfully found and navigated to case by saksnummer search');
   });
 
   test('skal kunne navigere tilbake til forsiden fra søkeresultater', async ({ page }) => {


### PR DESCRIPTION
## Hva
P3 i [arbeidsplanen](../melosys-kode-wiki) — **infra/UI-test-hardning** (assertion-styrke, ikke et dekningshull). Disse har ingen domene-sluttilstand av natur, så ingen falsk domene-assert er presset fram. Ingen mock-endring. Følger PR A (#286).

### `tests/core/oppgaver.spec.ts`
- Erstattet svak `count > 0` / `>= 1` (3 tester) med en **TYPE-assert**: ny `verifiserBehandlingOppgaveAvRiktigType` henter oppgaver via `fetchOppgaver` og asserterer ≥1 behandling-oppgave av riktig `oppgavetype` (`BEH_SAK_MK`, live-verifisert).
- Fjernet `if/else → søk`-fallbacken i navigasjonstesten — den lot happy-path bli **stille hoppet over** (en vacuous-risiko `check:tests` ikke fanger). Happy-path kjøres nå ubetinget og feiler hvis oppgaven mangler.

### `tests/core/sok-og-navigasjon.spec.ts`
- Saksnummer-søk-testen var `@manual` med en **uoppnåelig** happy-path (saksnummer-regex mot forside-URL = alltid null). Gjort **kjørbar**: henter ekte saksnummer fra `FAGSAK` (cleanup-fixture ⇒ nyeste rad = testens sak), søker, og asserterer at «Vis behandling» vises + navigerer. `@manual` fjernet.
- Resten av filen forblir bevisst en navigasjons-røyktest.

## Verifisert
- Lokalt: 10 passed (begge specs, 5+5), reproduserbart.
- `npm run check:tests` grønn; `tsc` rent for endrede filer; `/code-review` (fokusert): ingen funn.
- CI-dispatch (`E2E Tests`) — se kjøring lenket under.

## Resultat
SVAK **6 → ~1** (kun `sok-og-navigasjon` som helhet, ærlig re-merket som ren navigasjons-røyktest).