### PR TITLE
Fix test_grep with spaces and special characters (e.g. EØS)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -476,31 +476,34 @@ jobs:
             echo "🎚️  Unleash overrides: none (defaults apply)"
           fi
 
-          # Build Playwright command with optional filters
-          PLAYWRIGHT_CMD="npx playwright test --project=chromium"
+          # Build Playwright command arguments as an array.
+          # Using an array instead of string + eval ensures arguments with
+          # spaces or special characters (e.g. "EØS Medlemskap Lovvalg")
+          # are passed correctly to Playwright as a single --grep value.
+          PLAYWRIGHT_ARGS=(test --project=chromium)
 
           # Add test filter if specified
-          if [ -n "${{ inputs.test_grep }}" ]; then
-            echo "🔍 Filtering tests with pattern: ${{ inputs.test_grep }}"
-            PLAYWRIGHT_CMD="$PLAYWRIGHT_CMD --grep '${{ inputs.test_grep }}'"
+          if [ -n "$TEST_GREP" ]; then
+            echo "🔍 Filtering tests with pattern: $TEST_GREP"
+            PLAYWRIGHT_ARGS+=(--grep "$TEST_GREP")
           fi
 
           # Add repeat count if specified (for race condition testing)
           if [ "${{ inputs.repeat_each }}" -gt 1 ]; then
             echo "🔄 Running each test ${{ inputs.repeat_each }} times"
-            PLAYWRIGHT_CMD="$PLAYWRIGHT_CMD --repeat-each ${{ inputs.repeat_each }}"
+            PLAYWRIGHT_ARGS+=(--repeat-each "${{ inputs.repeat_each }}")
           fi
 
           # Disable retries if specified (for accurate race condition detection)
           if [ "${{ inputs.disable_retries }}" = "true" ]; then
             echo "🚫 Retries disabled"
-            PLAYWRIGHT_CMD="$PLAYWRIGHT_CMD --retries 0"
+            PLAYWRIGHT_ARGS+=(--retries 0)
           fi
 
-          echo "🎭 Running: $PLAYWRIGHT_CMD"
+          echo "🎭 Running: npx playwright ${PLAYWRIGHT_ARGS[*]}"
 
           # Run tests and capture exit code (don't fail immediately)
-          eval $PLAYWRIGHT_CMD || PLAYWRIGHT_EXIT_CODE=$?
+          npx playwright "${PLAYWRIGHT_ARGS[@]}" || PLAYWRIGHT_EXIT_CODE=$?
 
           # Check if test-summary.json was created by reporter
           if [ -f "playwright-report/test-summary.json" ]; then
@@ -540,6 +543,7 @@ jobs:
           fi
         env:
           CI: true
+          TEST_GREP: ${{ inputs.test_grep }}
           RETRIES_DISABLED: ${{ inputs.disable_retries == true }}
           RECORD_API: ${{ inputs.record_api == true && 'true' || '' }}
           UNLEASH_FORCE_DISABLE: ${{ inputs.unleash_force_disable }}


### PR DESCRIPTION
## Problem

The `test_grep` workflow input did not work when the value contained spaces or special characters like `Ø`.

For example, filtering with `EØS Medlemskap Lovvalg - Offentlig tjenesteperson 11.3b med trygdeavgift` found no tests.

## Cause

The old code built a command string and ran it with `eval`:

```bash
PLAYWRIGHT_CMD="$PLAYWRIGHT_CMD --grep '${{ inputs.test_grep }}'"
eval $PLAYWRIGHT_CMD
```

GitHub Actions substitutes `${{ inputs.test_grep }}` into the script before the shell runs. The `eval` + nested quoting then splits the grep value on spaces, so Playwright only received the first word (`EØS`) as the pattern.

## Fix

Replace string concatenation + `eval` with a **bash array**:

```bash
PLAYWRIGHT_ARGS+=(--grep "$TEST_GREP")
npx playwright "${PLAYWRIGHT_ARGS[@]}"
```

The array preserves the full string as a single argument. The input is also passed via an env variable (`TEST_GREP`) instead of inline `${{ }}` substitution, since env variables work with normal shell quoting rules.