### PR TITLE
Domenegruppert E2E-rapport: kollaps + varighet per gruppe

### DIFF
--- a/docs/report-ideas/data.js
+++ b/docs/report-ideas/data.js
@@ -1,0 +1,1583 @@
+// Generated from CI run 27886483545 (real titles+durations). DO NOT hand-edit.
+window.DATASETS = {
+ "green": {
+  "status": "passed",
+  "duration": 2936867.8449999997,
+  "startTime": "2026-06-20T23:02:29.461Z",
+  "tags": {
+   "melosys-api": "latest",
+   "melosys-web": "latest",
+   "faktureringskomponenten": "latest",
+   "melosys-trygdeavgift-beregning": "latest",
+   "melosys-trygdeavtale": "latest",
+   "melosys-inngangsvilkar": "latest",
+   "melosys-eessi": "latest",
+   "melosys-mock": "latest",
+   "melosys-dokgen": "latest"
+  },
+  "tests": [
+   {
+    "title": "skal opprette og fullføre årsavregning behandling",
+    "file": "tests/aarsavregning/aarsavregning-ftrl.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 28555
+   },
+   {
+    "title": "skal opprette årsavregning for ikke-skattepliktig bruker",
+    "file": "tests/aarsavregning/aarsavregning-ikke-skattepliktig.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 54026
+   },
+   {
+    "title": "skattehendelse uten fullmektig sender innhentingsbrev til bruker",
+    "file": "tests/aarsavregning/aarsavregning-innhentingsbrev-automatisk.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 44534
+   },
+   {
+    "title": "ikke-skattepliktig-jobben uten fullmektig sender innhentingsbrev til bruker",
+    "file": "tests/aarsavregning/aarsavregning-innhentingsbrev-automatisk.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 44585
+   },
+   {
+    "title": "skattehendelse med fullmektig sender innhentingsbrev til fullmektig",
+    "file": "tests/aarsavregning/aarsavregning-innhentingsbrev-automatisk.spec.ts",
+    "status": "skipped",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 0
+   },
+   {
+    "title": "ikke-skattepliktig-jobben med fullmektig sender innhentingsbrev til fullmektig",
+    "file": "tests/aarsavregning/aarsavregning-innhentingsbrev-automatisk.spec.ts",
+    "status": "skipped",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 0
+   },
+   {
+    "title": "skattehendelse for skatteår X gir årsavregningsoppgave med X i beskrivelsen",
+    "file": "tests/aarsavregning/aarsavregning-oppgave-skatteaar-i-beskrivelse-og-nokkelord.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 44653
+   },
+   {
+    "title": "ikke-skattepliktig-jobben for skatteår X gir årsavregningsoppgave med X i beskrivelsen",
+    "file": "tests/aarsavregning/aarsavregning-oppgave-skatteaar-i-beskrivelse-og-nokkelord.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 43870
+   },
+   {
+    "title": "saksbehandlingsflyt som berører tidligere år X gir årsavregningsoppgave med X i beskrivelsen",
+    "file": "tests/aarsavregning/aarsavregning-oppgave-skatteaar-i-beskrivelse-og-nokkelord.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 62734
+   },
+   {
+    "title": "skal fullføre pensjonistbehandling og opprette årsavregning for samme sak",
+    "file": "tests/aarsavregning/eos-pensjonist-aarsavregning-direkte-grunnlag-beregn.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 53657
+   },
+   {
+    "title": "skal fullføre pensjonistbehandling og årsavregning med innbetalt avvik",
+    "file": "tests/aarsavregning/eos-pensjonist-aarsavregning-innbetalt-avvik-beregn.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 73851
+   },
+   {
+    "title": "skal beregne endelig trygdeavgift i uten-grunnlag-flyten (OPPLYSNINGER_ENDRET)",
+    "file": "tests/aarsavregning/eos-pensjonist-aarsavregning-uten-grunnlag.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 49971
+   },
+   {
+    "title": "skal oppgi endelig trygdeavgift manuelt med obligatorisk begrunnelse (MANUELL_ENDELIG_AVGIFT)",
+    "file": "tests/aarsavregning/eos-pensjonist-aarsavregning-uten-grunnlag.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 44689
+   },
+   {
+    "title": "skal automatisk opprette årsavregning etter vedtak på pensjonist-sak",
+    "file": "tests/aarsavregning/ftrl-pensjonist-aarsavregning.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 21844
+   },
+   {
+    "title": "komplett førstegangsbehandling, automatisk opprettet årsavregning, nv annulerer også åpen årsavregning",
+    "file": "tests/aarsavregning/komplett-sak-nyvurdering-annullering-lukker-aapne-aarsavregninger.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 47363
+   },
+   {
+    "title": "skal fullføre sak med flere land, ikke-skattepliktig og arbeidsinntekt fra Norge. Så NV med skattepliktig, avregning skal bli riktig",
+    "file": "tests/aarsavregning/komplett-sak-nyvurdering-periode-endres-til-kun-tidligere-aar.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 63518
+   },
+   {
+    "title": "Scenario 1 — seksjonen vises med 5 år SKATT-rader (seeded)",
+    "file": "tests/aarsavregning/popp-pensjonsopptjening-visning.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 24526
+   },
+   {
+    "title": "Scenario 2 — delt grunnlag: Skatt og Avgiftssystemet samme år (seeded)",
+    "file": "tests/aarsavregning/popp-pensjonsopptjening-visning.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 23987
+   },
+   {
+    "title": "Scenario 3 — alle tre kilder med ulike tidsstempler per kilde (seeded)",
+    "file": "tests/aarsavregning/popp-pensjonsopptjening-visning.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 23453
+   },
+   {
+    "title": "Scenario 4 — ingen pensjonsopptjening: tom-melding vises (seeded tom)",
+    "file": "tests/aarsavregning/popp-pensjonsopptjening-visning.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 22372
+   },
+   {
+    "title": "Scenario 6 — flere inntektTyper per kilde rendres med dekode-beskrivelse",
+    "file": "tests/aarsavregning/popp-pensjonsopptjening-visning.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 23383
+   },
+   {
+    "title": "Scenario 5 — årsavregning eldre enn 5 år: visning utvides til avregningsåret",
+    "file": "tests/aarsavregning/popp-pensjonsopptjening-visning.spec.ts",
+    "status": "skipped",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 0
+   },
+   {
+    "title": "skal vise oppgave-seksjon på forsiden",
+    "file": "tests/core/oppgaver.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 9490
+   },
+   {
+    "title": "skal vise behandling-oppgave etter opprettelse av sak",
+    "file": "tests/core/oppgaver.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 11835
+   },
+   {
+    "title": "skal kunne navigere til behandling fra oppgave",
+    "file": "tests/core/oppgaver.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 12162
+   },
+   {
+    "title": "skal vise oppgave-antall",
+    "file": "tests/core/oppgaver.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 12060
+   },
+   {
+    "title": "skal håndtere tom oppgaveliste",
+    "file": "tests/core/oppgaver.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 9397
+   },
+   {
+    "title": "skal trigge MOTTAK_SED prosess ved mottak av A003",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 8717
+   },
+   {
+    "title": "skal opprette fagsak ved mottak av A003 fra Sverige",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7372
+   },
+   {
+    "title": "skal håndtere A009 og automatisk registrere unntak fra norsk trygd (REGISTRERT_UNNTAK)",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7902
+   },
+   {
+    "title": "skal håndtere A010 og automatisk registrere unntak fra norsk trygd – øvrige (REGISTRERT_UNNTAK)",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7367
+   },
+   {
+    "title": "skal håndtere A001 søknad fra Danmark",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7313
+   },
+   {
+    "title": "skal håndtere tilpasset SED konfigurasjon",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7327
+   },
+   {
+    "title": "skal verifisere at SED fører til oppgave i systemet",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 9205
+   },
+   {
+    "title": "skal håndtere flere SED-typer i sekvens",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 8302
+   },
+   {
+    "title": "skal verifisere prosessinstanser i databasen",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7308
+   },
+   {
+    "title": "skal trigge MOTTAK_SED via melosys-eessi flow",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7421
+   },
+   {
+    "title": "skal opprette fagsak via full eessi-flow med A003 fra Sverige",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7851
+   },
+   {
+    "title": "skal håndtere A009 informasjonsforespørsel via eessi",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 6826
+   },
+   {
+    "title": "skal sammenligne direkte vs eessi-flow @comparison",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7816
+   },
+   {
+    "title": "skal søke etter person med gyldig fødselsnummer og finne sak",
+    "file": "tests/core/sok-og-navigasjon.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 11936
+   },
+   {
+    "title": "skal vise ingen resultater for ukjent bruker",
+    "file": "tests/core/sok-og-navigasjon.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 8726
+   },
+   {
+    "title": "skal navigere til sak fra søkeresultat",
+    "file": "tests/core/sok-og-navigasjon.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 11514
+   },
+   {
+    "title": "skal søke etter sak med saksnummer",
+    "file": "tests/core/sok-og-navigasjon.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 11751
+   },
+   {
+    "title": "skal kunne navigere tilbake til forsiden fra søkeresultater",
+    "file": "tests/core/sok-og-navigasjon.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 11703
+   },
+   {
+    "title": "skal produsere korrekt, distinkt vedtaksbrev for FTRL- og trygdeavtale-mottaker",
+    "file": "tests/core/vedtaksbrev-mottakertype.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 57475
+   },
+   {
+    "title": "skal fullføre sak og verifisere at årsavregning ikke kan opprettes",
+    "file": "tests/eu-eos/eu-eos-art11-3b-medlemskap-offentlig-tjenesteperson.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 25343
+   },
+   {
+    "title": "skal iverksette vedtak og verifisere MEDL-periode, A009 SED og utgående journalpost",
+    "file": "tests/eu-eos/eu-eos-art12-iverksetting-mottaker-kjede.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 47113
+   },
+   {
+    "title": "skal forkorte lovvalgsperiode via nyvurdering og overføre ny periode til MEDL",
+    "file": "tests/eu-eos/eu-eos-art12-nyvurdering-medlemskap-overforing.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 88065
+   },
+   {
+    "title": "skal fullføre EU/EØS-arbeidsflyt med vedtak",
+    "file": "tests/eu-eos/eu-eos-art12-utsendt-arbeidstaker-fullfort-vedtak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 46790
+   },
+   {
+    "title": "skal fullføre \"Arbeid i flere land\" arbeidsflyt med vedtak",
+    "file": "tests/eu-eos/eu-eos-art13-arbeid-flere-land-fullfort-vedtak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 26430
+   },
+   {
+    "title": "skal fullføre \"Arbeid i flere land\" med selvstendig næringsvirksomhet og SED-dokument",
+    "file": "tests/eu-eos/eu-eos-art13-arbeid-flere-land-selvstendig-fullfort-vedtak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 36080
+   },
+   {
+    "title": "skal nyvurdere en registrert annet-land-sak og re-registrere unntaket",
+    "file": "tests/eu-eos/eu-eos-inngaaende-a003-annet-land-nyvurdering.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 15680
+   },
+   {
+    "title": "skal godkjenne at et annet land er utpekt og registrere unntak (uten SED)",
+    "file": "tests/eu-eos/eu-eos-inngaaende-a003-annet-land-utpekt-registrert-unntak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 11410
+   },
+   {
+    "title": "skal godkjenne utpeking av Norge og svare utland med A012",
+    "file": "tests/eu-eos/eu-eos-inngaaende-a003-norge-utpekt-a012.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 14046
+   },
+   {
+    "title": "Kosovo statsborgerskap bevart i SED A008",
+    "file": "tests/eu-eos/eu-eos-kosovo-statsborgerskap.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 37519
+   },
+   {
+    "title": "skal annullere sak med sendt vedtak og avvise MEDL-perioden",
+    "file": "tests/eu-eos/eu-eos-nyvurdering-annuller-medlemskap-avvis.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 52163
+   },
+   {
+    "title": "Scenario 1: SED sendes til EESSI-land og papir til Færøyene",
+    "file": "tests/eu-eos/eu-eos-papir-a1-til-ikke-eessi-land.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 37653
+   },
+   {
+    "title": "Scenario 2: SED sendes til EESSI-land og papir til Færøyene og Grønland",
+    "file": "tests/eu-eos/eu-eos-papir-a1-til-ikke-eessi-land.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 38003
+   },
+   {
+    "title": "Scenario 3 (regresjon): Kun EESSI-land — ingen papir-A1 til FO/GL",
+    "file": "tests/eu-eos/eu-eos-papir-a1-til-ikke-eessi-land.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 37582
+   },
+   {
+    "title": "Scenario 4: Kun Færøyene + Grønland — papir-A1 sendes til begge",
+    "file": "tests/eu-eos/eu-eos-papir-a1-til-ikke-eessi-land.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 27954
+   },
+   {
+    "title": "skal vise infomelding når inntekten er under minstebeløpet",
+    "file": "tests/eu-eos/eu-eos-pensjonist-trygdeavgift.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 27450
+   },
+   {
+    "title": "skal vise tabell med asterisk (*) for 25%-regel",
+    "file": "tests/eu-eos/eu-eos-pensjonist-trygdeavgift.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 27237
+   },
+   {
+    "title": "skal vise *** for sammenslåtte inntektskilder",
+    "file": "tests/eu-eos/eu-eos-pensjonist-trygdeavgift.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 28532
+   },
+   {
+    "title": "skal vise tabell ved ordinær beregning",
+    "file": "tests/eu-eos/eu-eos-pensjonist-trygdeavgift.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 27178
+   },
+   {
+    "title": "skal videresende søknad til Sverige",
+    "file": "tests/eu-eos/eu-eos-sed-a008-videresend-soeknad.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 37440
+   },
+   {
+    "title": "skal fullføre EU/EØS-skip-arbeidsflyt med vedtak",
+    "file": "tests/eu-eos/eu-eos-skip-fullfort-vedtak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 28384
+   },
+   {
+    "title": "mottar A002 (innvilgelse) - skal fatte vedtak automatisk",
+    "file": "tests/eu-eos/unntak/eu-eos-anmodning-unntak-nyvurdering-svar.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 34933
+   },
+   {
+    "title": "mottar A011 (avslag) - skal kreve manuell ny vurdering",
+    "file": "tests/eu-eos/unntak/eu-eos-anmodning-unntak-nyvurdering-svar.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 35004
+   },
+   {
+    "title": "direkte til - skal sende anmodning om unntak",
+    "file": "tests/eu-eos/unntak/eu-eos-utsendt-arbeidstaker-anmodning-unntak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 32506
+   },
+   {
+    "title": "direkte til art.13(1)(a) - skal sende anmodning om unntak",
+    "file": "tests/eu-eos/unntak/eu-eos-utsendt-arbeidstaker-anmodning-unntak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 33164
+   },
+   {
+    "title": "direkte til art.13(1)(a) med TWFA - skal sende anmodning om unntak",
+    "file": "tests/eu-eos/unntak/eu-eos-utsendt-arbeidstaker-anmodning-unntak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 32623
+   },
+   {
+    "title": "via full behandling - skal sende anmodning om unntak",
+    "file": "tests/eu-eos/unntak/eu-eos-utsendt-arbeidstaker-anmodning-unntak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 36407
+   },
+   {
+    "title": "direkte til CDM 4.3 - skal sende anmodning om unntak",
+    "file": "tests/eu-eos/unntak/eu-eos-utsendt-arbeidstaker-anmodning-unntak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 32977
+   },
+   {
+    "title": "direkte til art.13(1)(a) CDM 4.3 - skal sende anmodning om unntak",
+    "file": "tests/eu-eos/unntak/eu-eos-utsendt-arbeidstaker-anmodning-unntak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 32475
+   },
+   {
+    "title": "skal opprette manglende-innbetaling-behandling automatisk og fatte opphørsvedtak",
+    "file": "tests/ftrl/ftrl-manglende-innbetaling-opphor.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 48410
+   },
+   {
+    "title": "25%-regelen begrenser avgiften",
+    "file": "tests/ftrl/ftrl-trygdeavgift-25-prosent-regel.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 35426
+   },
+   {
+    "title": "ordinær beregning uten begrensning (80000 kr/md)",
+    "file": "tests/ftrl/ftrl-trygdeavgift-25-prosent-regel.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 35299
+   },
+   {
+    "title": "25%-regelen med Full dekning — pliktig medlem",
+    "file": "tests/ftrl/ftrl-trygdeavgift-25-prosent-regel.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 34298
+   },
+   {
+    "title": "inntekt under minstebeløpet — avgift 0 kr",
+    "file": "tests/ftrl/ftrl-trygdeavgift-25-prosent-regel.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 36027
+   },
+   {
+    "title": "Confluence Eksempel 1 — flere skatteforhold og inntekter, 25%-regel på alle perioder",
+    "file": "tests/ftrl/ftrl-trygdeavgift-25-prosent-regel.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 83209
+   },
+   {
+    "title": "25%-regelen for FTRL Pensjonist",
+    "file": "tests/ftrl/ftrl-trygdeavgift-25-prosent-regel.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 32780
+   },
+   {
+    "title": "skal innvilge pliktig medlemskap § 2-2, fatte vedtak og opprette fakturaserie",
+    "file": "tests/ftrl/ftrl-yrkesaktiv-2-2-forstegang.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 34365
+   },
+   {
+    "title": "skal fullføre trygdeavtale-arbeidsflyt med vedtak",
+    "file": "tests/trygdeavtale/trygdeavtale-fullfort-vedtak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 27906
+   },
+   {
+    "title": "skal forkorte periode via nyvurdering og erstatte MEDL-perioden in-place",
+    "file": "tests/trygdeavtale/trygdeavtale-nyvurdering.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 35282
+   },
+   {
+    "title": "skal registrere godkjent unntak med endelig MEDL-periode",
+    "file": "tests/trygdeavtale/trygdeavtale-unntaksregistrering.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 23646
+   },
+   {
+    "title": "skal avslutte saken uten lovvalgsperiode ved ikke godkjent unntak",
+    "file": "tests/trygdeavtale/trygdeavtale-unntaksregistrering.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 23474
+   },
+   {
+    "title": "skal fullføre komplett saksflyt med § 2-8 første ledd bokstav a (arbeidstaker)",
+    "file": "tests/utenfor-avtaleland/komplett-sak-2-8a.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 36719
+   },
+   {
+    "title": "FULL_DEKNING_FTRL",
+    "file": "tests/utenfor-avtaleland/komplett-sak-2-8a.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 36954
+   },
+   {
+    "title": "skal fullføre komplett saksflyt med § 2-8 første ledd bokstav b (student)",
+    "file": "tests/utenfor-avtaleland/komplett-sak-2-8b-student.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 35872
+   },
+   {
+    "title": "skal fullføre sak med flere land, pensjon-dekning, deretter NV som annulleres",
+    "file": "tests/utenfor-avtaleland/komplett-sak-flere-land-arbeidsinntekt-nyvurdering-annullering.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 55569
+   },
+   {
+    "title": "skal fullføre sak med flere land, ikke-skattepliktig og arbeidsinntekt fra Norge. Så NV med skattepliktig, avregning skal bli riktig",
+    "file": "tests/utenfor-avtaleland/komplett-sak-flere-land-arbeidsinntekt.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 47101
+   },
+   {
+    "title": "skal fullføre komplett saksflyt - delevis skattepliktig - med flere inntektskilder",
+    "file": "tests/utenfor-avtaleland/komplett-sak-flere-land-flereinntektskilder.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 64493
+   },
+   {
+    "title": "skal endre skattestatus fra ikke-skattepliktig til skattepliktig via nyvurdering",
+    "file": "tests/utenfor-avtaleland/nyvurdering-endring-skattestatus.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 59559
+   },
+   {
+    "title": "skal endre skattestatus fra skattepliktig til ikke-skattepliktig via nyvurdering",
+    "file": "tests/utenfor-avtaleland/nyvurdering-endring-skattestatus.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 61861
+   }
+  ]
+ },
+ "fail": {
+  "status": "failed",
+  "duration": 2936867.8449999997,
+  "startTime": "2026-06-20T23:02:29.461Z",
+  "tags": {
+   "melosys-api": "latest",
+   "melosys-web": "latest",
+   "faktureringskomponenten": "latest",
+   "melosys-trygdeavgift-beregning": "latest",
+   "melosys-trygdeavtale": "latest",
+   "melosys-inngangsvilkar": "latest",
+   "melosys-eessi": "latest",
+   "melosys-mock": "latest",
+   "melosys-dokgen": "latest"
+  },
+  "tests": [
+   {
+    "title": "skal opprette og fullføre årsavregning behandling",
+    "file": "tests/aarsavregning/aarsavregning-ftrl.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 28555
+   },
+   {
+    "title": "skal opprette årsavregning for ikke-skattepliktig bruker",
+    "file": "tests/aarsavregning/aarsavregning-ikke-skattepliktig.spec.ts",
+    "status": "flaky",
+    "totalAttempts": 2,
+    "failedAttempts": 1,
+    "duration": 54026
+   },
+   {
+    "title": "skattehendelse uten fullmektig sender innhentingsbrev til bruker",
+    "file": "tests/aarsavregning/aarsavregning-innhentingsbrev-automatisk.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 44534
+   },
+   {
+    "title": "ikke-skattepliktig-jobben uten fullmektig sender innhentingsbrev til bruker",
+    "file": "tests/aarsavregning/aarsavregning-innhentingsbrev-automatisk.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 44585
+   },
+   {
+    "title": "skattehendelse med fullmektig sender innhentingsbrev til fullmektig",
+    "file": "tests/aarsavregning/aarsavregning-innhentingsbrev-automatisk.spec.ts",
+    "status": "skipped",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 0
+   },
+   {
+    "title": "ikke-skattepliktig-jobben med fullmektig sender innhentingsbrev til fullmektig",
+    "file": "tests/aarsavregning/aarsavregning-innhentingsbrev-automatisk.spec.ts",
+    "status": "skipped",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 0
+   },
+   {
+    "title": "skattehendelse for skatteår X gir årsavregningsoppgave med X i beskrivelsen",
+    "file": "tests/aarsavregning/aarsavregning-oppgave-skatteaar-i-beskrivelse-og-nokkelord.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 44653
+   },
+   {
+    "title": "ikke-skattepliktig-jobben for skatteår X gir årsavregningsoppgave med X i beskrivelsen",
+    "file": "tests/aarsavregning/aarsavregning-oppgave-skatteaar-i-beskrivelse-og-nokkelord.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 43870
+   },
+   {
+    "title": "saksbehandlingsflyt som berører tidligere år X gir årsavregningsoppgave med X i beskrivelsen",
+    "file": "tests/aarsavregning/aarsavregning-oppgave-skatteaar-i-beskrivelse-og-nokkelord.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 62734
+   },
+   {
+    "title": "skal fullføre pensjonistbehandling og opprette årsavregning for samme sak",
+    "file": "tests/aarsavregning/eos-pensjonist-aarsavregning-direkte-grunnlag-beregn.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 53657
+   },
+   {
+    "title": "skal fullføre pensjonistbehandling og årsavregning med innbetalt avvik",
+    "file": "tests/aarsavregning/eos-pensjonist-aarsavregning-innbetalt-avvik-beregn.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 73851
+   },
+   {
+    "title": "skal beregne endelig trygdeavgift i uten-grunnlag-flyten (OPPLYSNINGER_ENDRET)",
+    "file": "tests/aarsavregning/eos-pensjonist-aarsavregning-uten-grunnlag.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 49971
+   },
+   {
+    "title": "skal oppgi endelig trygdeavgift manuelt med obligatorisk begrunnelse (MANUELL_ENDELIG_AVGIFT)",
+    "file": "tests/aarsavregning/eos-pensjonist-aarsavregning-uten-grunnlag.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 44689
+   },
+   {
+    "title": "skal automatisk opprette årsavregning etter vedtak på pensjonist-sak",
+    "file": "tests/aarsavregning/ftrl-pensjonist-aarsavregning.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 21844
+   },
+   {
+    "title": "komplett førstegangsbehandling, automatisk opprettet årsavregning, nv annulerer også åpen årsavregning",
+    "file": "tests/aarsavregning/komplett-sak-nyvurdering-annullering-lukker-aapne-aarsavregninger.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 47363
+   },
+   {
+    "title": "skal fullføre sak med flere land, ikke-skattepliktig og arbeidsinntekt fra Norge. Så NV med skattepliktig, avregning skal bli riktig",
+    "file": "tests/aarsavregning/komplett-sak-nyvurdering-periode-endres-til-kun-tidligere-aar.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 63518
+   },
+   {
+    "title": "Scenario 1 — seksjonen vises med 5 år SKATT-rader (seeded)",
+    "file": "tests/aarsavregning/popp-pensjonsopptjening-visning.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 24526
+   },
+   {
+    "title": "Scenario 2 — delt grunnlag: Skatt og Avgiftssystemet samme år (seeded)",
+    "file": "tests/aarsavregning/popp-pensjonsopptjening-visning.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 23987
+   },
+   {
+    "title": "Scenario 3 — alle tre kilder med ulike tidsstempler per kilde (seeded)",
+    "file": "tests/aarsavregning/popp-pensjonsopptjening-visning.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 23453
+   },
+   {
+    "title": "Scenario 4 — ingen pensjonsopptjening: tom-melding vises (seeded tom)",
+    "file": "tests/aarsavregning/popp-pensjonsopptjening-visning.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 22372
+   },
+   {
+    "title": "Scenario 6 — flere inntektTyper per kilde rendres med dekode-beskrivelse",
+    "file": "tests/aarsavregning/popp-pensjonsopptjening-visning.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 23383
+   },
+   {
+    "title": "Scenario 5 — årsavregning eldre enn 5 år: visning utvides til avregningsåret",
+    "file": "tests/aarsavregning/popp-pensjonsopptjening-visning.spec.ts",
+    "status": "skipped",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 0
+   },
+   {
+    "title": "skal vise oppgave-seksjon på forsiden",
+    "file": "tests/core/oppgaver.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 9490
+   },
+   {
+    "title": "skal vise behandling-oppgave etter opprettelse av sak",
+    "file": "tests/core/oppgaver.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 11835
+   },
+   {
+    "title": "skal kunne navigere til behandling fra oppgave",
+    "file": "tests/core/oppgaver.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 12162
+   },
+   {
+    "title": "skal vise oppgave-antall",
+    "file": "tests/core/oppgaver.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 12060
+   },
+   {
+    "title": "skal håndtere tom oppgaveliste",
+    "file": "tests/core/oppgaver.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 9397
+   },
+   {
+    "title": "skal trigge MOTTAK_SED prosess ved mottak av A003",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 8717,
+    "dockerErrors": [
+     {
+      "service": "faktureringskomponenten",
+      "errors": [
+       {
+        "timestamp": "2026-06-20T22:30:01Z",
+        "message": "WARN AuditorAwareFilter: missing Nav-User-Id header"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "title": "skal opprette fagsak ved mottak av A003 fra Sverige",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7372
+   },
+   {
+    "title": "skal håndtere A009 og automatisk registrere unntak fra norsk trygd (REGISTRERT_UNNTAK)",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7902
+   },
+   {
+    "title": "skal håndtere A010 og automatisk registrere unntak fra norsk trygd – øvrige (REGISTRERT_UNNTAK)",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7367
+   },
+   {
+    "title": "skal håndtere A001 søknad fra Danmark",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7313
+   },
+   {
+    "title": "skal håndtere tilpasset SED konfigurasjon",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7327
+   },
+   {
+    "title": "skal verifisere at SED fører til oppgave i systemet",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 9205
+   },
+   {
+    "title": "skal håndtere flere SED-typer i sekvens",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 8302
+   },
+   {
+    "title": "skal verifisere prosessinstanser i databasen",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7308
+   },
+   {
+    "title": "skal trigge MOTTAK_SED via melosys-eessi flow",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7421
+   },
+   {
+    "title": "skal opprette fagsak via full eessi-flow med A003 fra Sverige",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7851
+   },
+   {
+    "title": "skal håndtere A009 informasjonsforespørsel via eessi",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 6826
+   },
+   {
+    "title": "skal sammenligne direkte vs eessi-flow @comparison",
+    "file": "tests/core/sed-mottak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 7816
+   },
+   {
+    "title": "skal søke etter person med gyldig fødselsnummer og finne sak",
+    "file": "tests/core/sok-og-navigasjon.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 11936
+   },
+   {
+    "title": "skal vise ingen resultater for ukjent bruker",
+    "file": "tests/core/sok-og-navigasjon.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 8726
+   },
+   {
+    "title": "skal navigere til sak fra søkeresultat",
+    "file": "tests/core/sok-og-navigasjon.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 11514
+   },
+   {
+    "title": "skal søke etter sak med saksnummer",
+    "file": "tests/core/sok-og-navigasjon.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 11751
+   },
+   {
+    "title": "skal kunne navigere tilbake til forsiden fra søkeresultater",
+    "file": "tests/core/sok-og-navigasjon.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 11703
+   },
+   {
+    "title": "skal produsere korrekt, distinkt vedtaksbrev for FTRL- og trygdeavtale-mottaker",
+    "file": "tests/core/vedtaksbrev-mottakertype.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 57475
+   },
+   {
+    "title": "skal fullføre sak og verifisere at årsavregning ikke kan opprettes",
+    "file": "tests/eu-eos/eu-eos-art11-3b-medlemskap-offentlig-tjenesteperson.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 25343
+   },
+   {
+    "title": "skal iverksette vedtak og verifisere MEDL-periode, A009 SED og utgående journalpost",
+    "file": "tests/eu-eos/eu-eos-art12-iverksetting-mottaker-kjede.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 47113
+   },
+   {
+    "title": "skal forkorte lovvalgsperiode via nyvurdering og overføre ny periode til MEDL",
+    "file": "tests/eu-eos/eu-eos-art12-nyvurdering-medlemskap-overforing.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 88065
+   },
+   {
+    "title": "skal fullføre EU/EØS-arbeidsflyt med vedtak",
+    "file": "tests/eu-eos/eu-eos-art12-utsendt-arbeidstaker-fullfort-vedtak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 46790
+   },
+   {
+    "title": "skal fullføre \"Arbeid i flere land\" arbeidsflyt med vedtak",
+    "file": "tests/eu-eos/eu-eos-art13-arbeid-flere-land-fullfort-vedtak.spec.ts",
+    "status": "failed",
+    "totalAttempts": 3,
+    "failedAttempts": 3,
+    "duration": 26430,
+    "error": "expect(received).toBe(expected)\n\nExpected: 'AVSLUTTET'\nReceived: 'UNDER_BEHANDLING'\n  at verifiserBehandlingSluttilstand (pages/shared/behandling.assertions.ts:142:18)",
+    "dockerErrors": [
+     {
+      "service": "melosys-api",
+      "errors": [
+       {
+        "timestamp": "2026-06-20T22:41:03Z",
+        "message": "ORA-00001: unique constraint (MELOSYS.PK_LOVVALG) violated"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "title": "skal fullføre \"Arbeid i flere land\" med selvstendig næringsvirksomhet og SED-dokument",
+    "file": "tests/eu-eos/eu-eos-art13-arbeid-flere-land-selvstendig-fullfort-vedtak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 36080
+   },
+   {
+    "title": "skal nyvurdere en registrert annet-land-sak og re-registrere unntaket",
+    "file": "tests/eu-eos/eu-eos-inngaaende-a003-annet-land-nyvurdering.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 15680
+   },
+   {
+    "title": "skal godkjenne at et annet land er utpekt og registrere unntak (uten SED)",
+    "file": "tests/eu-eos/eu-eos-inngaaende-a003-annet-land-utpekt-registrert-unntak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 11410
+   },
+   {
+    "title": "skal godkjenne utpeking av Norge og svare utland med A012",
+    "file": "tests/eu-eos/eu-eos-inngaaende-a003-norge-utpekt-a012.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 14046
+   },
+   {
+    "title": "Kosovo statsborgerskap bevart i SED A008",
+    "file": "tests/eu-eos/eu-eos-kosovo-statsborgerskap.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 37519
+   },
+   {
+    "title": "skal annullere sak med sendt vedtak og avvise MEDL-perioden",
+    "file": "tests/eu-eos/eu-eos-nyvurdering-annuller-medlemskap-avvis.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 52163
+   },
+   {
+    "title": "Scenario 1: SED sendes til EESSI-land og papir til Færøyene",
+    "file": "tests/eu-eos/eu-eos-papir-a1-til-ikke-eessi-land.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 37653
+   },
+   {
+    "title": "Scenario 2: SED sendes til EESSI-land og papir til Færøyene og Grønland",
+    "file": "tests/eu-eos/eu-eos-papir-a1-til-ikke-eessi-land.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 38003
+   },
+   {
+    "title": "Scenario 3 (regresjon): Kun EESSI-land — ingen papir-A1 til FO/GL",
+    "file": "tests/eu-eos/eu-eos-papir-a1-til-ikke-eessi-land.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 37582
+   },
+   {
+    "title": "Scenario 4: Kun Færøyene + Grønland — papir-A1 sendes til begge",
+    "file": "tests/eu-eos/eu-eos-papir-a1-til-ikke-eessi-land.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 27954
+   },
+   {
+    "title": "skal vise infomelding når inntekten er under minstebeløpet",
+    "file": "tests/eu-eos/eu-eos-pensjonist-trygdeavgift.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 27450
+   },
+   {
+    "title": "skal vise tabell med asterisk (*) for 25%-regel",
+    "file": "tests/eu-eos/eu-eos-pensjonist-trygdeavgift.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 27237
+   },
+   {
+    "title": "skal vise *** for sammenslåtte inntektskilder",
+    "file": "tests/eu-eos/eu-eos-pensjonist-trygdeavgift.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 28532
+   },
+   {
+    "title": "skal vise tabell ved ordinær beregning",
+    "file": "tests/eu-eos/eu-eos-pensjonist-trygdeavgift.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 27178
+   },
+   {
+    "title": "skal videresende søknad til Sverige",
+    "file": "tests/eu-eos/eu-eos-sed-a008-videresend-soeknad.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 37440
+   },
+   {
+    "title": "skal fullføre EU/EØS-skip-arbeidsflyt med vedtak",
+    "file": "tests/eu-eos/eu-eos-skip-fullfort-vedtak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 28384
+   },
+   {
+    "title": "mottar A002 (innvilgelse) - skal fatte vedtak automatisk",
+    "file": "tests/eu-eos/unntak/eu-eos-anmodning-unntak-nyvurdering-svar.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 34933
+   },
+   {
+    "title": "mottar A011 (avslag) - skal kreve manuell ny vurdering",
+    "file": "tests/eu-eos/unntak/eu-eos-anmodning-unntak-nyvurdering-svar.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 35004
+   },
+   {
+    "title": "direkte til - skal sende anmodning om unntak",
+    "file": "tests/eu-eos/unntak/eu-eos-utsendt-arbeidstaker-anmodning-unntak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 32506
+   },
+   {
+    "title": "direkte til art.13(1)(a) - skal sende anmodning om unntak",
+    "file": "tests/eu-eos/unntak/eu-eos-utsendt-arbeidstaker-anmodning-unntak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 33164
+   },
+   {
+    "title": "direkte til art.13(1)(a) med TWFA - skal sende anmodning om unntak",
+    "file": "tests/eu-eos/unntak/eu-eos-utsendt-arbeidstaker-anmodning-unntak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 32623
+   },
+   {
+    "title": "via full behandling - skal sende anmodning om unntak",
+    "file": "tests/eu-eos/unntak/eu-eos-utsendt-arbeidstaker-anmodning-unntak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 36407
+   },
+   {
+    "title": "direkte til CDM 4.3 - skal sende anmodning om unntak",
+    "file": "tests/eu-eos/unntak/eu-eos-utsendt-arbeidstaker-anmodning-unntak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 32977
+   },
+   {
+    "title": "direkte til art.13(1)(a) CDM 4.3 - skal sende anmodning om unntak",
+    "file": "tests/eu-eos/unntak/eu-eos-utsendt-arbeidstaker-anmodning-unntak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 32475
+   },
+   {
+    "title": "skal opprette manglende-innbetaling-behandling automatisk og fatte opphørsvedtak",
+    "file": "tests/ftrl/ftrl-manglende-innbetaling-opphor.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 48410
+   },
+   {
+    "title": "25%-regelen begrenser avgiften",
+    "file": "tests/ftrl/ftrl-trygdeavgift-25-prosent-regel.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 35426
+   },
+   {
+    "title": "ordinær beregning uten begrensning (80000 kr/md)",
+    "file": "tests/ftrl/ftrl-trygdeavgift-25-prosent-regel.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 35299
+   },
+   {
+    "title": "25%-regelen med Full dekning — pliktig medlem",
+    "file": "tests/ftrl/ftrl-trygdeavgift-25-prosent-regel.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 34298
+   },
+   {
+    "title": "inntekt under minstebeløpet — avgift 0 kr",
+    "file": "tests/ftrl/ftrl-trygdeavgift-25-prosent-regel.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 36027
+   },
+   {
+    "title": "Confluence Eksempel 1 — flere skatteforhold og inntekter, 25%-regel på alle perioder",
+    "file": "tests/ftrl/ftrl-trygdeavgift-25-prosent-regel.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 83209
+   },
+   {
+    "title": "25%-regelen for FTRL Pensjonist",
+    "file": "tests/ftrl/ftrl-trygdeavgift-25-prosent-regel.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 32780
+   },
+   {
+    "title": "skal innvilge pliktig medlemskap § 2-2, fatte vedtak og opprette fakturaserie",
+    "file": "tests/ftrl/ftrl-yrkesaktiv-2-2-forstegang.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 34365
+   },
+   {
+    "title": "skal fullføre trygdeavtale-arbeidsflyt med vedtak",
+    "file": "tests/trygdeavtale/trygdeavtale-fullfort-vedtak.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 27906
+   },
+   {
+    "title": "skal forkorte periode via nyvurdering og erstatte MEDL-perioden in-place",
+    "file": "tests/trygdeavtale/trygdeavtale-nyvurdering.spec.ts",
+    "status": "failed",
+    "totalAttempts": 3,
+    "failedAttempts": 3,
+    "duration": 35282,
+    "error": "TimeoutError: locator.click: Timeout 30000ms exceeded.\nwaiting for getByRole('button', { name: 'Fatt vedtak' })"
+   },
+   {
+    "title": "skal registrere godkjent unntak med endelig MEDL-periode",
+    "file": "tests/trygdeavtale/trygdeavtale-unntaksregistrering.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 23646
+   },
+   {
+    "title": "skal avslutte saken uten lovvalgsperiode ved ikke godkjent unntak",
+    "file": "tests/trygdeavtale/trygdeavtale-unntaksregistrering.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 23474
+   },
+   {
+    "title": "skal fullføre komplett saksflyt med § 2-8 første ledd bokstav a (arbeidstaker)",
+    "file": "tests/utenfor-avtaleland/komplett-sak-2-8a.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 36719
+   },
+   {
+    "title": "FULL_DEKNING_FTRL",
+    "file": "tests/utenfor-avtaleland/komplett-sak-2-8a.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 36954
+   },
+   {
+    "title": "skal fullføre komplett saksflyt med § 2-8 første ledd bokstav b (student)",
+    "file": "tests/utenfor-avtaleland/komplett-sak-2-8b-student.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 35872
+   },
+   {
+    "title": "skal fullføre sak med flere land, pensjon-dekning, deretter NV som annulleres",
+    "file": "tests/utenfor-avtaleland/komplett-sak-flere-land-arbeidsinntekt-nyvurdering-annullering.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 55569
+   },
+   {
+    "title": "skal fullføre sak med flere land, ikke-skattepliktig og arbeidsinntekt fra Norge. Så NV med skattepliktig, avregning skal bli riktig",
+    "file": "tests/utenfor-avtaleland/komplett-sak-flere-land-arbeidsinntekt.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 47101
+   },
+   {
+    "title": "skal fullføre komplett saksflyt - delevis skattepliktig - med flere inntektskilder",
+    "file": "tests/utenfor-avtaleland/komplett-sak-flere-land-flereinntektskilder.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 64493
+   },
+   {
+    "title": "skal endre skattestatus fra ikke-skattepliktig til skattepliktig via nyvurdering",
+    "file": "tests/utenfor-avtaleland/nyvurdering-endring-skattestatus.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 59559
+   },
+   {
+    "title": "skal endre skattestatus fra skattepliktig til ikke-skattepliktig via nyvurdering",
+    "file": "tests/utenfor-avtaleland/nyvurdering-endring-skattestatus.spec.ts",
+    "status": "passed",
+    "totalAttempts": 1,
+    "failedAttempts": 0,
+    "duration": 61861
+   }
+  ]
+ }
+};

--- a/docs/report-ideas/index.html
+++ b/docs/report-ideas/index.html
@@ -67,6 +67,11 @@
     <button data-dataset="green">All green (real)</button>
     <button data-dataset="fail">With failures (simulated)</button>
   </div>
+  <div class="bar">
+    <span class="lbl">Domain mapping</span>
+    <button data-mapping="asis">As-is (ftrl + utenfor-avtaleland)</button>
+    <button data-mapping="consolidated">Consolidated (ftrl → utenfor-avtaleland)</button>
+  </div>
 
   <div class="note" id="note"></div>
 

--- a/docs/report-ideas/index.html
+++ b/docs/report-ideas/index.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>E2E report — layout ideas</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    margin: 0; background: #f6f8fa; color: #1f2328;
+  }
+  .wrap { max-width: 1000px; margin: 0 auto; padding: 24px 16px 80px; }
+  h1 { font-size: 22px; margin: 0 0 4px; }
+  .sub { color: #636c76; margin: 0 0 20px; font-size: 14px; }
+  .bar { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin-bottom: 8px; }
+  .bar .lbl { font-size: 12px; text-transform: uppercase; letter-spacing: .04em; color: #636c76; margin-right: 4px; }
+  button {
+    font: inherit; font-size: 13px; padding: 6px 12px; border: 1px solid #d0d7de;
+    background: #fff; border-radius: 6px; cursor: pointer; color: #1f2328;
+  }
+  button:hover { background: #f3f4f6; }
+  button.active { background: #0969da; border-color: #0969da; color: #fff; }
+  .note {
+    background: #fff8c5; border: 1px solid #d4a72c66; border-radius: 6px;
+    padding: 8px 12px; font-size: 13px; margin: 12px 0; line-height: 1.5;
+  }
+  .note code { background: #eef1f4; padding: 1px 4px; border-radius: 4px; }
+  .gh-label { font-size: 12px; color: #636c76; margin: 18px 0 6px; }
+  /* The frame mimics GitHub's job-summary rendering. Its CSS styles only the
+     container — the inner HTML uses GitHub's allowed tag subset, so layout is faithful. */
+  .gh {
+    background: #fff; border: 1px solid #d0d7de; border-radius: 6px;
+    padding: 16px 24px; font-size: 14px; line-height: 1.6;
+  }
+  .gh h2 { font-size: 20px; border-bottom: 1px solid #d8dee4; padding-bottom: 6px; margin: 18px 0 12px; }
+  .gh h3 { font-size: 16px; margin: 22px 0 10px; }
+  .gh table { border-collapse: collapse; width: 100%; margin: 6px 0 14px; display: block; overflow-x: auto; }
+  .gh th, .gh td { border: 1px solid #d0d7de; padding: 5px 11px; text-align: left; font-size: 13px; }
+  .gh th { background: #f6f8fa; }
+  .gh tr:nth-child(2n) td { background: #f6f8fa44; }
+  .gh code { background: #eff1f3; padding: 1px 5px; border-radius: 5px; font-size: 12px; }
+  .gh sub { color: #636c76; font-size: 11px; vertical-align: baseline; }
+  .gh details { border: 1px solid #d0d7de; border-radius: 6px; padding: 0 12px; margin: 8px 0; background: #fff; }
+  .gh details[open] { padding-bottom: 8px; }
+  .gh summary { cursor: pointer; padding: 8px 0; font-size: 14px; }
+  .gh details table { margin-bottom: 8px; }
+  .gh ul { margin: 4px 0; }
+  footer { margin-top: 28px; font-size: 12px; color: #636c76; line-height: 1.6; }
+  footer code { background: #eaeef2; padding: 1px 5px; border-radius: 4px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>E2E report — layout ideas</h1>
+  <p class="sub">Rendered from the real run <strong>CI 27886483545</strong> (95 tests, 48.9&nbsp;min). The frame below uses only the HTML GitHub job summaries allow — what you see is what the PR summary would show.</p>
+
+  <div class="bar">
+    <span class="lbl">Layout</span>
+    <button data-variant="current">Current</button>
+    <button data-variant="A">A · Domain groups</button>
+    <button data-variant="B">B · Scoreboard</button>
+    <button data-variant="C">C · Flat per-domain</button>
+  </div>
+  <div class="bar">
+    <span class="lbl">Data</span>
+    <button data-dataset="green">All green (real)</button>
+    <button data-dataset="fail">With failures (simulated)</button>
+  </div>
+
+  <div class="note" id="note"></div>
+
+  <div class="gh-label">▼ Preview — GitHub job summary</div>
+  <div class="gh" id="frame"></div>
+
+  <footer>
+    Iterate: edit <code>docs/report-ideas/render.js</code> and refresh — no test run needed.<br>
+    Regenerate data from another run: <code>gh run download &lt;id&gt; -n test-summary</code> then re-run the data step.<br>
+    Once you pick a layout, it ports into <code>lib/summary-generator.ts</code> (covered by <code>npm run test:unit</code>).
+  </footer>
+</div>
+<script src="data.js"></script>
+<script src="render.js"></script>
+</body>
+</html>

--- a/docs/report-ideas/render.js
+++ b/docs/report-ideas/render.js
@@ -1,0 +1,285 @@
+/* ------------------------------------------------------------------ *
+ * E2E report layout ideas — renderers
+ *
+ * Every renderer below emits ONLY the HTML subset that GitHub Actions
+ * job summaries actually allow: <details>/<summary>, <table>, <strong>,
+ * <code>, <br>, <sub>, emoji. No style/class/color/JS. So what you see
+ * in the frame is what you'll get in the real PR job summary.
+ *
+ * The page chrome (tabs, notes) uses normal CSS — that's the doc, not
+ * the report.
+ * ------------------------------------------------------------------ */
+
+// ---- helpers --------------------------------------------------------
+
+function fmtDur(ms) {
+  const s = Math.round(ms / 1000);
+  if (s < 60) return s + 's';
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return r ? `${m}m ${r}s` : `${m}m`;
+}
+
+const EMOJI = {
+  passed: '✅', failed: '❌', flaky: '🔄', skipped: '⏭️',
+  'known-error-failed': '⚠️', 'known-error-passed': '✨',
+};
+const emoji = (s) => EMOJI[s] || '❓';
+
+// tests/eu-eos/unntak/eu-eos-foo.spec.ts -> {domain, sub, base, label}
+function parsePath(file) {
+  const parts = file.split('/');         // ['tests','eu-eos','unntak','eu-eos-foo.spec.ts']
+  const i = parts.indexOf('tests');
+  const after = parts.slice(i + 1);
+  const base = after[after.length - 1];
+  const domain = after[0];
+  const sub = after.slice(1, -1).join('/'); // 'unntak' or ''
+  // strip ".spec.ts" and a redundant leading "<domain>-" so the file label
+  // does not repeat the domain folder name.
+  let label = base.replace(/\.spec\.ts$/, '');
+  if (label.startsWith(domain + '-')) label = label.slice(domain.length + 1);
+  if (sub) label = sub + '/' + label;
+  return { domain, sub, base, label };
+}
+
+function enrich(tests) {
+  return tests.map((t) => ({ ...t, ...parsePath(t.file) }));
+}
+
+// group -> {name, tests, passed, failed, flaky, skipped, dur, hasFail}
+function groupByDomain(tests) {
+  const map = new Map();
+  for (const t of tests) {
+    if (!map.has(t.domain)) map.set(t.domain, []);
+    map.get(t.domain).push(t);
+  }
+  const groups = [...map.entries()].map(([name, ts]) => {
+    const count = (s) => ts.filter((t) => t.status === s).length;
+    const failed = count('failed');
+    const flaky = count('flaky');
+    return {
+      name, tests: ts,
+      passed: count('passed'), failed, flaky, skipped: count('skipped'),
+      dur: ts.reduce((a, t) => a + t.duration, 0),
+      hasFail: failed > 0 || flaky > 0,
+    };
+  });
+  // failing groups first, then alphabetical
+  groups.sort((a, b) => (b.hasFail - a.hasFail) || a.name.localeCompare(b.name));
+  return groups;
+}
+
+function groupByFile(tests) {
+  const map = new Map();
+  for (const t of tests) {
+    if (!map.has(t.label)) map.set(t.label, []);
+    map.get(t.label).push(t);
+  }
+  const files = [...map.entries()].map(([label, ts]) => ({
+    label, tests: ts,
+    dur: ts.reduce((a, t) => a + t.duration, 0),
+    hasFail: ts.some((t) => t.status === 'failed' || t.status === 'flaky'),
+  }));
+  files.sort((a, b) => (b.hasFail - a.hasFail) || a.label.localeCompare(b.label));
+  return files;
+}
+
+function totals(tests) {
+  const c = (s) => tests.filter((t) => t.status === s).length;
+  return {
+    passed: c('passed'), failed: c('failed'), flaky: c('flaky'),
+    skipped: c('skipped'), total: tests.length,
+  };
+}
+
+// Top-of-report banner shared by the idea variants.
+function banner(data, tests) {
+  const t = totals(tests);
+  const ok = t.failed === 0 && t.flaky === 0;
+  const head = ok ? '✅ All green' : `❌ ${t.failed + t.flaky} failing`;
+  const bits = [
+    `${t.passed} passed`,
+    t.failed ? `${t.failed} failed` : null,
+    t.flaky ? `${t.flaky} flaky` : null,
+    t.skipped ? `${t.skipped} skipped` : null,
+  ].filter(Boolean).join(' · ');
+  return `<h2>${head} — ${bits}</h2>\n` +
+         `<p><strong>${t.total} tests</strong> · ⏱️ ${fmtDur(data.duration)} total</p>\n`;
+}
+
+// Flat "needs attention" list, always above the fold, only when red.
+function needsAttention(tests) {
+  const bad = tests.filter((t) => t.status === 'failed' || t.status === 'flaky');
+  if (!bad.length) return '';
+  let h = `<h3>❌ Needs attention (${bad.length})</h3>\n<table>\n<thead><tr><th>Test</th><th>Where</th><th>Why</th><th>⏱️</th></tr></thead>\n<tbody>\n`;
+  for (const t of bad) {
+    const why = t.status === 'flaky'
+      ? `🔄 flaky (${t.failedAttempts}/${t.totalAttempts} failed)`
+      : (t.error ? `<code>${esc(firstLine(t.error))}</code>` : 'failed');
+    h += `<tr><td>${emoji(t.status)} ${esc(t.title)}</td><td><code>${t.domain}/${esc(t.label)}</code></td><td>${why}</td><td>${fmtDur(t.duration)}</td></tr>\n`;
+  }
+  h += '</tbody>\n</table>\n';
+  return h;
+}
+
+function firstLine(s) { return (s || '').split('\n').find((l) => l.trim()) || ''; }
+function esc(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+function dockerBadge(t) {
+  if (!t.dockerErrors || !t.dockerErrors.length) return '';
+  const n = t.dockerErrors.reduce((a, d) => a + d.errors.length, 0);
+  return ` <sub>🐳 ${t.dockerErrors.map((d) => d.service).join(', ')} (${n})</sub>`;
+}
+
+// ====================================================================
+// VARIANT: CURRENT (baseline) — one flat table, folder + file repeated
+// ====================================================================
+function renderCurrent(data) {
+  const tests = enrich(data.tests);
+  const files = [];
+  for (const g of groupByDomain(tests))
+    for (const f of groupByFile(g.tests))
+      files.push({ folder: g.name, ...f });
+  files.sort((a, b) => (b.hasFail - a.hasFail) ||
+    `${a.folder}/${a.label}`.localeCompare(`${b.folder}/${b.label}`));
+
+  let h = banner(data, tests);
+  h += '<h3>📊 Test Results</h3>\n<table>\n<thead><tr><th>Test</th><th>Status</th><th>Attempts</th><th>Docker</th><th>Duration</th></tr></thead>\n<tbody>\n';
+  for (const f of files) {
+    // NOTE: this row repeats the domain in both folder and file — the duplication.
+    const orig = f.tests[0].base; // original filename WITH redundant prefix
+    const failN = f.tests.filter((t) => t.status === 'failed').length;
+    const info = failN ? ` (${failN}/${f.tests.length} failed)` : '';
+    h += `<tr><td colspan="5"><strong>📁 ${f.folder} / <code>${orig}</code>${info}</strong></td></tr>\n`;
+    for (const t of f.tests) {
+      const att = t.totalAttempts > 1 ? `${t.totalAttempts} (${t.failedAttempts} failed)` : '1';
+      const dck = t.dockerErrors ? '⚠️ ' + t.dockerErrors.map((d) => d.service).join(', ') : '✅';
+      h += `<tr><td>${esc(t.title)}</td><td>${emoji(t.status)}</td><td>${att}</td><td>${dck}</td><td>${fmtDur(t.duration)}</td></tr>\n`;
+    }
+  }
+  h += '</tbody>\n</table>\n';
+  return h;
+}
+
+// ====================================================================
+// VARIANT A: Domain groups · collapsible · duration rollup  (RECOMMENDED)
+//  - failures hoisted into a panel on top
+//  - one <details> per DOMAIN (failing = open, passing = collapsed)
+//  - summary line carries counts + summed duration
+//  - file labels de-duplicated (domain prefix stripped)
+// ====================================================================
+function renderA(data) {
+  const tests = enrich(data.tests);
+  let h = banner(data, tests);
+  h += needsAttention(tests);
+  h += '<h3>📊 By domain</h3>\n';
+  for (const g of groupByDomain(tests)) {
+    const open = g.hasFail ? ' open' : '';
+    const counts = [
+      `${g.passed} ✅`,
+      g.failed ? `${g.failed} ❌` : null,
+      g.flaky ? `${g.flaky} 🔄` : null,
+      g.skipped ? `${g.skipped} ⏭️` : null,
+    ].filter(Boolean).join(' · ');
+    const ico = g.hasFail ? '❌' : '✅';
+    h += `<details${open}>\n<summary>${ico} <strong>${g.name}</strong> — ${counts} · ⏱️ ${fmtDur(g.dur)}</summary>\n\n`;
+    h += '<table>\n<thead><tr><th>Test</th><th></th><th>⏱️</th></tr></thead>\n<tbody>\n';
+    for (const f of groupByFile(g.tests)) {
+      h += `<tr><td colspan="3"><sub>📄 ${esc(f.label)} · ${fmtDur(f.dur)}</sub></td></tr>\n`;
+      for (const t of f.tests) {
+        const att = t.totalAttempts > 1 ? ` <sub>(${t.failedAttempts}/${t.totalAttempts} failed)</sub>` : '';
+        h += `<tr><td>${esc(t.title)}${att}${dockerBadge(t)}</td><td>${emoji(t.status)}</td><td>${fmtDur(t.duration)}</td></tr>\n`;
+      }
+    }
+    h += '</tbody>\n</table>\n</details>\n\n';
+  }
+  return h;
+}
+
+// ====================================================================
+// VARIANT B: Scoreboard first · detail on demand
+//  - one compact rollup table: a row per domain (counts + duration)
+//  - the green case stays TINY; click a domain to expand its tests
+// ====================================================================
+function renderB(data) {
+  const tests = enrich(data.tests);
+  let h = banner(data, tests);
+  h += needsAttention(tests);
+  const groups = groupByDomain(tests);
+  h += '<h3>📊 Scoreboard</h3>\n<table>\n<thead><tr><th>Domain</th><th>✅</th><th>❌</th><th>🔄</th><th>⏭️</th><th>⏱️</th></tr></thead>\n<tbody>\n';
+  for (const g of groups) {
+    const ico = g.hasFail ? '❌' : '✅';
+    h += `<tr><td>${ico} <strong>${g.name}</strong></td><td>${g.passed}</td><td>${g.failed || ''}</td><td>${g.flaky || ''}</td><td>${g.skipped || ''}</td><td>${fmtDur(g.dur)}</td></tr>\n`;
+  }
+  const t = totals(tests);
+  h += `<tr><td><strong>Total</strong></td><td>${t.passed}</td><td>${t.failed || ''}</td><td>${t.flaky || ''}</td><td>${t.skipped || ''}</td><td><strong>${fmtDur(data.duration)}</strong></td></tr>\n`;
+  h += '</tbody>\n</table>\n\n<h3>📂 Details</h3>\n';
+  for (const g of groups) {
+    const open = g.hasFail ? ' open' : '';
+    h += `<details${open}>\n<summary>${g.hasFail ? '❌' : '✅'} <strong>${g.name}</strong> · ⏱️ ${fmtDur(g.dur)}</summary>\n\n<ul>\n`;
+    for (const f of groupByFile(g.tests)) {
+      h += `<li><strong>${esc(f.label)}</strong> <sub>${fmtDur(f.dur)}</sub><ul>\n`;
+      for (const t2 of f.tests)
+        h += `<li>${emoji(t2.status)} ${esc(t2.title)} <sub>${fmtDur(t2.duration)}</sub>${dockerBadge(t2)}</li>\n`;
+      h += '</ul></li>\n';
+    }
+    h += '</ul>\n</details>\n\n';
+  }
+  return h;
+}
+
+// ====================================================================
+// VARIANT C: Flat per-domain · no file layer
+//  - drops the file grouping entirely (titles already describe the case)
+//  - file shown only as a dim suffix → zero folder/file duplication
+// ====================================================================
+function renderC(data) {
+  const tests = enrich(data.tests);
+  let h = banner(data, tests);
+  h += needsAttention(tests);
+  h += '<h3>📊 By domain</h3>\n';
+  for (const g of groupByDomain(tests)) {
+    const open = g.hasFail ? ' open' : '';
+    const counts = `${g.passed}/${g.tests.length} ✅`;
+    h += `<details${open}>\n<summary>${g.hasFail ? '❌' : '✅'} <strong>${g.name}</strong> — ${counts} · ⏱️ ${fmtDur(g.dur)}</summary>\n\n`;
+    const sorted = [...g.tests].sort((a, b) =>
+      ((b.status !== 'passed') - (a.status !== 'passed')) || b.duration - a.duration);
+    h += '<table>\n<tbody>\n';
+    for (const t of sorted)
+      h += `<tr><td>${emoji(t.status)}</td><td>${esc(t.title)} <sub>${esc(t.label)}</sub>${dockerBadge(t)}</td><td>${fmtDur(t.duration)}</td></tr>\n`;
+    h += '</tbody>\n</table>\n</details>\n\n';
+  }
+  return h;
+}
+
+// ---- wiring ---------------------------------------------------------
+
+const VARIANTS = {
+  current: { fn: renderCurrent, name: 'Current (baseline)', note: 'Today’s report: one flat table, the domain repeated in folder <em>and</em> filename, no collapsing, no per-group duration.' },
+  A: { fn: renderA, name: 'A · Domain groups + rollup', note: '<strong>Recommended.</strong> Failures hoisted to a top panel; one collapsible <code>&lt;details&gt;</code> per domain (failing open, passing collapsed); summary line shows counts + summed duration; file labels de-duplicated.' },
+  B: { fn: renderB, name: 'B · Scoreboard first', note: 'A one-row-per-domain scoreboard (counts + duration) up top — the all-green case stays tiny. Tests live in collapsed lists below.' },
+  C: { fn: renderC, name: 'C · Flat per-domain', note: 'Drops the file grouping entirely — test titles already describe the case; the file is a dim suffix. Zero folder/file duplication.' },
+};
+
+let state = { variant: 'A', dataset: 'green' };
+
+function render() {
+  const data = window.DATASETS[state.dataset];
+  const v = VARIANTS[state.variant];
+  document.getElementById('note').innerHTML = v.note;
+  document.getElementById('frame').innerHTML = v.fn(data);
+  document.querySelectorAll('[data-variant]').forEach((b) =>
+    b.classList.toggle('active', b.dataset.variant === state.variant));
+  document.querySelectorAll('[data-dataset]').forEach((b) =>
+    b.classList.toggle('active', b.dataset.dataset === state.dataset));
+}
+
+document.addEventListener('click', (e) => {
+  const vb = e.target.closest('[data-variant]');
+  const db = e.target.closest('[data-dataset]');
+  if (vb) { state.variant = vb.dataset.variant; render(); }
+  if (db) { state.dataset = db.dataset.dataset; render(); }
+});
+
+document.addEventListener('DOMContentLoaded', render);

--- a/docs/report-ideas/render.js
+++ b/docs/report-ideas/render.js
@@ -26,20 +26,28 @@ const EMOJI = {
 };
 const emoji = (s) => EMOJI[s] || '❓';
 
+// Domain consolidation preview (no files are moved — this only re-groups for
+// the report). Verified faglig: "ftrl" == sakstema "Utenfor avtaleland (ftrl)".
+// Set by render() from the "Domain mapping" toggle.
+let DOMAIN_ALIAS = {};
+const CONSOLIDATE = { ftrl: 'utenfor-avtaleland' };
+
 // tests/eu-eos/unntak/eu-eos-foo.spec.ts -> {domain, sub, base, label}
 function parsePath(file) {
   const parts = file.split('/');         // ['tests','eu-eos','unntak','eu-eos-foo.spec.ts']
   const i = parts.indexOf('tests');
   const after = parts.slice(i + 1);
   const base = after[after.length - 1];
-  const domain = after[0];
+  const rawDomain = after[0];
+  const domain = DOMAIN_ALIAS[rawDomain] || rawDomain; // consolidation preview
   const sub = after.slice(1, -1).join('/'); // 'unntak' or ''
   // strip ".spec.ts" and a redundant leading "<domain>-" so the file label
-  // does not repeat the domain folder name.
+  // does not repeat the domain folder name. Uses the (consolidated) domain, so
+  // a moved "ftrl-…" file keeps its prefix under utenfor-avtaleland.
   let label = base.replace(/\.spec\.ts$/, '');
   if (label.startsWith(domain + '-')) label = label.slice(domain.length + 1);
   if (sub) label = sub + '/' + label;
-  return { domain, sub, base, label };
+  return { domain, rawDomain, sub, base, label };
 }
 
 function enrich(tests) {
@@ -262,24 +270,32 @@ const VARIANTS = {
   C: { fn: renderC, name: 'C · Flat per-domain', note: 'Drops the file grouping entirely — test titles already describe the case; the file is a dim suffix. Zero folder/file duplication.' },
 };
 
-let state = { variant: 'A', dataset: 'green' };
+let state = { variant: 'A', dataset: 'green', mapping: 'asis' };
 
 function render() {
+  DOMAIN_ALIAS = state.mapping === 'consolidated' ? CONSOLIDATE : {};
   const data = window.DATASETS[state.dataset];
   const v = VARIANTS[state.variant];
-  document.getElementById('note').innerHTML = v.note;
+  const consolidatedNote = state.mapping === 'consolidated'
+    ? ' <strong>· Consolidation ON:</strong> <code>ftrl</code> folded into <code>utenfor-avtaleland</code> (sakstema «Utenfor avtaleland (ftrl)»). No files moved — grouping preview only.'
+    : '';
+  document.getElementById('note').innerHTML = v.note + consolidatedNote;
   document.getElementById('frame').innerHTML = v.fn(data);
   document.querySelectorAll('[data-variant]').forEach((b) =>
     b.classList.toggle('active', b.dataset.variant === state.variant));
   document.querySelectorAll('[data-dataset]').forEach((b) =>
     b.classList.toggle('active', b.dataset.dataset === state.dataset));
+  document.querySelectorAll('[data-mapping]').forEach((b) =>
+    b.classList.toggle('active', b.dataset.mapping === state.mapping));
 }
 
 document.addEventListener('click', (e) => {
   const vb = e.target.closest('[data-variant]');
   const db = e.target.closest('[data-dataset]');
+  const mb = e.target.closest('[data-mapping]');
   if (vb) { state.variant = vb.dataset.variant; render(); }
   if (db) { state.dataset = db.dataset.dataset; render(); }
+  if (mb) { state.mapping = mb.dataset.mapping; render(); }
 });
 
 document.addEventListener('DOMContentLoaded', render);

--- a/lib/summary-generator.test.ts
+++ b/lib/summary-generator.test.ts
@@ -360,7 +360,7 @@ describe('Summary Generator', () => {
       const result = generateMarkdownSummary(data);
 
       assert(result.includes('**Docker Log Errors:**'));
-      assert(result.includes('🐳 **melosys-api** (2 error(s))'));
+      assert(result.includes('🐳 <strong>melosys-api</strong> (2 error(s))'));
       assert(result.includes('SQL Error: ORA-00001'));
     });
 
@@ -389,9 +389,9 @@ describe('Summary Generator', () => {
       const result = generateMarkdownSummary(data);
 
       assert(result.includes('## 🐳 Docker Log Errors by Service'));
-      // New format: shows errors as header with actual error messages
-      assert(result.includes('### melosys-api: 2 error(s)'));
-      assert(result.includes('### melosys-web: 1 error(s)'));
+      // Rendered as collapsible <details> per service with the error messages inside
+      assert(result.includes('<strong>melosys-api</strong>: 2 error(s)'));
+      assert(result.includes('<strong>melosys-web</strong>: 1 error(s)'));
       // Should show actual error messages
       assert(result.includes('error1'));
       assert(result.includes('error2'));
@@ -426,9 +426,9 @@ describe('Summary Generator', () => {
 
   });
 
-  describe('Folder Grouping', () => {
+  describe('Domain Grouping', () => {
 
-    test('should group tests by folder and file', () => {
+    test('should group tests into collapsible domain sections with file sub-headers', () => {
       const data: TestSummaryData = {
         status: 'passed',
         duration: 10000,
@@ -450,11 +450,34 @@ describe('Summary Generator', () => {
 
       const result = generateMarkdownSummary(data);
 
-      assert(result.includes('📁 eu-eos / <code>scenario1.spec.ts</code>'));
-      assert(result.includes('📁 trygdeavgift / <code>calculation.spec.ts</code>'));
+      // Collapsible domain sections (all-pass domains are collapsed)
+      assert(result.includes('<summary>✅ <strong>eu-eos</strong>'));
+      assert(result.includes('<summary>✅ <strong>trygdeavgift</strong>'));
+      // File sub-header rows inside the domain table
+      assert(result.includes('📄 scenario1'));
+      assert(result.includes('📄 calculation'));
     });
 
-    test('should sort files with failures first', () => {
+    test('should strip the redundant domain prefix from file labels', () => {
+      const data: TestSummaryData = {
+        status: 'passed',
+        duration: 10000,
+        tests: [
+          createTest({
+            title: 'test1',
+            file: 'tests/eu-eos/eu-eos-art13-arbeid-flere-land.spec.ts'
+          }),
+        ]
+      };
+
+      const result = generateMarkdownSummary(data);
+
+      // The "eu-eos-" prefix and ".spec.ts" are stripped so the domain isn't repeated
+      assert(result.includes('📄 art13-arbeid-flere-land'));
+      assert(!result.includes('eu-eos-art13'));
+    });
+
+    test('should sort failing domains first and expand them', () => {
       const data: TestSummaryData = {
         status: 'failed',
         duration: 10000,
@@ -474,12 +497,57 @@ describe('Summary Generator', () => {
 
       const result = generateMarkdownSummary(data);
 
-      // zzz/fail.spec.ts should appear before aaa/pass.spec.ts
-      // even though 'aaa' comes before 'zzz' alphabetically
-      const zzzIndex = result.indexOf('zzz / <code>fail.spec.ts</code>');
-      const aaaIndex = result.indexOf('aaa / <code>pass.spec.ts</code>');
+      // Failing domain 'zzz' should appear before passing 'aaa', despite alpha order
+      const zzzIndex = result.indexOf('<strong>zzz</strong>');
+      const aaaIndex = result.indexOf('<strong>aaa</strong>');
 
+      assert(zzzIndex !== -1 && aaaIndex !== -1);
       assert(zzzIndex < aaaIndex);
+      // Failing domain is expanded, passing domain stays collapsed
+      assert(result.includes('<details open>\n<summary>❌ <strong>zzz</strong>'));
+      assert(result.includes('<details>\n<summary>✅ <strong>aaa</strong>'));
+    });
+
+    test('should hoist failures into a Needs Attention panel above the table', () => {
+      const data: TestSummaryData = {
+        status: 'failed',
+        duration: 10000,
+        tests: [
+          createTest({
+            title: 'broken scenario',
+            file: 'tests/eu-eos/eu-eos-foo.spec.ts',
+            status: 'failed',
+            error: "expect(received).toBe(expected)\nExpected: 'AVSLUTTET'"
+          }),
+        ]
+      };
+
+      const result = generateMarkdownSummary(data);
+
+      assert(result.includes('## ❗ Needs Attention (1)'));
+      assert(result.includes('<code>eu-eos/foo</code>')); // de-duplicated location
+      // Panel appears before the per-domain table
+      assert(result.indexOf('## ❗ Needs Attention') < result.indexOf('## 📊 Test Results'));
+    });
+
+  });
+
+  describe('Duration Rollup', () => {
+
+    test('should sum and format duration per domain group', () => {
+      const data: TestSummaryData = {
+        status: 'passed',
+        duration: 250000,
+        tests: [
+          createTest({ title: 't1', file: 'tests/eu-eos/a.spec.ts', duration: 90000 }),
+          createTest({ title: 't2', file: 'tests/eu-eos/b.spec.ts', duration: 160000 }),
+        ]
+      };
+
+      const result = generateMarkdownSummary(data);
+
+      // 90s + 160s = 250s = 4m 10s rolled up onto the domain summary line
+      assert(result.includes('⏱️ 4m 10s</summary>'));
     });
 
   });

--- a/lib/summary-generator.ts
+++ b/lib/summary-generator.ts
@@ -134,7 +134,7 @@ export function generateMarkdownSummary(
     md += `- **Total Attempts:** ${totalAttempts} (including ${extraAttempts} retries)\n`;
   }
 
-  md += `- **Duration:** ${Math.round(data.duration / 1000)}s\n`;
+  md += `- **Duration:** ${formatDuration(data.duration)}\n`;
   md += `- **Status:** ${ciStatus}\n\n`;
 
   if (knownErrorFailed + knownErrorPassed > 0) {
@@ -145,7 +145,10 @@ export function generateMarkdownSummary(
     md += `> ⚠️ **Retries disabled:** ${flaky} flaky test(s) are treated as failures.\n\n`;
   }
 
-  // Test results table
+  // Needs-attention panel: hoist failures + flaky to the very top
+  md += generateNeedsAttentionPanel(tests);
+
+  // Test results table (grouped by domain, collapsible, with duration rollup)
   if (totalTests > 0) {
     md += generateTestResultsTable(tests);
   }
@@ -196,85 +199,201 @@ export function generateMarkdownSummary(
 }
 
 /**
- * Generate the test results table
+ * Format a millisecond duration as a compact human string ("8s", "4m 12s").
  */
-function generateTestResultsTable(tests: TestData[]): string {
-  let md = `## 📊 Test Results\n\n`;
+function formatDuration(ms: number): string {
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return r ? `${m}m ${r}s` : `${m}m`;
+}
 
-  // Group by folder and file
-  const byFolder = groupTestsByFolder(tests);
+/** First non-blank line of a (possibly multi-line) string. */
+function firstLine(text: string): string {
+  return (text || '').split('\n').map(l => l.trim()).find(Boolean) || '';
+}
 
-  // HTML table with proper colspan
-  md += '<table>\n';
-  md += '<thead>\n';
-  md += '<tr>\n';
-  md += '<th>Test</th>\n';
-  md += '<th>Status</th>\n';
-  md += '<th>Attempts</th>\n';
-  md += '<th>Playwright</th>\n';
-  md += '<th>Docker Logs</th>\n';
-  md += '<th>Duration</th>\n';
-  md += '</tr>\n';
-  md += '</thead>\n';
-  md += '<tbody>\n';
+/** Light escape so error snippets can't break the surrounding HTML table. */
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
 
-  // Flatten all files with their folder info
-  interface FileWithFolder {
-    folderName: string;
-    fileName: string;
-    tests: TestData[];
+interface ParsedTestPath {
+  domain: string;  // top-level folder under tests/ (e.g. "eu-eos")
+  sub: string;     // any nested folders (e.g. "unntak")
+  base: string;    // raw filename (e.g. "eu-eos-art13-...spec.ts")
+  label: string;   // de-duplicated label (domain prefix + .spec.ts stripped)
+}
+
+/**
+ * Parse a test file path into domain / file label, stripping the redundant
+ * leading "<domain>-" so file labels don't repeat the folder name.
+ */
+function parseTestPath(file: string): ParsedTestPath {
+  const parts = file.split('/');
+  const i = parts.indexOf('tests');
+  const after = i !== -1 ? parts.slice(i + 1) : parts.slice(-1);
+  const base = after[after.length - 1];
+  const domain = after.length > 1 ? after[0] : 'root';
+  const sub = after.length > 2 ? after.slice(1, -1).join('/') : '';
+
+  let label = base.replace(/\.spec\.ts$/, '');
+  if (domain !== 'root' && label.startsWith(`${domain}-`)) {
+    label = label.slice(domain.length + 1);
+  }
+  if (sub) label = `${sub}/${label}`;
+  return { domain, sub, base, label };
+}
+
+interface DomainGroup {
+  name: string;
+  tests: TestData[];
+  passed: number;
+  failed: number;
+  flaky: number;
+  skipped: number;
+  knownErrorFailed: number;
+  knownErrorPassed: number;
+  duration: number;
+  hasFail: boolean;
+}
+
+/** Group tests by top-level domain folder; failing domains sort first. */
+function groupTestsByDomain(tests: TestData[]): DomainGroup[] {
+  const map = new Map<string, TestData[]>();
+  for (const t of tests) {
+    const { domain } = parseTestPath(t.file);
+    if (!map.has(domain)) map.set(domain, []);
+    map.get(domain)!.push(t);
   }
 
-  const allFiles: FileWithFolder[] = [];
-  byFolder.forEach((files, folderName) => {
-    files.forEach((tests, fileName) => {
-      allFiles.push({ folderName, fileName, tests });
-    });
+  const groups: DomainGroup[] = Array.from(map.entries()).map(([name, ts]) => {
+    const count = (s: TestData['status']) => ts.filter(t => t.status === s).length;
+    const failed = count('failed');
+    const flaky = count('flaky');
+    return {
+      name,
+      tests: ts,
+      passed: count('passed'),
+      failed,
+      flaky,
+      skipped: count('skipped'),
+      knownErrorFailed: count('known-error-failed'),
+      knownErrorPassed: count('known-error-passed'),
+      duration: ts.reduce((sum, t) => sum + t.duration, 0),
+      hasFail: failed > 0 || flaky > 0,
+    };
   });
 
-  // Sort ALL files: files with failures first, then alphabetically
-  const sortedAllFiles = allFiles.sort((a, b) => {
-    const aHasFailures = a.tests.some(test => test.status === 'failed');
-    const bHasFailures = b.tests.some(test => test.status === 'failed');
+  groups.sort((a, b) =>
+    (Number(b.hasFail) - Number(a.hasFail)) || a.name.localeCompare(b.name));
+  return groups;
+}
 
-    if (aHasFailures && !bHasFailures) return -1;
-    if (!aHasFailures && bHasFailures) return 1;
-    return `${a.folderName}/${a.fileName}`.localeCompare(`${b.folderName}/${b.fileName}`);
-  });
+interface FileGroup {
+  label: string;
+  tests: TestData[];
+  duration: number;
+  hasFail: boolean;
+}
 
-  for (const { folderName, fileName, tests: fileTests } of sortedAllFiles) {
-    // Sort tests: failed first, then passed
-    const sortedTests = fileTests.sort((a, b) => {
-      if (a.status === 'failed' && b.status !== 'failed') return -1;
-      if (a.status !== 'failed' && b.status === 'failed') return 1;
-      return 0;
-    });
+/** Group a domain's tests by file label; failing files (and tests) sort first. */
+function groupTestsByFile(tests: TestData[]): FileGroup[] {
+  const map = new Map<string, TestData[]>();
+  for (const t of tests) {
+    const { label } = parseTestPath(t.file);
+    if (!map.has(label)) map.set(label, []);
+    map.get(label)!.push(t);
+  }
 
-    // Count failures
-    const failedCount = fileTests.filter(t => t.status === 'failed').length;
-    const totalCount = fileTests.length;
-    const failureInfo = failedCount > 0 ? ` (${failedCount}/${totalCount} failed)` : '';
+  const files: FileGroup[] = Array.from(map.entries()).map(([label, ts]) => ({
+    label,
+    tests: ts,
+    duration: ts.reduce((sum, t) => sum + t.duration, 0),
+    hasFail: ts.some(t => t.status === 'failed' || t.status === 'flaky'),
+  }));
 
-    // Folder/File header row (TRUE colspan spanning all 6 columns)
-    md += '<tr>\n';
-    md += `<td colspan="6"><strong>📁 ${folderName} / <code>${fileName}</code>${failureInfo}</strong></td>\n`;
-    md += '</tr>\n';
+  const isBad = (t: TestData) => t.status === 'failed' || t.status === 'flaky';
+  for (const f of files) {
+    f.tests.sort((a, b) => Number(isBad(b)) - Number(isBad(a)));
+  }
+  files.sort((a, b) =>
+    (Number(b.hasFail) - Number(a.hasFail)) || a.label.localeCompare(b.label));
+  return files;
+}
 
-    // Test rows
-    for (const testInfo of sortedTests) {
-      md += generateTestRow(testInfo);
+/**
+ * Needs-attention panel: a compact list of failed/flaky tests hoisted above
+ * the per-domain table, so problems are the first thing you read.
+ */
+function generateNeedsAttentionPanel(tests: TestData[]): string {
+  const bad = tests.filter(t => t.status === 'failed' || t.status === 'flaky');
+  if (bad.length === 0) return '';
+
+  let md = `## ❗ Needs Attention (${bad.length})\n\n`;
+  md += '<table>\n<thead>\n<tr><th>Test</th><th>Where</th><th>Why</th><th>Duration</th></tr>\n</thead>\n<tbody>\n';
+  for (const t of bad) {
+    const { domain, label } = parseTestPath(t.file);
+    let why: string;
+    if (t.status === 'flaky') {
+      why = `🔄 flaky (${t.failedAttempts}/${t.totalAttempts} failed)`;
+    } else if (t.error) {
+      why = `<code>${escapeHtml(firstLine(cleanAnsiCodes(t.error)).slice(0, 140))}</code>`;
+    } else {
+      why = 'failed';
     }
+    md += `<tr><td>${getStatusEmoji(t.status)} ${t.title}</td><td><code>${domain}/${label}</code></td><td>${why}</td><td>${formatDuration(t.duration)}</td></tr>\n`;
   }
-
-  md += '</tbody>\n';
-  md += '</table>\n\n';
-  md += '\n';
-
+  md += '</tbody>\n</table>\n\n';
   return md;
 }
 
 /**
- * Generate a single test row for the table
+ * Generate the test results table: one collapsible <details> per domain,
+ * failing domains expanded and first, each summary carrying counts and a
+ * summed duration.
+ */
+function generateTestResultsTable(tests: TestData[]): string {
+  let md = `## 📊 Test Results\n\n`;
+  for (const group of groupTestsByDomain(tests)) {
+    md += generateDomainGroup(group);
+  }
+  return md;
+}
+
+/** Render one domain as a collapsible section with a per-file/per-test table. */
+function generateDomainGroup(group: DomainGroup): string {
+  const open = group.hasFail ? ' open' : '';
+  const icon = group.hasFail ? '❌' : '✅';
+
+  const counts = [
+    group.passed ? `${group.passed} ✅` : null,
+    group.failed ? `${group.failed} ❌` : null,
+    group.flaky ? `${group.flaky} 🔄` : null,
+    group.knownErrorFailed ? `${group.knownErrorFailed} ⚠️` : null,
+    group.knownErrorPassed ? `${group.knownErrorPassed} ✨` : null,
+    group.skipped ? `${group.skipped} ⏭️` : null,
+  ].filter(Boolean).join(' · ');
+
+  let md = `<details${open}>\n`;
+  md += `<summary>${icon} <strong>${group.name}</strong> — ${counts} · ⏱️ ${formatDuration(group.duration)}</summary>\n\n`;
+  md += '<table>\n<thead>\n<tr><th>Test</th><th>Status</th><th>Attempts</th><th>Duration</th></tr>\n</thead>\n<tbody>\n';
+
+  for (const file of groupTestsByFile(group.tests)) {
+    md += `<tr><td colspan="4"><sub>📄 ${file.label} · ${formatDuration(file.duration)}</sub></td></tr>\n`;
+    for (const testInfo of file.tests) {
+      md += generateTestRow(testInfo);
+    }
+  }
+
+  md += '</tbody>\n</table>\n</details>\n\n';
+  return md;
+}
+
+/**
+ * Generate a single test row. Docker log issues are shown as an inline badge
+ * under the title rather than a dedicated column.
  */
 function generateTestRow(testInfo: TestData): string {
   const statusEmoji = getStatusEmoji(testInfo.status);
@@ -283,30 +402,19 @@ function generateTestRow(testInfo: TestData): string {
     ? `${testInfo.totalAttempts} (${testInfo.failedAttempts} failed)`
     : '1';
 
-  const duration = Math.round(testInfo.duration / 1000) + 's';
+  const duration = formatDuration(testInfo.duration);
 
-  // Playwright status (check if error is playwright-related vs process/docker)
-  let playwrightStatus = '✅';
-  if (testInfo.status === 'failed' || testInfo.status === 'known-error-failed') {
-    const hasPlaywrightError = testInfo.error &&
-      !testInfo.error.includes('Docker error') &&
-      !testInfo.error.includes('process instance');
-    playwrightStatus = hasPlaywrightError ? '❌' : '✅';
-  }
-
-  // Docker logs status - show errors regardless of test status (flaky tests can have errors too)
-  let dockerStatus = '✅';
+  let dockerBadge = '';
   if (testInfo.dockerErrors && testInfo.dockerErrors.length > 0) {
-    const services = testInfo.dockerErrors.map(de => `${de.service} (${de.errors.length})`).join(', ');
-    dockerStatus = `⚠️ ${services}`;
+    const n = testInfo.dockerErrors.reduce((sum, de) => sum + de.errors.length, 0);
+    const services = testInfo.dockerErrors.map(de => de.service).join(', ');
+    dockerBadge = ` <sub>🐳 ${services} (${n})</sub>`;
   }
 
   let row = '<tr>\n';
-  row += `<td>${testInfo.title}</td>\n`;
+  row += `<td>${testInfo.title}${dockerBadge}</td>\n`;
   row += `<td>${statusEmoji}</td>\n`;
   row += `<td>${attempts}</td>\n`;
-  row += `<td>${playwrightStatus}</td>\n`;
-  row += `<td>${dockerStatus}</td>\n`;
   row += `<td>${duration}</td>\n`;
   row += '</tr>\n';
 
@@ -326,42 +434,6 @@ function getStatusEmoji(status: TestData['status']): string {
     case 'skipped': return '⏭️';
     default: return '❓';
   }
-}
-
-/**
- * Group tests by folder and file
- */
-function groupTestsByFolder(tests: TestData[]): Map<string, Map<string, TestData[]>> {
-  const byFolder = new Map<string, Map<string, TestData[]>>();
-
-  for (const test of tests) {
-    const filePath = test.file;
-    const parts = filePath.split('/');
-    const fileName = parts[parts.length - 1];
-
-    // Find "tests" directory index and extract complete path after it
-    const testsIndex = parts.indexOf('tests');
-    let folderPath = 'root';
-
-    if (testsIndex !== -1 && testsIndex < parts.length - 1) {
-      // Get all folders between 'tests' and the filename
-      const foldersAfterTests = parts.slice(testsIndex + 1, parts.length - 1);
-      folderPath = foldersAfterTests.length > 0 ? foldersAfterTests.join('/') : 'root';
-    }
-
-    if (!byFolder.has(folderPath)) {
-      byFolder.set(folderPath, new Map());
-    }
-
-    const folder = byFolder.get(folderPath)!;
-    if (!folder.has(fileName)) {
-      folder.set(fileName, []);
-    }
-
-    folder.get(fileName)!.push(test);
-  }
-
-  return byFolder;
 }
 
 /**

--- a/reporters/README.md
+++ b/reporters/README.md
@@ -248,124 +248,81 @@ const failureInfo = failedCount > 0 ? ` (${failedCount}/${totalCount} failed)` :
 3. Check `playwright-report/test-summary.md`
 4. Verify format in GitHub Actions
 
-## Example Output
+## Report Layout (current: "domain groups")
+
+> **Source of truth:** all summary markdown is produced by `lib/summary-generator.ts`
+> (shared by this reporter and `scripts/generate-summary-from-json.ts`). The
+> line numbers in older sections of this README are historical — edit the named
+> functions in that module instead.
+>
+> Prototype alternative layouts in `docs/report-ideas/index.html` (renders a real
+> run in several candidate layouts using only the HTML GitHub job summaries allow).
+
+The `## 📊 Test Results` section renders **one collapsible `<details>` per
+top-level domain folder** (e.g. `eu-eos`, `aarsavregning`), not one flat table:
+
+- **Failures on top, twice over** — a compact `## ❗ Needs Attention` panel lists
+  every failed/flaky test above the table; failing domains then sort first and
+  render **expanded** (`<details open>`), while all-green domains stay collapsed.
+- **Duration rollup** — each domain (and each file sub-header) shows its summed
+  duration in its summary line.
+- **No folder/file duplication** — file labels strip the redundant `<domain>-`
+  prefix and `.spec.ts` (so `eu-eos/eu-eos-art13-….spec.ts` → `📄 art13-…`).
+
+### Example Output
 
 ```html
+## ❗ Needs Attention (1)
 <table>
-<thead>
-<tr>
-<th>Test</th>
-<th>Status</th>
-<th>Attempts</th>
-<th>Playwright</th>
-<th>Docker Logs</th>
-<th>Duration</th>
-</tr>
-</thead>
+<thead><tr><th>Test</th><th>Where</th><th>Why</th><th>Duration</th></tr></thead>
 <tbody>
-<!-- File with failures appears FIRST -->
-<tr>
-<td colspan="6"><strong>📁 workflows / <code>komplett-sak-2-8a.spec.ts</code> (2/2 failed)</strong></td>
-</tr>
-<!-- Failed test 1 -->
-<tr>
-<td>skal fullføre komplett saksflyt...</td>
-<td>❌</td>
-<td>3 (3 failed)</td>
-<td>✅</td>
-<td>❌ melosys-api (1)</td>
-<td>24s</td>
-</tr>
-<!-- Failed test 2 -->
-<tr>
-<td>FULL_DEKNING_FTRL</td>
-<td>❌</td>
-<td>3 (3 failed)</td>
-<td>✅</td>
-<td>❌ melosys-api (1)</td>
-<td>27s</td>
-</tr>
-
-<!-- File with no failures appears AFTER -->
-<tr>
-<td colspan="6"><strong>📁 eu-eos / <code>eu-eos-fullfort-vedtak.spec.ts</code></strong></td>
-</tr>
-<tr>
-<td>skal fullføre EU/EØS-arbeidsflyt med vedtak</td>
-<td>✅</td>
-<td>1</td>
-<td>✅</td>
-<td>✅</td>
-<td>21s</td>
-</tr>
+<tr><td>❌ skal fullføre "Arbeid i flere land"…</td><td><code>eu-eos/art13-arbeid-flere-land-fullfort-vedtak</code></td><td><code>expect(received).toBe(expected)</code></td><td>26s</td></tr>
 </tbody>
 </table>
+
+## 📊 Test Results
+
+<details open>
+<summary>❌ <strong>eu-eos</strong> — 28 ✅ · 1 ❌ · ⏱️ 11m 02s</summary>
+<table>
+<thead><tr><th>Test</th><th>Status</th><th>Attempts</th><th>Duration</th></tr></thead>
+<tbody>
+<tr><td colspan="4"><sub>📄 art13-arbeid-flere-land-fullfort-vedtak · 26s</sub></td></tr>
+<tr><td>skal fullføre "Arbeid i flere land"…</td><td>❌</td><td>3 (3 failed)</td><td>26s</td></tr>
+</tbody>
+</table>
+</details>
+
+<details>
+<summary>✅ <strong>ftrl</strong> — 8 ✅ · ⏱️ 5m 40s</summary>
+…collapsed…
+</details>
 ```
 
-## Benefits of Current Format
+### Key functions in `lib/summary-generator.ts`
 
-✅ **Immediate failure visibility** - Failed files at the very top
-✅ **Failure counts** - Quick assessment of severity
-✅ **Error source identification** - Know if it's Playwright, business logic, or Docker
-✅ **Service-level diagnostics** - See which Docker services failed
-✅ **Clean scanning** - Emoji-only format reduces noise
-✅ **Double prioritization** - Failed files first, then failed tests first
+| Function | Responsibility |
+|----------|----------------|
+| `generateNeedsAttentionPanel` | The top failures/flaky panel |
+| `generateTestResultsTable` / `generateDomainGroup` | Collapsible per-domain sections |
+| `groupTestsByDomain` / `groupTestsByFile` | Grouping + failing-first sort |
+| `parseTestPath` | Domain extraction + file-label de-duplication |
+| `formatDuration` | `8s` / `4m 12s` formatting (used by all rollups) |
 
-## Common Modifications
+Docker errors are shown as an inline `🐳 service (n)` badge under the test
+title, plus the full `## 🐳 Docker Log Errors by Service` section lower down.
 
-### Add a new column
+## Testing Changes
 
-```typescript
-// 1. Update header (around line 187)
-md += '<th>New Column</th>\n';
+Iterate against the unit suite (millisecond feedback, no E2E run):
 
-// 2. Update colspan (line 230)
-md += `<td colspan="7">...`;  // Changed from 6 to 7
-
-// 3. Add cell value (around line 270)
-const newValue = 'some value';
-md += `<td>${newValue}</td>\n`;
+```bash
+npm run test:unit   # lib/summary-generator.test.ts — 55+ scenarios
 ```
-
-### Change failure criteria
-
-```typescript
-// Modify this section (lines 206-212)
-const sortedAllFiles = allFiles.sort((a, b) => {
-  // Example: Sort by failure count instead of just has/no failures
-  const aFailCount = a.tests.filter(t => t.finalStatus === 'failed').length;
-  const bFailCount = b.tests.filter(t => t.finalStatus === 'failed').length;
-
-  if (aFailCount !== bFailCount) return bFailCount - aFailCount; // Most failures first
-  return `${a.folderName}/${a.fileName}`.localeCompare(`${b.folderName}/${b.fileName}`);
-});
-```
-
-### Add color coding
-
-```typescript
-// Add style to row based on status
-md += '<tr';
-if (testInfo.finalStatus === 'failed') {
-  md += ' style="background-color: #fee;"';
-}
-md += '>\n';
-```
-
-## Future Improvement Ideas
-
-- [ ] Add filtering by folder/status
-- [ ] Add expandable/collapsible sections for passed tests
-- [ ] Add links to trace files
-- [ ] Add execution time chart
-- [ ] Group by test suite instead of file
-- [ ] Add retry success rate
-- [ ] Add historical comparison
-- [ ] Add severity levels for failures
-- [ ] Add search/filter functionality (if rendered in HTML report)
 
 ## Related Files
 
-- `fixtures/docker-logs.ts` - Captures Docker errors that appear in "Docker Logs" column
+- `fixtures/docker-logs.ts` - Captures the Docker errors shown as badges/section
 - `playwright.config.ts` - Configures this reporter
 - `.github/workflows/e2e-tests.yml` - Uses the generated summary in PR comments
+- `docs/report-ideas/index.html` - Layout prototyping sandbox


### PR DESCRIPTION
## Hva

Erstatter den flate test-resultattabellen i E2E-jobbsammendraget med **én sammenleggbar `<details>`-seksjon per domenemappe** (Variant A):

- **Feil øverst** — et kompakt `❗ Needs Attention`-panel løfter feilede/flaky tester til topps; feilende domener sorteres først og vises ekspandert, grønne domener er kollapset.
- **Varighet per gruppe** — hver domene- og fil-overskrift viser summert varighet. Total varighet vises nå som `48m 57s` i stedet for `2937s`.
- **Ingen mappe/fil-duplisering** — fil-etiketter fjerner det duplikate `<domene>-`-prefikset (`eu-eos/eu-eos-art13-….spec.ts` → `📄 art13-…`).
- Docker-feil vises som inline-badge under testtittelen.

## Verifisering

- ✅ `npm run test:unit` — 55/55 grønne (oppdaterte til ny struktur + rettet to utdaterte Docker-tester som allerede var røde på main)
- ✅ E2E CI [run 27898760973](https://github.com/navikt/melosys-e2e-tests/actions/runs/27898760973) grønn (95 tester), og det faktiske jobbsammendraget rendret i ny layout

## I tillegg

- `docs/report-ideas/` — en prototyping-sandkasse som rendrer en ekte kjøring i flere kandidat-layouter, kun med HTML-subsettet GitHub-jobbsammendrag tillater.
- En «Domain mapping»-bryter i sandkassen forhåndsviser sammenslåing av `ftrl` → `utenfor-avtaleland` (samme sakstema «Utenfor avtaleland (ftrl)»). Ingen filer flyttes — selve mappeflyttingen vurderes i en egen PR.