### PR TITLE
Legg til e2e-tester for «Utsendt arbeidstaker»-søknad (skjema-web)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -113,14 +113,6 @@ jobs:
         run: |
           docker network create melosys.docker-internal || true
 
-      - name: Map host.docker.internal for browser OIDC redirect (skjema)
-        run: |
-          # Skjema-testene logger inn via wonderwall, som redirecter NETTLESEREN til
-          # http://host.docker.internal:8082 (ID-porten/mock-oauth2). På runneren må det
-          # navnet peke på den publiserte mock-oauth2-porten. (Tjenester i docker-nettet
-          # resolver host.docker.internal via nettverks-aliaset på mock-oauth2-server.)
-          echo "127.0.0.1 host.docker.internal" | sudo tee -a /etc/hosts
-
       - name: Determine image tags from trigger source
         id: image-tags
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -113,6 +113,14 @@ jobs:
         run: |
           docker network create melosys.docker-internal || true
 
+      - name: Map host.docker.internal for browser OIDC redirect (skjema)
+        run: |
+          # Skjema-testene logger inn via wonderwall, som redirecter NETTLESEREN til
+          # http://host.docker.internal:8082 (ID-porten/mock-oauth2). På runneren må det
+          # navnet peke på den publiserte mock-oauth2-porten. (Tjenester i docker-nettet
+          # resolver host.docker.internal via nettverks-aliaset på mock-oauth2-server.)
+          echo "127.0.0.1 host.docker.internal" | sudo tee -a /etc/hosts
+
       - name: Determine image tags from trigger source
         id: image-tags
         run: |
@@ -345,6 +353,10 @@ jobs:
           docker pull --platform linux/amd64 ghcr.io/navikt/mock-oauth2-server:2.3.0 &
           docker pull --platform linux/amd64 ghcr.io/navikt/mock-oauth2-server:0.4.8 &
           docker pull --platform linux/amd64 unleashorg/unleash-server:latest &
+          # Skjema-stack (digital «Utsendt arbeidstaker»-søknad)
+          docker pull --platform linux/amd64 europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-skjema-api:latest &
+          docker pull --platform linux/amd64 europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-skjema-web:latest &
+          docker pull --platform linux/amd64 ghcr.io/nais/wonderwall:latest &
           wait
           echo "✅ All images pre-pulled successfully"
 
@@ -437,6 +449,23 @@ jobs:
           sleep 10
           echo "✅ Ready to run tests!"
           echo "ℹ️  Note: Feature toggles are automatically created by melosys-api on startup"
+
+      - name: Wait for skjema stack (best-effort)
+        run: |
+          # Skjema-tjenestene er ikke i hoved-helsegaten over (for å ikke regge den
+          # eksisterende suiten). Gi wonderwall/web tid til å svare før testene starter.
+          # Ikke-fatalt: skjema-testene har egne ventere (SkjemaAuthHelper).
+          echo "⏳ Waiting for skjema web (wonderwall :3001)..."
+          for i in $(seq 1 24); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:3001/medlemskap-lovvalg/soknad/ || echo 000)
+            if [ "$code" != "000" ]; then
+              echo "✅ skjema web svarer (HTTP $code) etter $i forsøk"
+              break
+            fi
+            echo "  forsøk $i/24: ikke klar ennå"
+            sleep 5
+          done
+          docker compose ps melosys-skjema-api melosys-skjema-web melosys-skjema-web-auth || true
 
       - name: Run Playwright tests
         id: playwright

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,26 @@ services:
                 }
               }
             ]
+          },
+          {
+            "issuerId": "tokenx",
+            "tokenExpiry": 3600,
+            "requestMappings": [
+              {
+                "requestParam": "audience",
+                "match": "melosys-skjema-api",
+                "claims": {
+                  "pid": "$${pid}",
+                  "aud": "melosys-skjema-api",
+                  "sub": "$${pid}",
+                  "azp": "$${clientId}",
+                  "iss": "http://host.docker.internal:8082/tokenx",
+                  "tid": "tokenx",
+                  "acr": "Level4",
+                  "idp": "https://idporten.no"
+                }
+              }
+            ]
           }
         ]
       }'
@@ -307,6 +327,8 @@ services:
       MELOSYSDOKGEN_V1_URL: http://melosys-dokgen.melosys.docker-internal:8080/api/v1
       MELOSYSTRYGDEAVGIFT_URL: http://melosys-trygdeavgift-beregning.melosys.docker-internal:8095/api
       INNGANGSVILKAAR_URL: http://melosys-inngangsvilkar.melosys.docker-internal:8080/api
+      # M2M-callback til skjema-api for mottak av digital «Utsendt arbeidstaker»-søknad (skjema-tester)
+      MELOSYS_SKJEMA_API_URL: http://melosys-skjema-api.melosys.docker-internal:8090
       MICROSOFT_GRAPH_REST_URL: http://melosys-mock.melosys.docker-internal:8083/graph/v1.0
       TILGANGSMASKINEN_URL: http://melosys-mock.melosys.docker-internal:8083/tilgangsmaskinen
       UTBETALING_REST_URL: http://melosys-mock.melosys.docker-internal:8083/utbetaldata/api/v2/hent-utbetalingsinformasjon/intern
@@ -589,6 +611,105 @@ services:
       melosys.docker-internal:
         aliases:
           - melosys-eessi.melosys.docker-internal
+
+  # ============================================================================
+  # Digital «Utsendt arbeidstaker»-søknad (skjema-stack) — speiler skjema-profilen
+  # i melosys-docker-compose. Innbygger-login er ID-porten-stil, så web-en står bak
+  # en wonderwall-sidecar (auto-login mot mock-oauth2). BFF-en veksler den innloggede
+  # brukeren til et TokenX-token for skjema-api (USE_LOCAL_TOKEN).
+  #
+  # NB: nettleseren redirectes til host.docker.internal:8082 under login — workflowen
+  # mapper derfor host.docker.internal -> 127.0.0.1 i runnerens /etc/hosts.
+  #
+  # Frontend (via wonderwall): http://localhost:3001/medlemskap-lovvalg/soknad/
+  # API:                       http://localhost:8091
+  # ============================================================================
+  melosys-skjema-api:
+    image: europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-skjema-api:${MELOSYS_SKJEMA_API_TAG:-latest}
+    container_name: melosys-skjema-api
+    depends_on:
+      postgres:
+        condition: service_healthy
+      kafka:
+        condition: service_started
+      mock-oauth2-server:
+        condition: service_started
+      melosys-mock:
+        condition: service_started
+    environment:
+      SPRING_PROFILES_ACTIVE: local
+      SERVER_PORT: "8090"
+      # Schemaet "melosys-skjema" lages av Flyway (FLYWAY_ENABLED=true), som for de andre PG-appene.
+      DB_JDBC_URL: "jdbc:postgresql://postgres:5432/postgres?currentSchema=melosys-skjema&user=postgres&password=mysecretpassword"
+      FLYWAY_ENABLED: "true"
+      KAFKA_BROKERS: "kafka.melosys.docker-internal:9092"
+      # Eksterne integrasjoner -> mockes i melosys-mock
+      PDL_URL: "http://melosys-mock.melosys.docker-internal:8083/graphql"
+      EREG_URL: "http://melosys-mock.melosys.docker-internal:8083/ereg"
+      REPR_URL: "http://melosys-mock.melosys.docker-internal:8083/repr"
+      ARBEIDSGIVER_ALTINN_TILGANGER_URL: "http://melosys-mock.melosys.docker-internal:8083"
+      ARBEIDSGIVER_NOTIFIKASJON_URL: "http://melosys-mock.melosys.docker-internal:8083/arbeidsgiver-notifikasjon"
+      VEDLEGG_MOCK_STORAGE_URL: "http://melosys-mock.melosys.docker-internal:8083/vedlegg-storage"
+      CLAMAV_URL: "http://melosys-mock.melosys.docker-internal:8083/clamav"
+      VARSLING_ARBEIDSTAKER_SKJEMA_LENKE: "http://localhost:3001/medlemskap-lovvalg/soknad/"
+    ports:
+      - "8091:8090"
+    networks:
+      melosys.docker-internal:
+        aliases:
+          - melosys-skjema-api.melosys.docker-internal
+
+  melosys-skjema-web:
+    image: europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-skjema-web:${MELOSYS_SKJEMA_WEB_TAG:-latest}
+    container_name: melosys-skjema-web
+    depends_on:
+      melosys-skjema-api:
+        condition: service_started
+      mock-oauth2-server:
+        condition: service_started
+    environment:
+      NAIS_CLUSTER_NAME: dev-gcp
+      EXPRESS_PORT: "8080"
+      EXPRESS_HOST: "::"
+      # Må matche BASE_PATH imaget ble bygget med (Vite baker pathen inn i SPA-assets).
+      BASE_PATH: /medlemskap-lovvalg/soknad/
+      # BFF -> skjema-api: veksle innlogget bruker til TokenX-token via mock-oauth2.
+      USE_LOCAL_TOKEN: "true"
+      LOCAL_TOKEN_ENDPOINT: http://host.docker.internal:8082/tokenx/token
+      LOCAL_TOKEN_AUDIENCE: melosys-skjema-api
+      API_URL: http://melosys-skjema-api.melosys.docker-internal:8090/api
+      DEKORATOREN_API_URL: https://www.ekstern.dev.nav.no/person/nav-dekoratoren-api
+    networks:
+      melosys.docker-internal:
+        aliases:
+          - melosys-skjema-web.melosys.docker-internal
+
+  # ID-porten-stil login-proxy foran melosys-skjema-web (wonderwall auto-login).
+  melosys-skjema-web-auth:
+    image: ghcr.io/nais/wonderwall:latest
+    container_name: melosys-skjema-web-auth
+    depends_on:
+      - melosys-skjema-web
+      - mock-oauth2-server
+    ports:
+      - "3001:4000"
+    environment:
+      WONDERWALL_ENCRYPTION_KEY: "YWJjZGVmZ2hpajEyMzQ1Njc4OTBhYmNkZWZnaGlqMTI="
+    command: >
+      --auto-login=true
+      --openid.well-known-url=http://host.docker.internal:8082/isso/.well-known/openid-configuration
+      --openid.client-secret=not-so-secret
+      --openid.client-id=client-id
+      --ingress=http://localhost:3001
+      --bind-address=0.0.0.0:4000
+      --upstream-host=melosys-skjema-web.melosys.docker-internal:8080
+      --cookie.secure=false
+      --log-level=info
+      --log-format=text
+    networks:
+      melosys.docker-internal:
+        aliases:
+          - melosys-skjema-web-auth.melosys.docker-internal
 
 networks:
   melosys.docker-internal:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -679,6 +679,12 @@ services:
       LOCAL_TOKEN_AUDIENCE: melosys-skjema-api
       API_URL: http://melosys-skjema-api.melosys.docker-internal:8090/api
       DEKORATOREN_API_URL: https://www.ekstern.dev.nav.no/person/nav-dekoratoren-api
+    # SSR-dekoratøren hentes server-side fra den interne URL-en nav-dekoratoren.personbruker,
+    # som ikke nås på CI og HENGER på connect (~60s med retries → treg første render, som ga
+    # cold-start-flak på første test). Pek den på 127.0.0.1 så fetchen feiler RASKT (som lokalt,
+    # der navnet er NXDOMAIN) → rask CSR-fallback. Påvirker ikke klient-dekoratøren (ekstern URL).
+    extra_hosts:
+      - "nav-dekoratoren.personbruker:127.0.0.1"
     networks:
       melosys.docker-internal:
         aliases:

--- a/fixtures/cleanup.ts
+++ b/fixtures/cleanup.ts
@@ -35,14 +35,31 @@ async function cleanupTestData(page: any, waitForProcesses: boolean = false): Pr
         }
     }
 
-    // Clean Oracle database
+    // Clean Oracle database. Retry/backoff på ORA-00054 ("resource busy"): melosys-api kan holde
+    // DML-lås mens den prosesserer en nylig mottatt digital søknad (skjema-mottak) akkurat når
+    // cleanup kjører. db-helper setter også DDL_LOCK_TIMEOUT, så låsen rekker som regel å slippe;
+    // denne loopen dekker tilfeller der den holdes litt lenger.
     const db = new DatabaseHelper();
     try {
         await db.connect();
-        const result = await db.cleanDatabase(true); // silent = true
-
-        if (result.cleanedCount > 0 || result.totalRowsDeleted > 0) {
-            console.log(`   ✅ Oracle: ${result.cleanedCount} tables cleaned (${result.totalRowsDeleted} rows)`);
+        const maxAttempts = 3;
+        for (let attempt = 1; ; attempt++) {
+            try {
+                const result = await db.cleanDatabase(true); // silent = true
+                if (result.cleanedCount > 0 || result.totalRowsDeleted > 0) {
+                    console.log(`   ✅ Oracle: ${result.cleanedCount} tables cleaned (${result.totalRowsDeleted} rows)`);
+                }
+                break;
+            } catch (error: any) {
+                const msg = error?.message || String(error);
+                if (msg.includes('ORA-00054') && attempt < maxAttempts) {
+                    const waitMs = 2000 * attempt;
+                    console.log(`   ⏳ Oracle opptatt (ORA-00054) — venter ${waitMs}ms og prøver cleanup igjen (forsøk ${attempt}/${maxAttempts})`);
+                    await new Promise((r) => setTimeout(r, waitMs));
+                    continue;
+                }
+                throw error;
+            }
         }
     } catch (error: any) {
         console.log(`   ⚠️  Oracle cleanup failed: ${error.message || error}`);

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -5,7 +5,9 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
+import { chromium } from '@playwright/test';
 import { MetricsHelper } from './helpers/metrics-helper';
+import { SkjemaAuthHelper } from './helpers/skjema-auth-helper';
 
 const EESSI_BASE_URL = process.env.EESSI_BASE_URL || 'http://localhost:8081';
 
@@ -50,6 +52,56 @@ async function assertEessiAvailable(): Promise<void> {
   );
 }
 
+/**
+ * Varm opp skjema-stacken med én innlogging FØR de tidsbegrensede testene kjører.
+ *
+ * Kald oppstart (skjema-api JVM, wonderwall sin første OIDC-veksling, skjema-web sin første
+ * render) gjorde at den FØRSTE skjema-testen kunne time ut på 60s og passere på retry. Ved å
+ * betale kald-start-kostnaden her — utenfor test-timeouten — blir første ekte test rask.
+ *
+ * Best-effort: hopper raskt over hvis skjema-web ikke svarer (ikke-skjema-kjøringer eller stack
+ * uten skjema-profil), og svelger alle feil — oppvarming skal ALDRI velte testkjøringen.
+ * Skru av lokalt med SKIP_SKJEMA_WARMUP=true.
+ */
+async function warmUpSkjema(): Promise<void> {
+  if (process.env.SKIP_SKJEMA_WARMUP === 'true') {
+    console.log('⏭️  SKIP_SKJEMA_WARMUP=true → hopper over skjema-oppvarming');
+    return;
+  }
+
+  // Rask tilgjengelighetssjekk — hopp ut umiddelbart hvis skjema-stacken ikke kjører.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 3000);
+  try {
+    await fetch(SkjemaAuthHelper.BASE_URL, { redirect: 'manual', signal: controller.signal });
+  } catch {
+    console.log('⏭️  Skjema-web svarer ikke — hopper over oppvarming (ikke-skjema-kjøring?)');
+    return;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  console.log('🔥 Varmer opp skjema-stacken (én innlogging)...');
+  let browser;
+  try {
+    // Samme host-resolver-regel som testene: nettleseren må nå host.docker.internal:8082.
+    browser = await chromium.launch({
+      args: ['--host-resolver-rules=MAP host.docker.internal 127.0.0.1'],
+    });
+    const page = await browser.newPage();
+    const auth = new SkjemaAuthHelper(page);
+    await auth.login(); // browser → wonderwall → mock-oauth2 → skjema-web → /representasjon
+    // Videre til oversikt for å også varme skjema-api (tokenx-veksling + utkast-spørring).
+    await page.getByRole('button', { name: 'DEG SELV' }).click();
+    await page.waitForURL(/\/oversikt/, { timeout: 30000 });
+    console.log('✅ Skjema-stacken er varmet opp');
+  } catch (e) {
+    console.warn('⚠️  Skjema-oppvarming feilet (ikke-fatalt):', (e as Error).message);
+  } finally {
+    await browser?.close();
+  }
+}
+
 export default async function globalSetup() {
   console.log('🚀 Global setup: Docker log monitoring enabled for each test');
   console.log(
@@ -76,4 +128,7 @@ export default async function globalSetup() {
   } catch (error) {
     console.warn('⚠️  Could not capture metrics (API not running?):', (error as Error).message);
   }
+
+  // Varm opp skjema-stacken til slutt, slik at første skjema-test slipper kald-start-flaket.
+  await warmUpSkjema();
 }

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { chromium } from '@playwright/test';
 import { MetricsHelper } from './helpers/metrics-helper';
 import { SkjemaAuthHelper } from './helpers/skjema-auth-helper';
+import { SoknadUtsendtArbeidstakerPage } from './pages/skjema/soknad-utsendt-arbeidstaker.page';
 
 const EESSI_BASE_URL = process.env.EESSI_BASE_URL || 'http://localhost:8081';
 
@@ -91,10 +92,13 @@ async function warmUpSkjema(): Promise<void> {
     const page = await browser.newPage();
     const auth = new SkjemaAuthHelper(page);
     await auth.login(); // browser → wonderwall → mock-oauth2 → skjema-web → /representasjon
-    // Videre til oversikt for å også varme skjema-api (tokenx-veksling + utkast-spørring).
-    await page.getByRole('button', { name: 'DEG SELV' }).click();
-    await page.waitForURL(/\/oversikt/, { timeout: 30000 });
-    console.log('✅ Skjema-stacken er varmet opp');
+    // Kjør én KOMPLETT innsending, slik at alle skjema-api-endepunktene (opprett utkast, lagre
+    // hvert steg, send inn) og step-renderne er JVM-varme før første ekte test. En login-only
+    // oppvarming holdt ikke: første test stallet på "Start søknad" (kald create-draft-POST).
+    // Bonus: varmer også melosys-api sin Kafka-consumer for mottaket.
+    const soknad = new SoknadUtsendtArbeidstakerPage(page);
+    const { referanse } = await soknad.fyllUtOgSendInnKomplettSoknad();
+    console.log(`✅ Skjema-stacken er varmet opp (komplett innsending, ref ${referanse})`);
   } catch (e) {
     console.warn('⚠️  Skjema-oppvarming feilet (ikke-fatalt):', (e as Error).message);
   } finally {

--- a/helpers/db-helper.ts
+++ b/helpers/db-helper.ts
@@ -139,7 +139,12 @@ export class DatabaseHelper {
         console.log(`⏭️  Tables to skip: ${skippedTables.length} (lookup/reference tables)\n`);
       }
 
-      // Disable foreign key constraints temporarily
+      // Disable FK constraints, truncate, og ALLTID re-enable i en finally — slik at en feil under
+      // truncate (f.eks. ORA-00054 fra en lås melosys-api holder under skjema-mottak) ikke etterlater
+      // FK-constraints permanent disablet for resten av testkjøringen.
+      let cleanedCount = 0;
+      let totalRowsDeleted = 0;
+
       await this.connection.execute('BEGIN\n' +
         '  FOR c IN (SELECT constraint_name, table_name FROM user_constraints WHERE constraint_type = \'R\') LOOP\n' +
         '    EXECUTE IMMEDIATE \'ALTER TABLE \' || c.table_name || \' DISABLE CONSTRAINT \' || c.constraint_name;\n' +
@@ -150,38 +155,42 @@ export class DatabaseHelper {
         console.log('🔓 Disabled foreign key constraints\n');
       }
 
-      let cleanedCount = 0;
-      let totalRowsDeleted = 0;
+      try {
+        // Truncate data from each table (faster than DELETE and resets sequences)
+        for (const tableName of tablesToClean) {
+          try {
+            // Count rows before truncation
+            const countResult = await this.query(`SELECT COUNT(*) as cnt FROM ${tableName}`, {}, true);
+            const rowCount = countResult[0]?.CNT || 0;
 
-      // Truncate data from each table (faster than DELETE and resets sequences)
-      for (const tableName of tablesToClean) {
-        try {
-          // Count rows before truncation
-          const countResult = await this.query(`SELECT COUNT(*) as cnt FROM ${tableName}`, {}, true);
-          const rowCount = countResult[0]?.CNT || 0;
-
-          if (rowCount > 0) {
-            // TRUNCATE is faster than DELETE and resets auto-increment sequences
-            await this.connection.execute(`TRUNCATE TABLE ${tableName}`);
-            if (!silent) {
-              console.log(`✅ Cleaned ${tableName.padEnd(40)} (${rowCount} rows truncated)`);
+            if (rowCount > 0) {
+              // TRUNCATE is faster than DELETE and resets auto-increment sequences
+              await this.connection.execute(`TRUNCATE TABLE ${tableName}`);
+              if (!silent) {
+                console.log(`✅ Cleaned ${tableName.padEnd(40)} (${rowCount} rows truncated)`);
+              }
+              cleanedCount++;
+              totalRowsDeleted += rowCount;
             }
-            cleanedCount++;
-            totalRowsDeleted += rowCount;
-          }
-        } catch (error) {
-          if (!silent) {
-            console.log(`⚠️  Could not clean ${tableName}: ${(error as Error).message || error}`);
+          } catch (error) {
+            // Lås-konflikt (ORA-00054) løftes til cleanup-fixturens retry/backoff så låsen får tid til
+            // å slippe; andre per-tabell-feil hoppes over (som før) så én tabell ikke stopper alt.
+            if (((error as Error).message || '').includes('ORA-00054')) {
+              throw error;
+            }
+            if (!silent) {
+              console.log(`⚠️  Could not clean ${tableName}: ${(error as Error).message || error}`);
+            }
           }
         }
+      } finally {
+        // Re-enable foreign key constraints — kjører ALLTID, også når truncate kastet over.
+        await this.connection.execute('BEGIN\n' +
+          '  FOR c IN (SELECT constraint_name, table_name FROM user_constraints WHERE constraint_type = \'R\') LOOP\n' +
+          '    EXECUTE IMMEDIATE \'ALTER TABLE \' || c.table_name || \' ENABLE CONSTRAINT \' || c.constraint_name;\n' +
+          '  END LOOP;\n' +
+          'END;');
       }
-
-      // Re-enable foreign key constraints
-      await this.connection.execute('BEGIN\n' +
-        '  FOR c IN (SELECT constraint_name, table_name FROM user_constraints WHERE constraint_type = \'R\') LOOP\n' +
-        '    EXECUTE IMMEDIATE \'ALTER TABLE \' || c.table_name || \' ENABLE CONSTRAINT \' || c.constraint_name;\n' +
-        '  END LOOP;\n' +
-        'END;');
 
       if (!silent) {
         console.log('\n🔒 Re-enabled foreign key constraints');

--- a/helpers/db-helper.ts
+++ b/helpers/db-helper.ts
@@ -78,6 +78,16 @@ export class DatabaseHelper {
       throw new Error('Database not connected. Call connect() first.');
     }
 
+    // La DDL (TRUNCATE / ALTER TABLE) VENTE på radlåser i opptil 30s i stedet for å feile
+    // umiddelbart med ORA-00054. melosys-api kan holde DML-lås mens den prosesserer en nylig
+    // mottatt digital søknad (skjema-mottak) akkurat når cleanup kjører før neste test.
+    // Best-effort — retry/backoff i cleanup-fixturen dekker tilfeller der låsen holdes lenger.
+    try {
+      await this.connection.execute('ALTER SESSION SET DDL_LOCK_TIMEOUT = 30');
+    } catch {
+      // Ikke støttet på denne DB-en — ignorer; retry-loopen i fixturen håndterer lås-konflikt.
+    }
+
     if (!silent) {
       console.log('\n🧹 Starting database cleanup...\n');
     }

--- a/helpers/skjema-auth-helper.ts
+++ b/helpers/skjema-auth-helper.ts
@@ -30,9 +30,14 @@ export class SkjemaAuthHelper {
   async login(fnr: string = '12928056706'): Promise<void> {
     await this.page.goto(SkjemaAuthHelper.BASE_URL);
 
-    // Wonderwall redirecter til mock-oauth2 sitt "Velg testbruker"-skjema. Hvis vi
-    // allerede har en aktiv sesjon dukker ikke skjemaet opp og vi lander rett i appen.
-    const subjectField = this.page.getByRole('textbox', { name: 'Enter any user/subject' });
+    // Wonderwall redirecter til mock-oauth2 sin login-form. Hvis vi allerede har en
+    // aktiv sesjon dukker den ikke opp og vi lander rett i appen.
+    //
+    // Subjekt-feltet treffes på placeholder ELLER tilgjengelig navn: den rå mock-oauth2-formen
+    // (CI) gir feltet KUN en placeholder, mens login-proxyen lokalt legger på et navn.
+    const subjectField = this.page
+      .getByPlaceholder('Enter any user/subject')
+      .or(this.page.getByRole('textbox', { name: 'Enter any user/subject' }));
     const signInButton = this.page.getByRole('button', { name: 'Sign-in' });
 
     if (await subjectField.isVisible({ timeout: 15000 }).catch(() => false)) {

--- a/helpers/skjema-auth-helper.ts
+++ b/helpers/skjema-auth-helper.ts
@@ -1,7 +1,7 @@
 import { Page, expect } from '@playwright/test';
 
 /**
- * Innloggingshjelper for melosys-skjema-web (digital A1-søknad).
+ * Innloggingshjelper for melosys-skjema-web (digital «Utsendt arbeidstaker»-søknad).
  *
  * I MOTSETNING til AuthHelper (saksbehandler i melosys-web, Azure AD) logger denne
  * inn som INNBYGGER via ID-porten-flyten: wonderwall-sidecar foran skjema-web gjør

--- a/helpers/skjema-auth-helper.ts
+++ b/helpers/skjema-auth-helper.ts
@@ -1,0 +1,51 @@
+import { Page, expect } from '@playwright/test';
+
+/**
+ * Innloggingshjelper for melosys-skjema-web (digital A1-søknad).
+ *
+ * I MOTSETNING til AuthHelper (saksbehandler i melosys-web, Azure AD) logger denne
+ * inn som INNBYGGER via ID-porten-flyten: wonderwall-sidecar foran skjema-web gjør
+ * auto-login mot mock-oauth2-server, som viser et "Velg testbruker"-skjema der vi
+ * oppgir fødselsnummeret til testbrukeren.
+ *
+ * Testbrukere er dokumentert i melosys-docker-compose/TESTBRUKERE.md. Eksempler:
+ *  - 12928056706  LANSEN LANSANSEN   (arbeidstaker NOR → Frankrike, "DEG SELV")
+ *  - 30056928150  KARAFFEL TRIVIELL  (arbeidsgiver, Ståles Stål + Steinars Stein)
+ *  - 77777777777  JUNIOR TRIVIELL    (kun "DEG SELV", ingen tilganger)
+ *
+ * Stacken må kjøre med skjema-profilen: cd ../melosys-docker-compose && make dev-skjema
+ */
+export class SkjemaAuthHelper {
+  /** Frontend bak wonderwall. Kan overstyres med SKJEMA_WEB_BASE_URL i .env.local. */
+  static readonly BASE_URL =
+    process.env.SKJEMA_WEB_BASE_URL || 'http://localhost:3001/medlemskap-lovvalg/soknad/';
+
+  constructor(private page: Page) {}
+
+  /**
+   * Logg inn som innbygger og lande på rollevalg-siden (/representasjon).
+   *
+   * @param fnr Fødselsnummeret til testbrukeren (default LANSEN — arbeidstaker).
+   */
+  async login(fnr: string = '12928056706'): Promise<void> {
+    await this.page.goto(SkjemaAuthHelper.BASE_URL);
+
+    // Wonderwall redirecter til mock-oauth2 sitt "Velg testbruker"-skjema. Hvis vi
+    // allerede har en aktiv sesjon dukker ikke skjemaet opp og vi lander rett i appen.
+    const subjectField = this.page.getByRole('textbox', { name: 'Enter any user/subject' });
+    const signInButton = this.page.getByRole('button', { name: 'Sign-in' });
+
+    if (await subjectField.isVisible({ timeout: 15000 }).catch(() => false)) {
+      await subjectField.fill(fnr);
+      await signInButton.click();
+    }
+
+    // Appen redirecter via /oauth2/callback til rollevalg-siden.
+    await this.page.waitForURL(/\/representasjon/, { timeout: 30000 });
+    await expect(
+      this.page.getByRole('heading', { name: 'Hvem skal du opptre som?' })
+    ).toBeVisible();
+
+    console.log('✅ Logget inn i skjema-web som', fnr);
+  }
+}

--- a/pages/skjema/skjema-mottak.assertions.ts
+++ b/pages/skjema/skjema-mottak.assertions.ts
@@ -1,0 +1,67 @@
+import { expect } from '@playwright/test';
+import { withDatabase } from '../../helpers/db-helper';
+
+/**
+ * Assertions for at en digital A1-søknad sendt fra skjema-web blir mottatt av melosys-api
+ * (via Kafka `teammelosys.skjema.innsendt.v1-local`) og ender som sak + behandling i Oracle.
+ *
+ * Korrelasjon: melosys-api lagrer søknads-id-en (UUID) i SKJEMA_SAK_MAPPING.SKJEMA_ID (Oracle RAW(16))
+ * sammen med saksnummeret det opprettet. Vi slår opp via HEXTORAW(<uuid uten bindestrek>).
+ */
+export class SkjemaMottakAssertions {
+  /**
+   * Poll Oracle til melosys-api har konsumert Kafka-meldingen og opprettet mappingen for skjema-id-en.
+   * @returns saksnummeret melosys-api opprettet, og journalpost-id (om journalføring er ferdig).
+   */
+  async ventPaaSakForSkjema(
+    skjemaId: string,
+    timeoutMs = 45000
+  ): Promise<{ saksnummer: string; journalpostId: string | null }> {
+    const hex = skjemaId.replace(/-/g, '').toUpperCase();
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const row = await withDatabase(async (db) =>
+        db.queryOne<{ SAKSNUMMER: string; JOURNALPOST_ID: string | null }>(
+          `SELECT SAKSNUMMER, JOURNALPOST_ID FROM SKJEMA_SAK_MAPPING WHERE SKJEMA_ID = HEXTORAW(:hex)`,
+          { hex }
+        )
+      );
+      if (row?.SAKSNUMMER) {
+        console.log(`✅ melosys-api opprettet sak ${row.SAKSNUMMER} for skjema ${skjemaId}`);
+        return { saksnummer: row.SAKSNUMMER, journalpostId: row.JOURNALPOST_ID ?? null };
+      }
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+    throw new Error(
+      `Fant ingen SKJEMA_SAK_MAPPING for skjema-id ${skjemaId} innen ${timeoutMs} ms — ` +
+        'melosys-api konsumerte ikke Kafka-meldingen (sjekk DigitalSøknadMottattConsumer + M2M-kall mot skjema-api).'
+    );
+  }
+
+  /**
+   * Verifiser at saksnummeret peker på en fagsak med en utsendt-arbeidstaker-førstegangsbehandling.
+   */
+  async verifiserSakOgBehandling(saksnummer: string): Promise<void> {
+    await withDatabase(async (db) => {
+      const fagsak = await db.queryOne<{ SAKSNUMMER: string; STATUS: string }>(
+        `SELECT SAKSNUMMER, STATUS FROM FAGSAK WHERE SAKSNUMMER = :s`,
+        { s: saksnummer }
+      );
+      expect(fagsak, `FAGSAK ${saksnummer} skal finnes`).not.toBeNull();
+
+      const beh = await db.queryOne<{ ID: number; BEH_TEMA: string; BEH_TYPE: string; STATUS: string }>(
+        `SELECT ID, BEH_TEMA, BEH_TYPE, STATUS FROM BEHANDLING
+         WHERE SAKSNUMMER = :s ORDER BY ID DESC FETCH FIRST 1 ROWS ONLY`,
+        { s: saksnummer }
+      );
+      expect(beh, `BEHANDLING for ${saksnummer} skal finnes`).not.toBeNull();
+      expect(beh!.BEH_TEMA, 'behandlingstema').toBe('UTSENDT_ARBEIDSTAKER');
+      expect(beh!.BEH_TYPE, 'behandlingstype').toBe('FØRSTEGANG');
+
+      console.log(
+        `✅ Fagsak ${saksnummer} (${fagsak!.STATUS}) / behandling ${beh!.ID} ` +
+          `(${beh!.BEH_TEMA}/${beh!.BEH_TYPE}, ${beh!.STATUS})`
+      );
+    });
+  }
+}

--- a/pages/skjema/skjema-mottak.assertions.ts
+++ b/pages/skjema/skjema-mottak.assertions.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import { withDatabase } from '../../helpers/db-helper';
 
 /**
- * Assertions for at en digital A1-søknad sendt fra skjema-web blir mottatt av melosys-api
+ * Assertions for at en digital «Utsendt arbeidstaker»-søknad sendt fra skjema-web blir mottatt av melosys-api
  * (via Kafka `teammelosys.skjema.innsendt.v1-local`) og ender som sak + behandling i Oracle.
  *
  * Korrelasjon: melosys-api lagrer søknads-id-en (UUID) i SKJEMA_SAK_MAPPING.SKJEMA_ID (Oracle RAW(16))

--- a/pages/skjema/soknad-utsendt-arbeidstaker.page.ts
+++ b/pages/skjema/soknad-utsendt-arbeidstaker.page.ts
@@ -29,7 +29,12 @@ export class SoknadUtsendtArbeidstakerPage {
     await page.getByRole('button', { name: 'Start søknad' }).click();
 
     await page.waitForURL(/\/skjema\/[^/]+\/utsendingsperiode-og-land/);
-    return page.url().match(/\/skjema\/([^/]+)\//)?.[1] ?? '';
+    // Hent søknads-id-en (UUID) ut av URL-en. Feil HER med en presis melding hvis URL-formen
+    // har endret seg — ellers bæres en tom id videre til SKJEMA_SAK_MAPPING-oppslaget i T2 og
+    // gir en misvisende "Kafka-mottak feilet"-timeout 45s senere.
+    const skjemaId = page.url().match(/\/skjema\/([0-9a-f-]{36})\//i)?.[1];
+    expect(skjemaId, `Fant ikke søknads-id (UUID) i URL-en: ${page.url()}`).toBeTruthy();
+    return skjemaId!;
   }
 
   async fyllUtsendingsperiodeOgLand(land = 'Frankrike'): Promise<void> {
@@ -92,7 +97,11 @@ export class SoknadUtsendtArbeidstakerPage {
     const kvitteringstekst = await page
       .getByText(/Vi har mottatt din søknad med referanse/)
       .innerText();
-    return kvitteringstekst.match(/referanse\s+([A-Z0-9]+)/)?.[1] ?? '';
+    // Feil HER hvis kvitteringsteksten ikke inneholder en referanse — tom streng ville ellers
+    // smyge forbi T1-assertionen som en forvirrende regex-mismatch på '' i stedet for her.
+    const referanse = kvitteringstekst.match(/referanse\s+([A-Z0-9]+)/)?.[1];
+    expect(referanse, `Fant ikke referansenummer i kvitteringen: "${kvitteringstekst}"`).toBeTruthy();
+    return referanse!;
   }
 
   /**

--- a/pages/skjema/soknad-utsendt-arbeidstaker.page.ts
+++ b/pages/skjema/soknad-utsendt-arbeidstaker.page.ts
@@ -95,16 +95,23 @@ export class SoknadUtsendtArbeidstakerPage {
     return kvitteringstekst.match(/referanse\s+([A-Z0-9]+)/)?.[1] ?? '';
   }
 
-  /** Fyll ut hele DEG SELV-flyten og send inn. Returnerer referansenummeret. */
-  async fyllUtOgSendInnKomplettSoknad(arbeidsgiverOrgnr = '999999999', land = 'Frankrike'): Promise<string> {
-    await this.startSoknadSomDegSelv(arbeidsgiverOrgnr);
+  /**
+   * Fyll ut hele DEG SELV-flyten og send inn.
+   * @returns søknads-id (UUID, korrelerer mot SKJEMA_SAK_MAPPING i melosys-api) og referansenummeret.
+   */
+  async fyllUtOgSendInnKomplettSoknad(
+    arbeidsgiverOrgnr = '999999999',
+    land = 'Frankrike'
+  ): Promise<{ skjemaId: string; referanse: string }> {
+    const skjemaId = await this.startSoknadSomDegSelv(arbeidsgiverOrgnr);
     await this.fyllUtsendingsperiodeOgLand(land);
     await this.fyllArbeidssituasjon();
     await this.fyllSkatteforholdOgInntekt();
     await this.fyllFamiliemedlemmer();
     await this.fyllTilleggsopplysninger();
     await this.fyllVedlegg();
-    return this.sendInnOgHentReferanse();
+    const referanse = await this.sendInnOgHentReferanse();
+    return { skjemaId, referanse };
   }
 
   private async svarRadio(gruppe: RegExp, svar: 'Ja' | 'Nei'): Promise<void> {

--- a/pages/skjema/soknad-utsendt-arbeidstaker.page.ts
+++ b/pages/skjema/soknad-utsendt-arbeidstaker.page.ts
@@ -1,0 +1,125 @@
+import { Page, expect } from '@playwright/test';
+
+/**
+ * Page Object for den digitale A1-søknaden "utsendt arbeidstaker" i melosys-skjema-web,
+ * variant DEG SELV (arbeidstaker fyller ut sin egen del).
+ *
+ * Selvstendig POM (utvider IKKE pages/shared/base.page.ts) fordi BasePage er koblet til
+ * melosys-web/FormHelper. Bruker rolle-baserte selektorer (label/legend/knappetekst) sider
+ * Aksel-komponentene genererer dynamiske id-er.
+ *
+ * Stegrekkefølge for DEG SELV-arbeidstaker (verifisert i live-flyt 2026-06-21):
+ *   oversikt → utsendingsperiode-og-land → arbeidssituasjon → skatteforhold-og-inntekt
+ *   → familiemedlemmer → tilleggsopplysninger → vedlegg → oppsummering → kvittering
+ */
+export class SoknadUtsendtArbeidstakerPage {
+  constructor(private page: Page) {}
+
+  /**
+   * Fra rollevalg-siden (/representasjon): velg DEG SELV, oppgi arbeidsgiver og start søknaden.
+   * @returns søknads-id (UUID) fra URL-en.
+   */
+  async startSoknadSomDegSelv(arbeidsgiverOrgnr = '999999999'): Promise<string> {
+    const page = this.page;
+    await page.getByRole('button', { name: 'DEG SELV' }).click();
+    await page.waitForURL(/\/oversikt/);
+
+    await page.getByRole('textbox', { name: 'Arbeidsgivers organisasjonsnummer' }).fill(arbeidsgiverOrgnr);
+    await page.getByRole('checkbox', { name: /Jeg bekrefter/ }).check();
+    await page.getByRole('button', { name: 'Start søknad' }).click();
+
+    await page.waitForURL(/\/skjema\/[^/]+\/utsendingsperiode-og-land/);
+    return page.url().match(/\/skjema\/([^/]+)\//)?.[1] ?? '';
+  }
+
+  async fyllUtsendingsperiodeOgLand(land = 'Frankrike'): Promise<void> {
+    const page = this.page;
+    await expect(page.getByRole('heading', { name: 'Utsendingsperiode og land' })).toBeVisible();
+    await page.getByLabel('I hvilket land skal arbeidet utføres?').selectOption({ label: land });
+
+    // Periode godt innenfor 24-måneders-grensen, beregnet relativt til i dag så testen ikke ruster.
+    const fra = new Date();
+    fra.setMonth(fra.getMonth() + 1, 1); // 1. i neste måned
+    const til = new Date(fra);
+    til.setMonth(til.getMonth() + 6);
+    await page.getByRole('textbox', { name: 'Fra dato' }).fill(ddmmyyyy(fra));
+    await page.getByRole('textbox', { name: 'Til dato' }).fill(ddmmyyyy(til));
+
+    await this.lagreOgFortsett(/\/arbeidssituasjon/);
+  }
+
+  async fyllArbeidssituasjon(): Promise<void> {
+    await this.svarRadio(/lønnet arbeid i Norge/, 'Ja');
+    await this.svarRadio(/selvstendig virksomhet eller arbeide for en annen/, 'Nei');
+    await this.lagreOgFortsett(/\/skatteforhold-og-inntekt/);
+  }
+
+  async fyllSkatteforholdOgInntekt(): Promise<void> {
+    const page = this.page;
+    await this.svarRadio(/skattepliktig til Norge/, 'Ja');
+    await page.getByRole('checkbox', { name: 'Norsk virksomhet' }).check();
+    await page.getByRole('checkbox', { name: 'Lønnsinntekt' }).check();
+    await this.svarRadio(/pengestøtte fra et annet EØS-land/, 'Nei');
+    await this.lagreOgFortsett(/\/familiemedlemmer/);
+  }
+
+  async fyllFamiliemedlemmer(): Promise<void> {
+    await this.svarRadio(/ektefelle, partner, samboer eller barn/, 'Nei');
+    await this.lagreOgFortsett(/\/tilleggsopplysninger/);
+  }
+
+  async fyllTilleggsopplysninger(): Promise<void> {
+    await this.svarRadio(/flere opplysninger til søknaden/, 'Nei');
+    await this.lagreOgFortsett(/\/vedlegg/);
+  }
+
+  async fyllVedlegg(): Promise<void> {
+    await this.svarRadio(/annen dokumentasjon/, 'Nei');
+    await this.lagreOgFortsett(/\/oppsummering/);
+  }
+
+  /**
+   * Send inn fra oppsummeringssiden og returner referansenummeret fra kvitteringen.
+   */
+  async sendInnOgHentReferanse(): Promise<string> {
+    const page = this.page;
+    await expect(page.getByRole('heading', { name: 'Oppsummering' })).toBeVisible();
+    await page.getByRole('button', { name: 'Send søknad' }).click();
+
+    await page.waitForURL(/\/kvittering/);
+    await expect(page.getByRole('heading', { name: 'Takk!' })).toBeVisible();
+
+    const kvitteringstekst = await page
+      .getByText(/Vi har mottatt din søknad med referanse/)
+      .innerText();
+    return kvitteringstekst.match(/referanse\s+([A-Z0-9]+)/)?.[1] ?? '';
+  }
+
+  /** Fyll ut hele DEG SELV-flyten og send inn. Returnerer referansenummeret. */
+  async fyllUtOgSendInnKomplettSoknad(arbeidsgiverOrgnr = '999999999', land = 'Frankrike'): Promise<string> {
+    await this.startSoknadSomDegSelv(arbeidsgiverOrgnr);
+    await this.fyllUtsendingsperiodeOgLand(land);
+    await this.fyllArbeidssituasjon();
+    await this.fyllSkatteforholdOgInntekt();
+    await this.fyllFamiliemedlemmer();
+    await this.fyllTilleggsopplysninger();
+    await this.fyllVedlegg();
+    return this.sendInnOgHentReferanse();
+  }
+
+  private async svarRadio(gruppe: RegExp, svar: 'Ja' | 'Nei'): Promise<void> {
+    // Aksel RadioGroup rendrer <fieldset role="radiogroup"> med legend som tilgjengelig navn.
+    await this.page.getByRole('radiogroup', { name: gruppe }).getByRole('radio', { name: svar }).check();
+  }
+
+  private async lagreOgFortsett(nesteUrl: RegExp): Promise<void> {
+    await this.page.getByRole('button', { name: 'Lagre og fortsett' }).click();
+    await this.page.waitForURL(nesteUrl);
+  }
+}
+
+/** dd.mm.yyyy — formatet Aksel DatePicker forventer på norsk. */
+function ddmmyyyy(d: Date): string {
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${p(d.getDate())}.${p(d.getMonth() + 1)}.${d.getFullYear()}`;
+}

--- a/pages/skjema/soknad-utsendt-arbeidstaker.page.ts
+++ b/pages/skjema/soknad-utsendt-arbeidstaker.page.ts
@@ -1,7 +1,7 @@
 import { Page, expect } from '@playwright/test';
 
 /**
- * Page Object for den digitale A1-søknaden "utsendt arbeidstaker" i melosys-skjema-web,
+ * Page Object for den digitale «Utsendt arbeidstaker»-søknaden i melosys-skjema-web,
  * variant DEG SELV (arbeidstaker fyller ut sin egen del).
  *
  * Selvstendig POM (utvider IKKE pages/shared/base.page.ts) fordi BasePage er koblet til

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -76,6 +76,11 @@ export default defineConfig({
         // Slow down actions slightly for more stable tests
         launchOptions: {
           slowMo: 100,
+          // Skjema-innlogging: wonderwall redirecter nettleseren til host.docker.internal:8082
+          // (mock-oauth2). Chromium leser ikke pålitelig /etc/hosts, så vi tvinger mappingen på
+          // browser-nivå. Uskadelig for øvrige tester (ingen annen nettlesertrafikk går dit), og
+          // fungerer både lokalt og på CI (mock-oauth2 er publisert på localhost:8082 begge steder).
+          args: ['--host-resolver-rules=MAP host.docker.internal 127.0.0.1'],
         }
       },
     },

--- a/tests/skjema/skjema-deg-selv-innsending.spec.ts
+++ b/tests/skjema/skjema-deg-selv-innsending.spec.ts
@@ -22,7 +22,7 @@ test.describe('skjema-web innsending', () => {
     await auth.login('12928056706');
 
     const soknad = new SoknadUtsendtArbeidstakerPage(page);
-    const referanse = await soknad.fyllUtOgSendInnKomplettSoknad('999999999', 'Frankrike');
+    const { referanse } = await soknad.fyllUtOgSendInnKomplettSoknad('999999999', 'Frankrike');
 
     // Kvitteringen viser et referansenummer (alfanumerisk kode) — beviser at innsendingen
     // ble persistert i skjema-api.

--- a/tests/skjema/skjema-deg-selv-innsending.spec.ts
+++ b/tests/skjema/skjema-deg-selv-innsending.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { SkjemaAuthHelper } from '../../helpers/skjema-auth-helper';
+import { SoknadUtsendtArbeidstakerPage } from '../../pages/skjema/soknad-utsendt-arbeidstaker.page';
+
+/**
+ * T1 — full happy-path innsending av digital A1-søknad (utsendt arbeidstaker), variant DEG SELV.
+ *
+ * Innbygger logger inn, fyller ut alle stegene i arbeidstakerdelen og sender inn. Verifiserer at
+ * søknaden går igjennom skjema-api (utkast opprettes, hvert steg lagres, innsending gir kvittering
+ * med referansenummer). Dette er det første scenariet som faktisk produserer en innsendt søknad —
+ * grunnlaget for T2 (Kafka-mottak → sak/behandling i melosys-api).
+ *
+ * Ren @playwright/test (ingen Oracle/Unleash-fixture). Krever stacken oppe:
+ *   cd ../melosys-docker-compose && make dev-skjema
+ *   SKIP_EESSI_GATE=true npx playwright test tests/skjema/ --project=chromium
+ *
+ * Testbruker: 12928056706 (LANSEN, arbeidstaker NOR → Frankrike), arbeidsgiver 999999999 (Ståles Stål).
+ */
+test.describe('skjema-web innsending', () => {
+  test('innbygger fyller ut og sender inn A1-søknad som DEG SELV', async ({ page }) => {
+    const auth = new SkjemaAuthHelper(page);
+    await auth.login('12928056706');
+
+    const soknad = new SoknadUtsendtArbeidstakerPage(page);
+    const referanse = await soknad.fyllUtOgSendInnKomplettSoknad('999999999', 'Frankrike');
+
+    // Kvitteringen viser et referansenummer (alfanumerisk kode) — beviser at innsendingen
+    // ble persistert i skjema-api.
+    expect(referanse).toMatch(/^[A-Z0-9]{5,6}$/);
+    console.log('✅ Søknad sendt inn, referanse:', referanse);
+  });
+});

--- a/tests/skjema/skjema-deg-selv-innsending.spec.ts
+++ b/tests/skjema/skjema-deg-selv-innsending.spec.ts
@@ -3,7 +3,7 @@ import { SkjemaAuthHelper } from '../../helpers/skjema-auth-helper';
 import { SoknadUtsendtArbeidstakerPage } from '../../pages/skjema/soknad-utsendt-arbeidstaker.page';
 
 /**
- * T1 — full happy-path innsending av digital A1-søknad (utsendt arbeidstaker), variant DEG SELV.
+ * T1 — full happy-path innsending av digital «Utsendt arbeidstaker»-søknad, variant DEG SELV.
  *
  * Innbygger logger inn, fyller ut alle stegene i arbeidstakerdelen og sender inn. Verifiserer at
  * søknaden går igjennom skjema-api (utkast opprettes, hvert steg lagres, innsending gir kvittering
@@ -17,7 +17,7 @@ import { SoknadUtsendtArbeidstakerPage } from '../../pages/skjema/soknad-utsendt
  * Testbruker: 12928056706 (LANSEN, arbeidstaker NOR → Frankrike), arbeidsgiver 999999999 (Ståles Stål).
  */
 test.describe('skjema-web innsending', () => {
-  test('innbygger fyller ut og sender inn A1-søknad som DEG SELV', async ({ page }) => {
+  test('innbygger fyller ut og sender inn «Utsendt arbeidstaker»-søknad som DEG SELV', async ({ page }) => {
     const auth = new SkjemaAuthHelper(page);
     await auth.login('12928056706');
 

--- a/tests/skjema/skjema-mottak-sak.spec.ts
+++ b/tests/skjema/skjema-mottak-sak.spec.ts
@@ -1,0 +1,36 @@
+import { test } from '../../fixtures';
+import { SkjemaAuthHelper } from '../../helpers/skjema-auth-helper';
+import { SoknadUtsendtArbeidstakerPage } from '../../pages/skjema/soknad-utsendt-arbeidstaker.page';
+import { SkjemaMottakAssertions } from '../../pages/skjema/skjema-mottak.assertions';
+
+/**
+ * T2 — den tverdifulle vertikale skiva: en digital A1-søknad sendt fra skjema-web skal mottas av
+ * melosys-api og bli en sak + behandling.
+ *
+ * Flyt som verifiseres: skjema-web innsending → skjema-api publiserer `teammelosys.skjema.innsendt.v1-local`
+ * → melosys-api `DigitalSøknadMottattConsumer` → M2M-kall tilbake til skjema-api for søknadsdata →
+ * oppretter fagsak + behandling (UTSENDT_ARBEIDSTAKER/FØRSTEGANG) → journalfører → kaller tilbake saksnummer.
+ *
+ * Denne testen BRUKER ../fixtures (i motsetning til T0/T1) fordi den berører melosys-api/Oracle:
+ * fixturen rydder Oracle FØR testen, så vi asserterer på en fersk sak. Krever full stack med
+ * melosys-api + Kafka i tillegg til skjema:
+ *   cd ../melosys-docker-compose && make full   (eller dev-skjema + melosys-api)
+ *
+ * Korrelasjon mot riktig sak skjer via søknads-id-en (UUID) i SKJEMA_SAK_MAPPING.
+ */
+test.describe('skjema-web → melosys-api mottak', () => {
+  test('innsendt A1-søknad blir sak og behandling i melosys-api', async ({ page }) => {
+    test.setTimeout(120000); // async Kafka-mottak + DB-polling
+
+    const auth = new SkjemaAuthHelper(page);
+    await auth.login('12928056706'); // LANSEN, arbeidstaker NOR → Frankrike
+
+    const soknad = new SoknadUtsendtArbeidstakerPage(page);
+    const { skjemaId, referanse } = await soknad.fyllUtOgSendInnKomplettSoknad('999999999', 'Frankrike');
+    console.log('📨 Søknad sendt:', { skjemaId, referanse });
+
+    const mottak = new SkjemaMottakAssertions();
+    const { saksnummer } = await mottak.ventPaaSakForSkjema(skjemaId);
+    await mottak.verifiserSakOgBehandling(saksnummer);
+  });
+});

--- a/tests/skjema/skjema-mottak-sak.spec.ts
+++ b/tests/skjema/skjema-mottak-sak.spec.ts
@@ -4,7 +4,7 @@ import { SoknadUtsendtArbeidstakerPage } from '../../pages/skjema/soknad-utsendt
 import { SkjemaMottakAssertions } from '../../pages/skjema/skjema-mottak.assertions';
 
 /**
- * T2 — den tverdifulle vertikale skiva: en digital A1-søknad sendt fra skjema-web skal mottas av
+ * T2 — den verdifulle vertikale skiva: en digital «Utsendt arbeidstaker»-søknad sendt fra skjema-web skal mottas av
  * melosys-api og bli en sak + behandling.
  *
  * Flyt som verifiseres: skjema-web innsending → skjema-api publiserer `teammelosys.skjema.innsendt.v1-local`
@@ -19,7 +19,7 @@ import { SkjemaMottakAssertions } from '../../pages/skjema/skjema-mottak.asserti
  * Korrelasjon mot riktig sak skjer via søknads-id-en (UUID) i SKJEMA_SAK_MAPPING.
  */
 test.describe('skjema-web → melosys-api mottak', () => {
-  test('innsendt A1-søknad blir sak og behandling i melosys-api', async ({ page }) => {
+  test('innsendt «Utsendt arbeidstaker»-søknad blir sak og behandling i melosys-api', async ({ page }) => {
     test.setTimeout(120000); // async Kafka-mottak + DB-polling
 
     const auth = new SkjemaAuthHelper(page);

--- a/tests/skjema/skjema-smoke.spec.ts
+++ b/tests/skjema/skjema-smoke.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { SkjemaAuthHelper } from '../../helpers/skjema-auth-helper';
+
+/**
+ * Røyktest for melosys-skjema-web (digital A1-søknad, utsendt arbeidstaker).
+ *
+ * Dette er den FØRSTE e2e-testen mot skjema-stacken (melosys-skjema-web +
+ * melosys-skjema-api), lagt til docker-compose under "skjema"-profilen.
+ *
+ * Hva den verifiserer (hele kjeden, uten testdata-fixtures):
+ *   wonderwall auto-login → mock-oauth2 (innbygger/ID-porten)
+ *   → skjema-web SPA → BFF TokenX-veksling → skjema-api er oppe og svarer.
+ *
+ * Den bruker BEVISST ren @playwright/test og IKKE ../fixtures: standard-fixturen
+ * gjør Oracle-cleanup, Unleash-reset og melosys-api docker-logg-skanning som er
+ * irrelevant (og støyende) for en ren skjema-web-frontendtest. Tester som faktisk
+ * berører melosys-api/Oracle (Kafka-mottak → sak/behandling) tar inn fixturen.
+ *
+ * Krever stacken oppe: cd ../melosys-docker-compose && make dev-skjema
+ */
+test.describe('skjema-web røyktest', () => {
+  test('innbygger kan logge inn og starte søknad (DEG SELV)', async ({ page }) => {
+    const auth = new SkjemaAuthHelper(page);
+
+    // Steg 1: logg inn som innbygger → rollevalg-siden.
+    await auth.login('12928056706'); // LANSEN LANSANSEN — arbeidstaker NOR → Frankrike
+
+    // Steg 2: rollevalget viser de fire representasjonstypene.
+    await expect(page.getByRole('heading', { name: 'Hvem skal du opptre som?' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'DEG SELV' })).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /ARBEIDSGIVER/ })
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: /RÅDGIVER/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: /PRIVATPERSON/ })).toBeVisible();
+
+    // Steg 3: velg "DEG SELV" → oversiktssiden for søknader.
+    await page.getByRole('button', { name: 'DEG SELV' }).click();
+    await page.waitForURL(/\/oversikt/, { timeout: 30000 });
+
+    // Oversikten lastes (henter utkast/innsendte fra skjema-api via BFF) og viser
+    // inngangen til en ny søknad.
+    await expect(page.getByRole('heading', { name: 'Oversiktsside for søknader' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Start søknad' })).toBeVisible();
+  });
+});

--- a/tests/skjema/skjema-smoke.spec.ts
+++ b/tests/skjema/skjema-smoke.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import { SkjemaAuthHelper } from '../../helpers/skjema-auth-helper';
 
 /**
- * Røyktest for melosys-skjema-web (digital A1-søknad, utsendt arbeidstaker).
+ * Røyktest for melosys-skjema-web (digital «Utsendt arbeidstaker»-søknad).
  *
  * Dette er den FØRSTE e2e-testen mot skjema-stacken (melosys-skjema-web +
  * melosys-skjema-api), lagt til docker-compose under "skjema"-profilen.


### PR DESCRIPTION
Etablerer den første e2e-dekningen for digital «Utsendt arbeidstaker»-søknad (`melosys-skjema-web` + `melosys-skjema-api`) og gjør testene kjørbare på CI.

`melosys-skjema-api` og `melosys-skjema-web` ble nylig lagt til docker-compose, men hadde ingen e2e-tester. Denne PR-en dekker hele kjeden fra innbygger-innlogging til mottak i melosys-api, og speiler skjema-stacken inn i CI-compose-fila slik at testene kan kjøre i pipeline.

- **Tre tester** (bygger oppå hverandre): T0 røyktest (login → rollevalg → oversikt), T1 full innsending (alle steg → kvittering), T2 mottak (Kafka → melosys-api oppretter sak/behandling, korrelert via `SKJEMA_SAK_MAPPING`).
- **Ny infrastruktur**: `SkjemaAuthHelper` (innbygger-login via wonderwall/mock-oauth2), `SoknadUtsendtArbeidstakerPage` (POM) og `SkjemaMottakAssertions` (Oracle-verifisering).
- **CI-oppsett**: skjema-stack (api + web + wonderwall) + tokenx-issuer i mock-oauth2 + `MELOSYS_SKJEMA_API_URL` på melosys-api, lagt i repoets egen `docker-compose.yml`; workflowen pre-puller imagene.
- **CI-spesifikke fikser**: Chromium `--host-resolver-rules` for at nettleseren skal nå `host.docker.internal` (wonderwall-redirect), og subjekt-felt-selektor som tåler både rå mock-oauth2 (CI) og login-proxy (lokalt).

## Designvalg
- T0/T1 bruker ren `@playwright/test` (frontend); T2 bruker `../fixtures` fordi den berører Oracle. Skjema holdes utenfor hoved-helsegaten på CI for ikke å regge saksbehandler-suiten.

## Testing
- [x] Kjørt lokalt (alle tre grønne, stabilt over gjentatte kjøringer)
- [x] E2E på CI grønn — `gh workflow run "E2E Tests" -f environment=latest -f test_grep=skjema-web` ([run 27904422847](https://github.com/navikt/melosys-e2e-tests/actions/runs/27904422847), 3/3)
- [x] `npm run check:tests` (vacuous-test-gate)

## Notes
- T1 (første test i CI-kjøringen) kan time ut på 1. forsøk ved cold-start og passere på retry (`retries=1` fanger det). Verdt å overvåke; evt. en liten warm-up senere.
