### PR TITLE
E2E «Utsendt arbeidstaker»: arbeidsgiver (T1b) + samme-sak-kobling (T3) + rådgiver (T1c) + CI-gating

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -325,6 +325,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PASSWORD: ${{ secrets.READER_TOKEN }}
 
+      - name: Determine skjema scope
+        # Skjema-stacken (digital «Utsendt arbeidstaker»-søknad: skjema-api/-web/-web-auth +
+        # full-flow-oppvarmingen) er kostbar og trengs bare når skjema-tester faktisk kjører.
+        # Den er i scope når det IKKE er filtrert (full suite kjører skjema) ELLER test_grep
+        # nevner «skjema». Da settes COMPOSE_PROFILES=skjema (aktiverer profiled-tjenestene) for
+        # alle påfølgende `docker compose`-kall. Ellers hoppes pull/start/vent/oppvarming over.
+        run: |
+          if [ -z "${{ inputs.test_grep }}" ] || echo "${{ inputs.test_grep }}" | grep -qi skjema; then
+            echo "🧩 Skjema-tester i scope → starter skjema-stack + oppvarming"
+            echo "SKJEMA_IN_SCOPE=true" >> "$GITHUB_ENV"
+            echo "COMPOSE_PROFILES=skjema" >> "$GITHUB_ENV"
+          else
+            echo "🧩 Skjema-tester IKKE i scope → hopper over skjema-stack + oppvarming"
+            echo "SKJEMA_IN_SCOPE=false" >> "$GITHUB_ENV"
+            echo "SKIP_SKJEMA_WARMUP=true" >> "$GITHUB_ENV"
+          fi
+
       - name: Pre-pull Docker images in parallel
         run: |
           echo "🐳 Pre-pulling Docker images to avoid timeout during compose up..."
@@ -345,10 +362,12 @@ jobs:
           docker pull --platform linux/amd64 ghcr.io/navikt/mock-oauth2-server:2.3.0 &
           docker pull --platform linux/amd64 ghcr.io/navikt/mock-oauth2-server:0.4.8 &
           docker pull --platform linux/amd64 unleashorg/unleash-server:latest &
-          # Skjema-stack (digital «Utsendt arbeidstaker»-søknad)
-          docker pull --platform linux/amd64 europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-skjema-api:latest &
-          docker pull --platform linux/amd64 europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-skjema-web:latest &
-          docker pull --platform linux/amd64 ghcr.io/nais/wonderwall:latest &
+          # Skjema-stack (digital «Utsendt arbeidstaker»-søknad) — kun når skjema er i scope.
+          if [ "$SKJEMA_IN_SCOPE" = "true" ]; then
+            docker pull --platform linux/amd64 europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-skjema-api:latest &
+            docker pull --platform linux/amd64 europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-skjema-web:latest &
+            docker pull --platform linux/amd64 ghcr.io/nais/wonderwall:latest &
+          fi
           wait
           echo "✅ All images pre-pulled successfully"
 
@@ -443,6 +462,7 @@ jobs:
           echo "ℹ️  Note: Feature toggles are automatically created by melosys-api on startup"
 
       - name: Wait for skjema stack (best-effort)
+        if: env.SKJEMA_IN_SCOPE == 'true'
         run: |
           # Skjema-tjenestene er ikke i hoved-helsegaten over (for å ikke regge den
           # eksisterende suiten). Gi wonderwall/web tid til å svare før testene starter.
@@ -528,6 +548,14 @@ jobs:
             echo "  ✨ Known Error (Passed): $KNOWN_ERROR_PASSED"
             echo "  📊 Total: $TOTAL"
             echo ""
+
+            # Vakt mot falsk grønn: en collection-/import-feil (f.eks. en stale import-sti) gjør at
+            # Playwright laster INGEN tester, men reporteren rapporterer da «passed» med 0 tester.
+            # En reell E2E-kjøring samler alltid >0 tester (også test_grep skal matche noe), så 0 = feil.
+            if [ "${TOTAL:-0}" -eq 0 ]; then
+              echo "❌ CI Status: FAILED — 0 tester ble samlet/kjørt (sannsynlig collection-/import-feil, eller test_grep matchet ingenting). Feiler for å unngå falsk grønn."
+              exit 1
+            fi
 
             if [ "$CI_STATUS" = "passed" ]; then
               echo "✅ CI Status: PASSED (known-error tests don't fail the build)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -627,6 +627,9 @@ services:
   melosys-skjema-api:
     image: europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-skjema-api:${MELOSYS_SKJEMA_API_TAG:-latest}
     container_name: melosys-skjema-api
+    # Skjema-stacken startes kun når skjema-tester er i scope (workflowen setter
+    # COMPOSE_PROFILES=skjema). Saksbehandler-fokuserte kjøringer slipper kostnaden.
+    profiles: ["skjema"]
     depends_on:
       postgres:
         condition: service_healthy
@@ -662,6 +665,7 @@ services:
   melosys-skjema-web:
     image: europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-skjema-web:${MELOSYS_SKJEMA_WEB_TAG:-latest}
     container_name: melosys-skjema-web
+    profiles: ["skjema"]
     depends_on:
       melosys-skjema-api:
         condition: service_started
@@ -694,6 +698,7 @@ services:
   melosys-skjema-web-auth:
     image: ghcr.io/nais/wonderwall:latest
     container_name: melosys-skjema-web-auth
+    profiles: ["skjema"]
     depends_on:
       - melosys-skjema-web
       - mock-oauth2-server

--- a/pages/skjema/skjema-mottak.assertions.ts
+++ b/pages/skjema/skjema-mottak.assertions.ts
@@ -1,5 +1,6 @@
-import { expect } from '@playwright/test';
+import { APIRequestContext, expect } from '@playwright/test';
 import { withDatabase } from '../../helpers/db-helper';
+import { withPgDatabase } from '../../helpers/pg-db-helper';
 
 /**
  * Assertions for at en digital «Utsendt arbeidstaker»-søknad sendt fra skjema-web blir mottatt av melosys-api
@@ -17,15 +18,9 @@ export class SkjemaMottakAssertions {
     skjemaId: string,
     timeoutMs = 45000
   ): Promise<{ saksnummer: string; journalpostId: string | null }> {
-    const hex = skjemaId.replace(/-/g, '').toUpperCase();
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
-      const row = await withDatabase(async (db) =>
-        db.queryOne<{ SAKSNUMMER: string; JOURNALPOST_ID: string | null }>(
-          `SELECT SAKSNUMMER, JOURNALPOST_ID FROM SKJEMA_SAK_MAPPING WHERE SKJEMA_ID = HEXTORAW(:hex)`,
-          { hex }
-        )
-      );
+      const row = await this.hentMapping(skjemaId);
       if (row?.SAKSNUMMER) {
         console.log(`✅ melosys-api opprettet sak ${row.SAKSNUMMER} for skjema ${skjemaId}`);
         return { saksnummer: row.SAKSNUMMER, journalpostId: row.JOURNALPOST_ID ?? null };
@@ -38,10 +33,45 @@ export class SkjemaMottakAssertions {
     );
   }
 
+  /** Slå opp én SKJEMA_SAK_MAPPING-rad på skjema-id (Oracle RAW(16) → HEXTORAW). */
+  private async hentMapping(
+    skjemaId: string
+  ): Promise<{ SAKSNUMMER: string; JOURNALPOST_ID: string | null } | null> {
+    const hex = skjemaId.replace(/-/g, '').toUpperCase();
+    return withDatabase((db) =>
+      db.queryOne<{ SAKSNUMMER: string; JOURNALPOST_ID: string | null }>(
+        `SELECT SAKSNUMMER, JOURNALPOST_ID FROM SKJEMA_SAK_MAPPING WHERE SKJEMA_ID = HEXTORAW(:hex)`,
+        { hex }
+      )
+    );
+  }
+
   /**
-   * Verifiser at saksnummeret peker på en fagsak med en utsendt-arbeidstaker-førstegangsbehandling.
+   * Poll til journalføring er ferdig (SKJEMA_SAK_MAPPING.JOURNALPOST_ID satt) og returner journalpost-id-en.
+   * Journalføringen er et eget asynkront saga-steg etter at sak/behandling er opprettet.
    */
-  async verifiserSakOgBehandling(saksnummer: string): Promise<void> {
+  async ventPaaJournalpostForSkjema(skjemaId: string, timeoutMs = 45000): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const row = await this.hentMapping(skjemaId);
+      if (row?.JOURNALPOST_ID) return row.JOURNALPOST_ID;
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+    throw new Error(
+      `JOURNALPOST_ID ble ikke satt for skjema ${skjemaId} innen ${timeoutMs} ms — journalføringen (OpprettOgFerdigstillJournalpostDigitalSøknad) fullførte ikke.`
+    );
+  }
+
+  /**
+   * Verifiser at saksnummeret peker på en fagsak med en utsendt-arbeidstaker-behandling.
+   * @param forventet.behType  default FØRSTEGANG.
+   */
+  async verifiserSakOgBehandling(
+    saksnummer: string,
+    forventet: { behTema?: string; behType?: string } = {}
+  ): Promise<void> {
+    const behTema = forventet.behTema ?? 'UTSENDT_ARBEIDSTAKER';
+    const behType = forventet.behType ?? 'FØRSTEGANG';
     await withDatabase(async (db) => {
       const fagsak = await db.queryOne<{ SAKSNUMMER: string; STATUS: string }>(
         `SELECT SAKSNUMMER, STATUS FROM FAGSAK WHERE SAKSNUMMER = :s`,
@@ -55,13 +85,142 @@ export class SkjemaMottakAssertions {
         { s: saksnummer }
       );
       expect(beh, `BEHANDLING for ${saksnummer} skal finnes`).not.toBeNull();
-      expect(beh!.BEH_TEMA, 'behandlingstema').toBe('UTSENDT_ARBEIDSTAKER');
-      expect(beh!.BEH_TYPE, 'behandlingstype').toBe('FØRSTEGANG');
+      expect(beh!.BEH_TEMA, 'behandlingstema').toBe(behTema);
+      expect(beh!.BEH_TYPE, 'behandlingstype').toBe(behType);
 
       console.log(
         `✅ Fagsak ${saksnummer} (${fagsak!.STATUS}) / behandling ${beh!.ID} ` +
           `(${beh!.BEH_TEMA}/${beh!.BEH_TYPE}, ${beh!.STATUS})`
       );
     });
+  }
+
+  /** Antall fagsaker totalt (databasen ryddes per test, så dette er saker opprettet i testen). */
+  async tellFagsaker(): Promise<number> {
+    return withDatabase(async (db) => {
+      const row = await db.queryOne<{ ANTALL: number }>(`SELECT COUNT(*) AS ANTALL FROM FAGSAK`);
+      return Number(row?.ANTALL ?? 0);
+    });
+  }
+
+  /** Antall behandlinger på en fagsak. */
+  async tellBehandlinger(saksnummer: string): Promise<number> {
+    return withDatabase(async (db) => {
+      const row = await db.queryOne<{ ANTALL: number }>(
+        `SELECT COUNT(*) AS ANTALL FROM BEHANDLING WHERE SAKSNUMMER = :s`,
+        { s: saksnummer }
+      );
+      return Number(row?.ANTALL ?? 0);
+    });
+  }
+
+  /**
+   * Poll til den nyeste behandlingen på saken har forventet status. Statusovergangene skjer i
+   * asynkrone saga-steg (AG-del-mottak setter AVVENT_DOK_PART, AT-del-mottak setter VURDER_DOKUMENT).
+   */
+  async ventPaaBehandlingStatus(
+    saksnummer: string,
+    forventetStatus: string,
+    timeoutMs = 45000
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    let sisteStatus: string | null = null;
+    while (Date.now() < deadline) {
+      sisteStatus = await withDatabase((db) =>
+        db
+          .queryOne<{ STATUS: string }>(
+            `SELECT STATUS FROM BEHANDLING WHERE SAKSNUMMER = :s ORDER BY ID DESC FETCH FIRST 1 ROWS ONLY`,
+            { s: saksnummer }
+          )
+          .then((r) => r?.STATUS ?? null)
+      );
+      if (sisteStatus === forventetStatus) {
+        console.log(`✅ Behandling på ${saksnummer} har status ${forventetStatus}`);
+        return;
+      }
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+    throw new Error(
+      `Behandlingen på ${saksnummer} fikk ikke status ${forventetStatus} innen ${timeoutMs} ms (siste status: ${sisteStatus}).`
+    );
+  }
+
+  /**
+   * Poll skjema-api (Postgres `melosys-skjema`.innsending) til saksnummeret fra melosys-api er
+   * registrert tilbake via M2M-callback (POST /m2m/api/skjema/{id}/saksnummer).
+   */
+  async ventPaaSaksnummerISkjemaApi(
+    skjemaId: string,
+    forventetSaksnummer: string,
+    timeoutMs = 30000
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    let sisteVerdi: string | null = null;
+    while (Date.now() < deadline) {
+      sisteVerdi = await withPgDatabase('melosys-skjema', (db) =>
+        db
+          .queryOne<{ saksnummer: string | null }>(
+            `SELECT saksnummer FROM innsending WHERE skjema_id = $1::uuid`,
+            [skjemaId]
+          )
+          .then((r) => r?.saksnummer ?? null)
+      );
+      if (sisteVerdi === forventetSaksnummer) {
+        console.log(`✅ skjema-api registrerte saksnummer ${forventetSaksnummer} for skjema ${skjemaId}`);
+        return;
+      }
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+    throw new Error(
+      `skjema-api (innsending.saksnummer) fikk ikke saksnummer ${forventetSaksnummer} for skjema ${skjemaId} ` +
+        `innen ${timeoutMs} ms (siste verdi: ${sisteVerdi}). Sjekk SEND_SAKSNUMMER_TIL_MELOSYS_SKJEMA_API-steget.`
+    );
+  }
+
+  /**
+   * Verifiser at en innsendt del er journalført i Joark/SAF-mock og at det opplastede vedlegget
+   * ligger på journalposten. Journalposten finnes via eksternReferanseId = referansenummeret, og
+   * melosys-api setter vedleggets dokument-tittel = filnavnet (OpprettOgFerdigstillJournalpostDigitalSøknad).
+   */
+  async verifiserDelJournalfoertMedVedlegg(
+    request: APIRequestContext,
+    referanse: string,
+    vedleggFilnavn: string,
+    timeoutMs = 30000
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    let sisteFunn = 'ingen journalpost';
+    while (Date.now() < deadline) {
+      const response = await request.get('http://localhost:8083/testdata/verification/journalpost');
+      if (response.ok()) {
+        const journalposter = (await response.json()) as Array<{
+          journalpostId: string;
+          journalposttype: string | null;
+          eksternReferanseId: string | null;
+          dokumentModellList?: Array<{ tittel: string | null; dokumentTilknyttetJournalpost: string | null }>;
+        }>;
+        const jp = journalposter.find(
+          (j) => j.eksternReferanseId === referanse && j.journalposttype === 'INNGAAENDE'
+        );
+        if (jp) {
+          const dokumenter = jp.dokumentModellList ?? [];
+          const harVedlegg = dokumenter.some((d) => d.tittel === vedleggFilnavn);
+          if (harVedlegg) {
+            console.log(
+              `✅ Vedlegg «${vedleggFilnavn}» journalført på journalpost ${jp.journalpostId} (ref ${referanse})`
+            );
+            return;
+          }
+          sisteFunn = `journalpost ${jp.journalpostId} uten vedlegg-dokument (dok: ${dokumenter
+            .map((d) => d.tittel)
+            .join(', ')})`;
+        }
+      }
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+    throw new Error(
+      `Fant ikke vedlegget «${vedleggFilnavn}» på en INNGAAENDE journalpost med eksternReferanseId ${referanse} ` +
+        `innen ${timeoutMs} ms (siste funn: ${sisteFunn}).`
+    );
   }
 }

--- a/pages/skjema/skjema-mottak.assertions.ts
+++ b/pages/skjema/skjema-mottak.assertions.ts
@@ -223,4 +223,26 @@ export class SkjemaMottakAssertions {
         `innen ${timeoutMs} ms (siste funn: ${sisteFunn}).`
     );
   }
+
+  /**
+   * Verifiser at melosys-api mottok forventede metadata-verdier. ORIGINAL_DATA i SKJEMA_SAK_MAPPING
+   * er hele M2M-DTO-en (CLOB JSON, inkl. skjema.metadata), så vi kan bekrefte at f.eks.
+   * rådgiverfirma-orgnr, fullmektig-fnr og representasjonstype fulgte med fra skjema-web til melosys-api.
+   */
+  async verifiserOriginalDataInneholder(skjemaId: string, forventetInnhold: string[]): Promise<void> {
+    const hex = skjemaId.replace(/-/g, '').toUpperCase();
+    const original = await withDatabase((db) =>
+      db
+        .queryOne<{ ORIGINAL_DATA: string }>(
+          `SELECT ORIGINAL_DATA FROM SKJEMA_SAK_MAPPING WHERE SKJEMA_ID = HEXTORAW(:hex)`,
+          { hex }
+        )
+        .then((r) => r?.ORIGINAL_DATA ?? null)
+    );
+    expect(original, `ORIGINAL_DATA skal finnes for skjema ${skjemaId}`).not.toBeNull();
+    for (const innhold of forventetInnhold) {
+      expect(original!, `ORIGINAL_DATA skal inneholde «${innhold}»`).toContain(innhold);
+    }
+    console.log(`✅ ORIGINAL_DATA for ${skjemaId} inneholder: ${forventetInnhold.join(', ')}`);
+  }
 }

--- a/pages/skjema/skjema-utils.ts
+++ b/pages/skjema/skjema-utils.ts
@@ -1,0 +1,43 @@
+import { Page } from '@playwright/test';
+
+/**
+ * Delte hjelpere for «Utsendt arbeidstaker»-søknaden i melosys-skjema-web.
+ *
+ * Brukes av både DEG SELV-POM-en (soknad-utsendt-arbeidstaker.page.ts) og
+ * arbeidsgiver-POM-en (soknad-arbeidsgiver.page.ts). Holdes som frittstående
+ * funksjoner (ikke metoder) slik at begge POM-ene kan dele dem uten arv.
+ */
+
+/** dd.mm.yyyy — formatet Aksel DatePicker forventer på norsk. */
+export function ddmmyyyy(d: Date): string {
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${p(d.getDate())}.${p(d.getMonth() + 1)}.${d.getFullYear()}`;
+}
+
+/**
+ * En utsendingsperiode godt innenfor 24-måneders-grensen, beregnet relativt til i dag
+ * (1. i neste måned → +6 måneder) så testen ikke ruster. Begge skjemadeler i en
+ * kobling-test (T3) må dele EN periode for å overlappe — beregn én gang og send inn.
+ */
+export function standardUtsendingsperiode(): { fraDato: string; tilDato: string } {
+  const fra = new Date();
+  fra.setMonth(fra.getMonth() + 1, 1);
+  const til = new Date(fra);
+  til.setMonth(til.getMonth() + 6);
+  return { fraDato: ddmmyyyy(fra), tilDato: ddmmyyyy(til) };
+}
+
+/**
+ * Svar på en Aksel RadioGroup. Aksel rendrer `<fieldset role="radiogroup">` med legend
+ * som tilgjengelig navn — id-er er dynamiske, så vi scoper på legend og velger radioen
+ * på dens tilgjengelige navn.
+ */
+export async function svarRadio(page: Page, gruppe: RegExp, svar: string): Promise<void> {
+  await page.getByRole('radiogroup', { name: gruppe }).getByRole('radio', { name: svar }).check();
+}
+
+/** Klikk «Lagre og fortsett» og vent på neste steg-URL. */
+export async function lagreOgFortsett(page: Page, nesteUrl: RegExp): Promise<void> {
+  await page.getByRole('button', { name: 'Lagre og fortsett' }).click();
+  await page.waitForURL(nesteUrl);
+}

--- a/pages/skjema/soknad-arbeidsgiver.page.ts
+++ b/pages/skjema/soknad-arbeidsgiver.page.ts
@@ -47,10 +47,51 @@ export class SoknadArbeidsgiverPage {
     medFullmakt: boolean;
     arbeidstakerEtternavn?: string;
   }): Promise<string> {
-    const page = this.page;
-    await page.getByRole('button', { name: /^ARBEIDSGIVER/ }).click();
-    await page.waitForURL(/\/oversikt/);
+    await this.page.getByRole('button', { name: /^ARBEIDSGIVER/ }).click();
+    await this.page.waitForURL(/\/oversikt/);
+    return this.velgVirksomhetArbeidstakerOgStart(opts);
+  }
 
+  /**
+   * Som {@link velgArbeidsgiverOgStart}, men via rollevalg RÅDGIVER: et ekstra steg velger
+   * rådgivingsfirmaet (fritt org.nr-/EREG-oppslag — ikke Altinn-begrenset, så en hvilken som
+   * helst innlogget bruker kan opptre som rådgiver). Arbeidsgiver + arbeidstaker velges deretter
+   * på samme oversikt som arbeidsgiver-flyten (arbeidsgiver fra Altinn-tilganger, arbeidstaker
+   * fra fullmakt). medFullmakt=true gir RADGIVER_MED_FULLMAKT (begge deler).
+   *
+   * @param opts.radgiverfirmaOrgnr  org.nr til rådgivingsfirmaet (EREG-oppslag).
+   * @param opts.radgiverfirmaNavn   forventet firmanavn (ventes på før «Ok», bekrefter EREG-treff).
+   */
+  async velgRadgiverOgStart(opts: {
+    radgiverfirmaOrgnr: string;
+    radgiverfirmaNavn: string;
+    arbeidsgiverOrgnr: string;
+    arbeidstakerFnr: string;
+    medFullmakt: boolean;
+    arbeidstakerEtternavn?: string;
+  }): Promise<string> {
+    const page = this.page;
+    await page.getByRole('button', { name: /^RÅDGIVER/ }).click();
+    await page.waitForURL(/\/velg-radgiverfirma/);
+    await page.getByRole('textbox', { name: /Søk på virksomhet/ }).fill(opts.radgiverfirmaOrgnr);
+    // Vent på at EREG-oppslaget rendrer firmanavnet før vi bekrefter.
+    await expect(page.getByText(opts.radgiverfirmaNavn)).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'Ok', exact: true }).click();
+    await page.waitForURL(/\/oversikt/);
+    return this.velgVirksomhetArbeidstakerOgStart(opts);
+  }
+
+  /**
+   * Felles oversikt-logikk (delt av arbeidsgiver- og rådgiver-rollevalget): velg virksomhet,
+   * velg/oppgi arbeidstaker, bekreft og start. Forutsetter at vi står på /oversikt.
+   */
+  private async velgVirksomhetArbeidstakerOgStart(opts: {
+    arbeidsgiverOrgnr: string;
+    arbeidstakerFnr: string;
+    medFullmakt: boolean;
+    arbeidstakerEtternavn?: string;
+  }): Promise<string> {
+    const page = this.page;
     // Velg arbeidsgiver i Aksel-comboboxen (Altinn-tilganger). Filtrer på orgnr og velg treffet.
     const arbeidsgiverCombo = page.getByRole('combobox', { name: /Velg arbeidsgiver/ });
     await arbeidsgiverCombo.click();
@@ -164,7 +205,37 @@ export class SoknadArbeidsgiverPage {
       arbeidstakerFnr: opts.arbeidstakerFnr,
       medFullmakt: true,
     });
-    await this.fyllUtsendingsperiodeOgLand(opts.land);
+    const referanse = await this.fyllAlleStegBeggeDeler(opts.land, opts.vedleggFilsti);
+    return { skjemaId, referanse };
+  }
+
+  /**
+   * Full innsending som RÅDGIVER med fullmakt — fyller ut BEGGE deler (11 steg) på vegne av et
+   * rådgivingsfirma. Som begge-deler-flyten, men med et innledende rådgiverfirma-valg.
+   * @returns søknads-id (UUID) og referansenummer fra kvitteringen.
+   */
+  async fyllUtOgSendInnRadgiverBeggeDeler(opts: {
+    radgiverfirmaOrgnr: string;
+    radgiverfirmaNavn: string;
+    arbeidsgiverOrgnr: string;
+    arbeidstakerFnr: string;
+    land?: string;
+    vedleggFilsti?: string;
+  }): Promise<{ skjemaId: string; referanse: string }> {
+    const skjemaId = await this.velgRadgiverOgStart({
+      radgiverfirmaOrgnr: opts.radgiverfirmaOrgnr,
+      radgiverfirmaNavn: opts.radgiverfirmaNavn,
+      arbeidsgiverOrgnr: opts.arbeidsgiverOrgnr,
+      arbeidstakerFnr: opts.arbeidstakerFnr,
+      medFullmakt: true,
+    });
+    const referanse = await this.fyllAlleStegBeggeDeler(opts.land, opts.vedleggFilsti);
+    return { skjemaId, referanse };
+  }
+
+  /** Fyll ut alle steg for begge-deler-varianten (steg 1-5 AG + AT-steg + hale) og send inn. */
+  private async fyllAlleStegBeggeDeler(land?: string, vedleggFilsti?: string): Promise<string> {
+    await this.fyllUtsendingsperiodeOgLand(land);
     await this.fyllArbeidsgiverensVirksomhet();
     await this.fyllUtenlandsoppdraget();
     await this.fyllArbeidssted();
@@ -174,9 +245,8 @@ export class SoknadArbeidsgiverPage {
     await this.felles.fyllSkatteforholdOgInntekt();
     await this.felles.fyllFamiliemedlemmer();
     await this.felles.fyllTilleggsopplysninger();
-    await this.felles.fyllVedlegg(opts.vedleggFilsti);
-    const referanse = await this.felles.sendInnOgHentReferanse();
-    return { skjemaId, referanse };
+    await this.felles.fyllVedlegg(vedleggFilsti);
+    return this.felles.sendInnOgHentReferanse();
   }
 
   /**

--- a/pages/skjema/soknad-arbeidsgiver.page.ts
+++ b/pages/skjema/soknad-arbeidsgiver.page.ts
@@ -72,11 +72,13 @@ export class SoknadArbeidsgiverPage {
       ).toBeTruthy();
       await svarRadio(page, /Skal du fylle ut søknaden for arbeidstaker/, 'Nei');
       await page.getByRole('textbox', { name: 'Fødsels-/d-nummer' }).fill(opts.arbeidstakerFnr);
-      await page.getByRole('textbox', { name: 'Etternavn' }).fill(opts.arbeidstakerEtternavn!);
-      // To knapper heter «Søk» (denne + tabellsøket lenger ned); verifiseringsknappen er først i DOM.
-      await page.getByRole('button', { name: 'Søk', exact: true }).first().click();
-      // Vent på at personen er verifisert (vises som «NAVN - fnr») før vi kan starte.
-      await expect(page.getByText(new RegExp(opts.arbeidstakerFnr))).toBeVisible();
+      const etternavnFelt = page.getByRole('textbox', { name: 'Etternavn' });
+      await etternavnFelt.fill(opts.arbeidstakerEtternavn!);
+      // Flere knapper heter «Søk» (toppmeny-søk + evt. tabellsøk i «Tidligere innsendte»);
+      // verifiseringsknappen er den første «Søk» etter etternavn-feltet i DOM.
+      await etternavnFelt.locator('xpath=following::button[normalize-space()="Søk"][1]').click();
+      // Vent på at personen er verifisert (vises som «NAVN - fnr») før vi kan starte (PDL-oppslag).
+      await expect(page.getByText(new RegExp(opts.arbeidstakerFnr))).toBeVisible({ timeout: 15000 });
     }
 
     await page.getByRole('checkbox', { name: /Jeg bekrefter/ }).check();

--- a/pages/skjema/soknad-arbeidsgiver.page.ts
+++ b/pages/skjema/soknad-arbeidsgiver.page.ts
@@ -1,0 +1,208 @@
+import { Page, expect } from '@playwright/test';
+import {
+  SoknadUtsendtArbeidstakerPage,
+  hentSkjemaIdFraUrl,
+} from './soknad-utsendt-arbeidstaker.page';
+import { lagreOgFortsett, standardUtsendingsperiode, svarRadio } from './skjema-utils';
+
+/**
+ * Page Object for den digitale «Utsendt arbeidstaker»-søknaden, variant ARBEIDSGIVER.
+ *
+ * Dekker de to arbeidsgiver-variantene (verifisert live 2026-06-28):
+ *  - **Begge deler** («Skal du fylle ut søknaden for arbeidstaker?» = Ja, med fullmakt):
+ *    11 steg, skjemadel ARBEIDSGIVER_OG_ARBEIDSTAKERS_DEL.
+ *  - **Kun arbeidsgiver-del** (= Nei, oppgir arbeidstaker manuelt): 8 steg (ingen AT-steg),
+ *    skjemadel ARBEIDSGIVERS_DEL → melosys-api setter behandling AVVENT_DOK_PART (T3).
+ *
+ * De fire arbeidsgiver-stegene (arbeidsgiverens-virksomhet-i-norge, utenlandsoppdraget,
+ * arbeidssted-i-utlandet, arbeidstakerens-lonn) finnes kun her. Arbeidstaker-stegene
+ * (arbeidssituasjon/skatteforhold/familiemedlemmer) og hale-stegene (tilleggsopplysninger/
+ * vedlegg/oppsummering/kvittering) er identiske med DEG SELV og gjenbrukes via en komponert
+ * {@link SoknadUtsendtArbeidstakerPage}.
+ *
+ * Egen POM (utvider IKKE BasePage) av samme grunn som DEG SELV-POM-en.
+ */
+export class SoknadArbeidsgiverPage {
+  /** Komponert DEG SELV-POM som leverer de delte AT- og hale-stegene. */
+  private readonly felles: SoknadUtsendtArbeidstakerPage;
+
+  constructor(private page: Page) {
+    this.felles = new SoknadUtsendtArbeidstakerPage(page);
+  }
+
+  /**
+   * Fra rollevalg-siden (/representasjon): velg ARBEIDSGIVER, velg organisasjon (Altinn-tilgang),
+   * velg/oppgi arbeidstaker, bekreft og start søknaden.
+   *
+   * @param opts.arbeidsgiverOrgnr  organisasjonen du har Altinn-tilgang til (f.eks. 999999999).
+   * @param opts.arbeidstakerFnr    arbeidstakerens fødselsnummer.
+   * @param opts.medFullmakt        true = fyll ut for begge (krever fullmakt fra arbeidstaker);
+   *                                 false = send kun arbeidsgiver-delen, arbeidstaker fyller ut selv.
+   * @param opts.arbeidstakerEtternavn  påkrevd når medFullmakt=false (PDL-oppslag på navn + fnr).
+   * @returns søknads-id (UUID) fra URL-en.
+   */
+  async velgArbeidsgiverOgStart(opts: {
+    arbeidsgiverOrgnr: string;
+    arbeidstakerFnr: string;
+    medFullmakt: boolean;
+    arbeidstakerEtternavn?: string;
+  }): Promise<string> {
+    const page = this.page;
+    await page.getByRole('button', { name: /^ARBEIDSGIVER/ }).click();
+    await page.waitForURL(/\/oversikt/);
+
+    // Velg arbeidsgiver i Aksel-comboboxen (Altinn-tilganger). Filtrer på orgnr og velg treffet.
+    const arbeidsgiverCombo = page.getByRole('combobox', { name: /Velg arbeidsgiver/ });
+    await arbeidsgiverCombo.click();
+    await arbeidsgiverCombo.fill(opts.arbeidsgiverOrgnr);
+    await page.getByRole('option', { name: new RegExp(`\\(${opts.arbeidsgiverOrgnr}\\)`) }).click();
+
+    if (opts.medFullmakt) {
+      // «Ja» → velg arbeidstaker fra fullmakt-lista (begge deler).
+      await svarRadio(page, /Skal du fylle ut søknaden for arbeidstaker/, 'Ja');
+      const arbeidstakerCombo = page.getByRole('combobox', { name: /Velg arbeidstaker/ });
+      await arbeidstakerCombo.click();
+      await arbeidstakerCombo.fill(opts.arbeidstakerFnr);
+      await page.getByRole('option', { name: new RegExp(opts.arbeidstakerFnr) }).click();
+    } else {
+      // «Nei» → oppgi arbeidstaker manuelt og verifiser mot PDL (kun arbeidsgiver-del).
+      expect(
+        opts.arbeidstakerEtternavn,
+        'arbeidstakerEtternavn er påkrevd når medFullmakt=false'
+      ).toBeTruthy();
+      await svarRadio(page, /Skal du fylle ut søknaden for arbeidstaker/, 'Nei');
+      await page.getByRole('textbox', { name: 'Fødsels-/d-nummer' }).fill(opts.arbeidstakerFnr);
+      await page.getByRole('textbox', { name: 'Etternavn' }).fill(opts.arbeidstakerEtternavn!);
+      // To knapper heter «Søk» (denne + tabellsøket lenger ned); verifiseringsknappen er først i DOM.
+      await page.getByRole('button', { name: 'Søk', exact: true }).first().click();
+      // Vent på at personen er verifisert (vises som «NAVN - fnr») før vi kan starte.
+      await expect(page.getByText(new RegExp(opts.arbeidstakerFnr))).toBeVisible();
+    }
+
+    await page.getByRole('checkbox', { name: /Jeg bekrefter/ }).check();
+    await page.getByRole('button', { name: 'Start søknad' }).click();
+
+    await page.waitForURL(/\/skjema\/[^/]+\/utsendingsperiode-og-land/);
+    return hentSkjemaIdFraUrl(page);
+  }
+
+  // ---- Arbeidsgiver-spesifikke steg ------------------------------------------------------
+
+  /** Steg 1: utsendingsperiode og land. Går videre til arbeidsgiverens-virksomhet-i-norge. */
+  async fyllUtsendingsperiodeOgLand(land = 'Frankrike'): Promise<void> {
+    const page = this.page;
+    await expect(page.getByRole('heading', { name: 'Utsendingsperiode og land' })).toBeVisible();
+    await page.getByLabel('I hvilket land skal arbeidet utføres?').selectOption({ label: land });
+
+    const { fraDato, tilDato } = standardUtsendingsperiode();
+    await page.getByRole('textbox', { name: 'Fra dato' }).fill(fraDato);
+    await page.getByRole('textbox', { name: 'Til dato' }).fill(tilDato);
+
+    await lagreOgFortsett(page, /\/arbeidsgiverens-virksomhet-i-norge/);
+  }
+
+  /** Steg 2: arbeidsgiverens virksomhet i Norge (privat virksomhet med ordinær drift). */
+  async fyllArbeidsgiverensVirksomhet(): Promise<void> {
+    const page = this.page;
+    await svarRadio(page, /offentlig virksomhet/, 'Nei');
+    // «bemannings-/vikarbyrå» og «opprettholder vanlig drift» dukker først opp etter «Nei» over.
+    await svarRadio(page, /bemannings- eller vikarbyrå/, 'Nei');
+    await svarRadio(page, /Opprettholder arbeidsgiveren vanlig drift/, 'Ja');
+    await lagreOgFortsett(page, /\/utenlandsoppdraget/);
+  }
+
+  /** Steg 3: utenlandsoppdraget. */
+  async fyllUtenlandsoppdraget(): Promise<void> {
+    const page = this.page;
+    await svarRadio(page, /oppdrag i landet arbeidstaker skal sendes ut til/, 'Ja');
+    await svarRadio(page, /ansatt på grunn av dette utenlandsoppdraget/, 'Nei');
+    await svarRadio(page, /fortsatt være ansatt hos dere i hele utsendingsperioden/, 'Ja');
+    await svarRadio(page, /Erstatter arbeidstaker en annen person/, 'Nei');
+    await lagreOgFortsett(page, /\/arbeidssted-i-utlandet/);
+  }
+
+  /** Steg 4: arbeidssted i utlandet (fast arbeidssted på land med adresse). */
+  async fyllArbeidssted(): Promise<void> {
+    const page = this.page;
+    await page.getByLabel('Hvor skal arbeidet utføres?').selectOption({ label: 'På land' });
+    await page.getByRole('textbox', { name: 'Navn på virksomheten' }).fill('Utenlandsk Avdeling SARL');
+    // «Fast arbeidssted» avslører adressefeltene; «Land» fylles automatisk fra steg 1.
+    await page.getByRole('radio', { name: 'Fast arbeidssted' }).check();
+    await page.getByRole('textbox', { name: 'Gate/vei' }).fill('Hovedgata');
+    await page.getByRole('textbox', { name: 'Nummer' }).fill('12');
+    await page.getByRole('textbox', { name: 'Postkode' }).fill('75001');
+    await page.getByRole('textbox', { name: 'By/sted/region' }).fill('Paris');
+    await svarRadio(page, /jobbe på hjemmekontor/, 'Nei');
+    await lagreOgFortsett(page, /\/arbeidstakerens-lonn/);
+  }
+
+  /**
+   * Steg 5: arbeidstakerens lønn. Neste steg avhenger av variant:
+   * begge deler → arbeidssituasjon, kun arbeidsgiver-del → tilleggsopplysninger.
+   */
+  async fyllArbeidstakerensLonn(nesteUrl: RegExp): Promise<void> {
+    await svarRadio(this.page, /Utbetaler du som arbeidsgiver all lønn/, 'Ja');
+    await lagreOgFortsett(this.page, nesteUrl);
+  }
+
+  // ---- Orkestrering ----------------------------------------------------------------------
+
+  /**
+   * Full innsending som arbeidsgiver MED fullmakt — fyller ut BEGGE deler (11 steg).
+   * @returns søknads-id (UUID) og referansenummer fra kvitteringen.
+   */
+  async fyllUtOgSendInnBeggeDeler(opts: {
+    arbeidsgiverOrgnr: string;
+    arbeidstakerFnr: string;
+    land?: string;
+    vedleggFilsti?: string;
+  }): Promise<{ skjemaId: string; referanse: string }> {
+    const skjemaId = await this.velgArbeidsgiverOgStart({
+      arbeidsgiverOrgnr: opts.arbeidsgiverOrgnr,
+      arbeidstakerFnr: opts.arbeidstakerFnr,
+      medFullmakt: true,
+    });
+    await this.fyllUtsendingsperiodeOgLand(opts.land);
+    await this.fyllArbeidsgiverensVirksomhet();
+    await this.fyllUtenlandsoppdraget();
+    await this.fyllArbeidssted();
+    await this.fyllArbeidstakerensLonn(/\/arbeidssituasjon/);
+    // AT-stegene er identiske med DEG SELV → gjenbruk komponert POM.
+    await this.felles.fyllArbeidssituasjon();
+    await this.felles.fyllSkatteforholdOgInntekt();
+    await this.felles.fyllFamiliemedlemmer();
+    await this.felles.fyllTilleggsopplysninger();
+    await this.felles.fyllVedlegg(opts.vedleggFilsti);
+    const referanse = await this.felles.sendInnOgHentReferanse();
+    return { skjemaId, referanse };
+  }
+
+  /**
+   * Full innsending av KUN arbeidsgiver-delen (8 steg, ingen AT-steg). Arbeidstaker oppgis
+   * manuelt. melosys-api setter behandling AVVENT_DOK_PART (venter på arbeidstakerens del).
+   * @returns søknads-id (UUID) og referansenummer fra kvitteringen.
+   */
+  async fyllUtOgSendInnArbeidsgiversDel(opts: {
+    arbeidsgiverOrgnr: string;
+    arbeidstakerFnr: string;
+    arbeidstakerEtternavn: string;
+    land?: string;
+    vedleggFilsti?: string;
+  }): Promise<{ skjemaId: string; referanse: string }> {
+    const skjemaId = await this.velgArbeidsgiverOgStart({
+      arbeidsgiverOrgnr: opts.arbeidsgiverOrgnr,
+      arbeidstakerFnr: opts.arbeidstakerFnr,
+      arbeidstakerEtternavn: opts.arbeidstakerEtternavn,
+      medFullmakt: false,
+    });
+    await this.fyllUtsendingsperiodeOgLand(opts.land);
+    await this.fyllArbeidsgiverensVirksomhet();
+    await this.fyllUtenlandsoppdraget();
+    await this.fyllArbeidssted();
+    await this.fyllArbeidstakerensLonn(/\/tilleggsopplysninger/);
+    await this.felles.fyllTilleggsopplysninger();
+    await this.felles.fyllVedlegg(opts.vedleggFilsti);
+    const referanse = await this.felles.sendInnOgHentReferanse();
+    return { skjemaId, referanse };
+  }
+}

--- a/pages/skjema/soknad-utsendt-arbeidstaker.page.ts
+++ b/pages/skjema/soknad-utsendt-arbeidstaker.page.ts
@@ -1,4 +1,5 @@
 import { Page, expect } from '@playwright/test';
+import { ddmmyyyy, lagreOgFortsett, standardUtsendingsperiode, svarRadio } from './skjema-utils';
 
 /**
  * Page Object for den digitale «Utsendt arbeidstaker»-søknaden i melosys-skjema-web,
@@ -11,6 +12,9 @@ import { Page, expect } from '@playwright/test';
  * Stegrekkefølge for DEG SELV-arbeidstaker (verifisert i live-flyt 2026-06-21):
  *   oversikt → utsendingsperiode-og-land → arbeidssituasjon → skatteforhold-og-inntekt
  *   → familiemedlemmer → tilleggsopplysninger → vedlegg → oppsummering → kvittering
+ *
+ * Steg-metodene for arbeidssituasjon t.o.m. oppsummering deles med arbeidsgiver-varianten
+ * (begge deler) — se soknad-arbeidsgiver.page.ts som komponerer denne POM-en for AT-stegene.
  */
 export class SoknadUtsendtArbeidstakerPage {
   constructor(private page: Page) {}
@@ -29,12 +33,7 @@ export class SoknadUtsendtArbeidstakerPage {
     await page.getByRole('button', { name: 'Start søknad' }).click();
 
     await page.waitForURL(/\/skjema\/[^/]+\/utsendingsperiode-og-land/);
-    // Hent søknads-id-en (UUID) ut av URL-en. Feil HER med en presis melding hvis URL-formen
-    // har endret seg — ellers bæres en tom id videre til SKJEMA_SAK_MAPPING-oppslaget i T2 og
-    // gir en misvisende "Kafka-mottak feilet"-timeout 45s senere.
-    const skjemaId = page.url().match(/\/skjema\/([0-9a-f-]{36})\//i)?.[1];
-    expect(skjemaId, `Fant ikke søknads-id (UUID) i URL-en: ${page.url()}`).toBeTruthy();
-    return skjemaId!;
+    return hentSkjemaIdFraUrl(page);
   }
 
   async fyllUtsendingsperiodeOgLand(land = 'Frankrike'): Promise<void> {
@@ -42,45 +41,58 @@ export class SoknadUtsendtArbeidstakerPage {
     await expect(page.getByRole('heading', { name: 'Utsendingsperiode og land' })).toBeVisible();
     await page.getByLabel('I hvilket land skal arbeidet utføres?').selectOption({ label: land });
 
-    // Periode godt innenfor 24-måneders-grensen, beregnet relativt til i dag så testen ikke ruster.
-    const fra = new Date();
-    fra.setMonth(fra.getMonth() + 1, 1); // 1. i neste måned
-    const til = new Date(fra);
-    til.setMonth(til.getMonth() + 6);
-    await page.getByRole('textbox', { name: 'Fra dato' }).fill(ddmmyyyy(fra));
-    await page.getByRole('textbox', { name: 'Til dato' }).fill(ddmmyyyy(til));
+    const { fraDato, tilDato } = standardUtsendingsperiode();
+    await page.getByRole('textbox', { name: 'Fra dato' }).fill(fraDato);
+    await page.getByRole('textbox', { name: 'Til dato' }).fill(tilDato);
 
-    await this.lagreOgFortsett(/\/arbeidssituasjon/);
+    await lagreOgFortsett(page, /\/arbeidssituasjon/);
   }
 
   async fyllArbeidssituasjon(): Promise<void> {
-    await this.svarRadio(/lønnet arbeid i Norge/, 'Ja');
-    await this.svarRadio(/selvstendig virksomhet eller arbeide for en annen/, 'Nei');
-    await this.lagreOgFortsett(/\/skatteforhold-og-inntekt/);
+    await svarRadio(this.page, /lønnet arbeid i Norge/, 'Ja');
+    await svarRadio(this.page, /selvstendig virksomhet eller arbeide for en annen/, 'Nei');
+    await lagreOgFortsett(this.page, /\/skatteforhold-og-inntekt/);
   }
 
   async fyllSkatteforholdOgInntekt(): Promise<void> {
     const page = this.page;
-    await this.svarRadio(/skattepliktig til Norge/, 'Ja');
+    await svarRadio(page, /skattepliktig til Norge/, 'Ja');
     await page.getByRole('checkbox', { name: 'Norsk virksomhet' }).check();
     await page.getByRole('checkbox', { name: 'Lønnsinntekt' }).check();
-    await this.svarRadio(/pengestøtte fra et annet EØS-land/, 'Nei');
-    await this.lagreOgFortsett(/\/familiemedlemmer/);
+    await svarRadio(page, /pengestøtte fra et annet EØS-land/, 'Nei');
+    await lagreOgFortsett(page, /\/familiemedlemmer/);
   }
 
   async fyllFamiliemedlemmer(): Promise<void> {
-    await this.svarRadio(/ektefelle, partner, samboer eller barn/, 'Nei');
-    await this.lagreOgFortsett(/\/tilleggsopplysninger/);
+    await svarRadio(this.page, /ektefelle, partner, samboer eller barn/, 'Nei');
+    await lagreOgFortsett(this.page, /\/tilleggsopplysninger/);
   }
 
   async fyllTilleggsopplysninger(): Promise<void> {
-    await this.svarRadio(/flere opplysninger til søknaden/, 'Nei');
-    await this.lagreOgFortsett(/\/vedlegg/);
+    await svarRadio(this.page, /flere opplysninger til søknaden/, 'Nei');
+    await lagreOgFortsett(this.page, /\/vedlegg/);
   }
 
-  async fyllVedlegg(): Promise<void> {
-    await this.svarRadio(/annen dokumentasjon/, 'Nei');
-    await this.lagreOgFortsett(/\/oppsummering/);
+  /**
+   * Vedlegg-steget. Uten argument svarer den «Nei» (ingen vedlegg). Med en filsti svarer
+   * den «Ja» og laster opp filen (deles av arbeidsgiver-varianten + T3 sin journalpost-assert).
+   * @param filsti absolutt sti til en fil (PDF/JPG/PNG, maks 10 MB) — lastes opp via det
+   *               skjulte file-input-feltet bak «Velg filer».
+   */
+  async fyllVedlegg(filsti?: string): Promise<void> {
+    const page = this.page;
+    if (filsti) {
+      await svarRadio(page, /annen dokumentasjon/, 'Ja');
+      await page.locator('input[type="file"]').setInputFiles(filsti);
+      // Vent på at filnavn-chipen dukker opp — beviser at opplasting + ClamAV-scan er ferdig
+      // (skjema-api lagrer vedlegget). Uten denne ventingen kan «Lagre og fortsett» tråkke
+      // forbi før vedlegget er persistert.
+      const filnavn = filsti.split('/').pop()!;
+      await expect(page.getByRole('link', { name: filnavn })).toBeVisible({ timeout: 15000 });
+    } else {
+      await svarRadio(page, /annen dokumentasjon/, 'Nei');
+    }
+    await lagreOgFortsett(page, /\/oppsummering/);
   }
 
   /**
@@ -110,7 +122,8 @@ export class SoknadUtsendtArbeidstakerPage {
    */
   async fyllUtOgSendInnKomplettSoknad(
     arbeidsgiverOrgnr = '999999999',
-    land = 'Frankrike'
+    land = 'Frankrike',
+    vedleggFilsti?: string
   ): Promise<{ skjemaId: string; referanse: string }> {
     const skjemaId = await this.startSoknadSomDegSelv(arbeidsgiverOrgnr);
     await this.fyllUtsendingsperiodeOgLand(land);
@@ -118,24 +131,21 @@ export class SoknadUtsendtArbeidstakerPage {
     await this.fyllSkatteforholdOgInntekt();
     await this.fyllFamiliemedlemmer();
     await this.fyllTilleggsopplysninger();
-    await this.fyllVedlegg();
+    await this.fyllVedlegg(vedleggFilsti);
     const referanse = await this.sendInnOgHentReferanse();
     return { skjemaId, referanse };
   }
-
-  private async svarRadio(gruppe: RegExp, svar: 'Ja' | 'Nei'): Promise<void> {
-    // Aksel RadioGroup rendrer <fieldset role="radiogroup"> med legend som tilgjengelig navn.
-    await this.page.getByRole('radiogroup', { name: gruppe }).getByRole('radio', { name: svar }).check();
-  }
-
-  private async lagreOgFortsett(nesteUrl: RegExp): Promise<void> {
-    await this.page.getByRole('button', { name: 'Lagre og fortsett' }).click();
-    await this.page.waitForURL(nesteUrl);
-  }
 }
 
-/** dd.mm.yyyy — formatet Aksel DatePicker forventer på norsk. */
-function ddmmyyyy(d: Date): string {
-  const p = (n: number) => String(n).padStart(2, '0');
-  return `${p(d.getDate())}.${p(d.getMonth() + 1)}.${d.getFullYear()}`;
+/**
+ * Hent søknads-id-en (UUID) ut av URL-en på første skjema-steg. Feil med en presis melding hvis
+ * URL-formen har endret seg — ellers bæres en tom id videre til SKJEMA_SAK_MAPPING-oppslaget i T2
+ * og gir en misvisende «Kafka-mottak feilet»-timeout 45s senere.
+ */
+export function hentSkjemaIdFraUrl(page: Page): string {
+  const skjemaId = page.url().match(/\/skjema\/([0-9a-f-]{36})\//i)?.[1];
+  expect(skjemaId, `Fant ikke søknads-id (UUID) i URL-en: ${page.url()}`).toBeTruthy();
+  return skjemaId!;
 }
+
+export { ddmmyyyy };

--- a/tests/skjema/fixtures/vedlegg-test.pdf
+++ b/tests/skjema/fixtures/vedlegg-test.pdf
@@ -1,0 +1,6 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]>>endobj
+trailer<</Size 4/Root 1 0 R>>
+%%EOF

--- a/tests/skjema/skjema-arbeidsgiver-innsending.spec.ts
+++ b/tests/skjema/skjema-arbeidsgiver-innsending.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import * as path from 'path';
+import { SkjemaAuthHelper } from '../../helpers/skjema-auth-helper';
+import { SoknadArbeidsgiverPage } from '../../pages/skjema/soknad-arbeidsgiver.page';
+
+/**
+ * T1b — full happy-path innsending av digital «Utsendt arbeidstaker»-søknad, variant ARBEIDSGIVER
+ * MED fullmakt (fyller ut BEGGE deler). Dette er den dominerende produksjonsflyten.
+ *
+ * Arbeidsgiver KARAFFEL logger inn, velger organisasjonen Ståles Stål (via Altinn-tilgang), velger
+ * arbeidstaker LANSEN fra fullmakt-lista, fyller ut alle 11 stegene — inkludert de fire
+ * arbeidsgiver-stegene som DEG SELV-flyten ikke har (arbeidsgiverens-virksomhet-i-norge,
+ * utenlandsoppdraget, arbeidssted-i-utlandet, arbeidstakerens-lonn) — laster opp et vedlegg, og
+ * sender inn. Verifiserer at innsendingen gir kvittering med referansenummer.
+ *
+ * Ren @playwright/test (ingen Oracle/Unleash-fixture — frontend-flyt). Krever skjema-stacken oppe:
+ *   cd ../melosys-docker-compose && make dev-skjema
+ *   SKIP_EESSI_GATE=true npx playwright test tests/skjema/ --project=chromium
+ *
+ * Testbruker (TESTBRUKERE.md scenario 1): KARAFFEL 30056928150 (daglig leder) → Ståles Stål
+ * 999999999 → på vegne av LANSEN 12928056706 (arbeidstaker NOR → Frankrike).
+ */
+test.describe('skjema-web innsending (arbeidsgiver)', () => {
+  test('arbeidsgiver fyller ut og sender inn «Utsendt arbeidstaker»-søknad for begge deler', async ({
+    page,
+  }) => {
+    test.setTimeout(90000); // 11 steg + vedlegg-opplasting (ClamAV) tar lengre tid enn DEG SELV
+
+    const auth = new SkjemaAuthHelper(page);
+    await auth.login('30056928150'); // KARAFFEL TRIVIELL, daglig leder
+
+    const soknad = new SoknadArbeidsgiverPage(page);
+    const { skjemaId, referanse } = await soknad.fyllUtOgSendInnBeggeDeler({
+      arbeidsgiverOrgnr: '999999999', // Ståles Stål AS
+      arbeidstakerFnr: '12928056706', // LANSEN LANSANSEN
+      land: 'Frankrike',
+      vedleggFilsti: path.resolve(__dirname, 'fixtures/vedlegg-test.pdf'),
+    });
+
+    // Kvitteringen viser et referansenummer (alfanumerisk kode) — beviser at hele
+    // arbeidsgiver-flyten (begge deler + vedlegg) ble persistert i skjema-api.
+    expect(skjemaId).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(referanse).toMatch(/^[A-Z0-9]{5,6}$/);
+    console.log('✅ Arbeidsgiver-søknad (begge deler) sendt inn, referanse:', referanse);
+  });
+});

--- a/tests/skjema/skjema-begge-deler-samme-sak.spec.ts
+++ b/tests/skjema/skjema-begge-deler-samme-sak.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from '../../fixtures';
+import * as path from 'path';
+import { withPgDatabase } from '../../helpers/pg-db-helper';
+import { SkjemaAuthHelper } from '../../helpers/skjema-auth-helper';
+import { SoknadArbeidsgiverPage } from '../../pages/skjema/soknad-arbeidsgiver.page';
+import { SoknadUtsendtArbeidstakerPage } from '../../pages/skjema/soknad-utsendt-arbeidstaker.page';
+import { SkjemaMottakAssertions } from '../../pages/skjema/skjema-mottak.assertions';
+
+/**
+ * T3 — «begge deler → samme sak» (kryss-tjeneste). Verifiserer hele koblingsmekanismen når
+ * arbeidsgiver-delen og arbeidstaker-delen sendes SEPARAT for samme arbeidstaker, juridiske
+ * enhet og overlappende periode:
+ *
+ *  1. Arbeidsgiver (KARAFFEL) sender KUN sin del FØRST → melosys-api oppretter sak + behandling
+ *     med status AVVENT_DOK_PART (venter på arbeidstakerens del).
+ *  2. Arbeidstaker (LANSEN) sender sin del (DEG SELV) med samme arbeidsgiver/periode →
+ *     skjema-api kobler delene (motpart), melosys-api ruter til EKSISTERENDE sak og flipper
+ *     behandlingen til VURDER_DOKUMENT — UTEN å opprette en ny sak.
+ *
+ * Asserter (mot Oracle + skjema-api Postgres + SAF/Joark-mock):
+ *  - nøyaktig ÉN fagsak og ÉN behandling totalt (ingen dobbel sak),
+ *  - status AVVENT_DOK_PART etter AG-del, VURDER_DOKUMENT etter AT-del,
+ *  - begge skjema-id-er mapper til SAMME saksnummer, hver med sin egen (distinkte) JOURNALPOST_ID,
+ *  - vedlegget fra AG-delen ligger på journalposten (Joark-mock),
+ *  - saksnummeret er skrevet tilbake til skjema-api (innsending.saksnummer) for begge deler.
+ *
+ * Bruker ../fixtures (Oracle-cleanup før testen). I tillegg ryddes skjema-api sin Postgres
+ * (`melosys-skjema`) FØRST i testen: tidligere innsendte søknader for samme arbeidstaker
+ * (fra warm-up/andre tester) ville ellers gjøre motpart-koblingen ikke-deterministisk.
+ *
+ * To innlogginger (arbeidsgiver + arbeidstaker) = to browser-contexts i samme test.
+ * Testbrukere (TESTBRUKERE.md scenario 1): KARAFFEL 30056928150 → Ståles Stål 999999999 →
+ * LANSEN 12928056706.
+ */
+test.describe('skjema-web → melosys-api: begge deler kobles til samme sak', () => {
+  test('AG-del først (AVVENT_DOK_PART) + AT-del → samme sak, VURDER_DOKUMENT', async ({
+    page,
+    browser,
+    request,
+  }) => {
+    test.setTimeout(240000); // to innsendinger + async Kafka-mottak/kobling + DB-polling
+
+    const ORGNR = '999999999'; // Ståles Stål AS
+    const ARBEIDSTAKER_FNR = '12928056706'; // LANSEN LANSANSEN
+    const VEDLEGG = path.resolve(__dirname, 'fixtures/vedlegg-test.pdf');
+    const mottak = new SkjemaMottakAssertions();
+
+    // Rydd skjema-api sin Postgres så motpart-koblingen blir deterministisk (kun denne testens
+    // deler er SENDT for arbeidstakeren — ellers kan koblingen treffe en gammel arbeidsgiver-del).
+    await withPgDatabase('melosys-skjema', (db) => db.cleanDatabase(true));
+
+    // ---- 1. Arbeidsgiver sender KUN sin del (context 1) -----------------------------------
+    const auth = new SkjemaAuthHelper(page);
+    await auth.login('30056928150'); // KARAFFEL
+
+    const agSoknad = new SoknadArbeidsgiverPage(page);
+    const { skjemaId: agSkjemaId, referanse: agReferanse } =
+      await agSoknad.fyllUtOgSendInnArbeidsgiversDel({
+        arbeidsgiverOrgnr: ORGNR,
+        arbeidstakerFnr: ARBEIDSTAKER_FNR,
+        arbeidstakerEtternavn: 'LANSANSEN',
+        land: 'Frankrike',
+        vedleggFilsti: VEDLEGG,
+      });
+    console.log('📨 Arbeidsgiver-del sendt:', { agSkjemaId, agReferanse });
+
+    const { saksnummer } = await mottak.ventPaaSakForSkjema(agSkjemaId);
+    // Kun arbeidsgiver-del mottatt → behandlingen venter på arbeidstakerens del.
+    await mottak.ventPaaBehandlingStatus(saksnummer, 'AVVENT_DOK_PART');
+    await mottak.verifiserSakOgBehandling(saksnummer); // UTSENDT_ARBEIDSTAKER / FØRSTEGANG
+    expect(await mottak.tellFagsaker(), 'kun én fagsak etter AG-del').toBe(1);
+    const agJournalpostId = await mottak.ventPaaJournalpostForSkjema(agSkjemaId);
+    await mottak.verifiserDelJournalfoertMedVedlegg(request, agReferanse, 'vedlegg-test.pdf');
+    await mottak.ventPaaSaksnummerISkjemaApi(agSkjemaId, saksnummer);
+
+    // ---- 2. Arbeidstaker sender sin del, DEG SELV (context 2 = ny innlogging) -------------
+    const arbeidstakerContext = await browser.newContext();
+    try {
+      const page2 = await arbeidstakerContext.newPage();
+      const auth2 = new SkjemaAuthHelper(page2);
+      await auth2.login(ARBEIDSTAKER_FNR); // LANSEN
+
+      const atSoknad = new SoknadUtsendtArbeidstakerPage(page2);
+      const { skjemaId: atSkjemaId, referanse: atReferanse } =
+        await atSoknad.fyllUtOgSendInnKomplettSoknad(ORGNR, 'Frankrike');
+      console.log('📨 Arbeidstaker-del sendt:', { atSkjemaId, atReferanse });
+
+      // AT-delen skal kobles til den eksisterende saken — IKKE opprette en ny.
+      const { saksnummer: atSaksnummer } = await mottak.ventPaaSakForSkjema(atSkjemaId);
+      expect(atSaksnummer, 'begge deler skal mappe til samme saksnummer').toBe(saksnummer);
+      await mottak.ventPaaBehandlingStatus(saksnummer, 'VURDER_DOKUMENT');
+
+      expect(await mottak.tellFagsaker(), 'fortsatt kun én fagsak etter AT-del').toBe(1);
+      expect(await mottak.tellBehandlinger(saksnummer), 'fortsatt kun én behandling').toBe(1);
+
+      const atJournalpostId = await mottak.ventPaaJournalpostForSkjema(atSkjemaId);
+      expect(atJournalpostId, 'hver del journalføres på sin egen journalpost').not.toBe(
+        agJournalpostId
+      );
+
+      await mottak.ventPaaSaksnummerISkjemaApi(atSkjemaId, saksnummer);
+
+      console.log(
+        `✅ Begge deler koblet til sak ${saksnummer} (AG jp ${agJournalpostId}, AT jp ${atJournalpostId})`
+      );
+    } finally {
+      await arbeidstakerContext.close();
+    }
+  });
+});

--- a/tests/skjema/skjema-radgiver-innsending.spec.ts
+++ b/tests/skjema/skjema-radgiver-innsending.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '../../fixtures';
+import { SkjemaAuthHelper } from '../../helpers/skjema-auth-helper';
+import { SoknadArbeidsgiverPage } from '../../pages/skjema/soknad-arbeidsgiver.page';
+import { SkjemaMottakAssertions } from '../../pages/skjema/skjema-mottak.assertions';
+
+/**
+ * T1c — innsending via rollevalg RÅDGIVER med fullmakt (RADGIVER_MED_FULLMAKT). En rådgiver fyller
+ * ut «Utsendt arbeidstaker»-søknaden på vegne av et rådgivingsfirma, for en arbeidsgiver (via
+ * Altinn-tilgang) og en arbeidstaker (via fullmakt) — begge deler.
+ *
+ * Den nye UI-delen vs. T1b er rådgiverfirma-valget (`/representasjon/velg-radgiverfirma`): et fritt
+ * org.nr-/EREG-oppslag (ikke Altinn-begrenset), så enhver innlogget bruker kan opptre som rådgiver.
+ * Resten av oversikten (arbeidsgiver + arbeidstaker) og stegene er identiske med arbeidsgiver-flyten.
+ *
+ * Cross-service (../fixtures, Oracle): verifiserer at søknaden blir sak + behandling i melosys-api,
+ * og — det rådgiver-spesifikke — at rådgiverfirmaet og rådgiver-med-fullmakt-representasjonen
+ * fulgte med hele veien (SKJEMA_SAK_MAPPING.ORIGINAL_DATA, som er hele mottatt M2M-DTO inkl. metadata).
+ *
+ * Testbruker: KARAFFEL 30056928150 opptrer som rådgiver for rådgivingsfirma Skatteetaten 974761076,
+ * arbeidsgiver Ståles Stål 999999999, arbeidstaker LANSEN 12928056706.
+ */
+test.describe('skjema-web → melosys-api: rådgiver med fullmakt', () => {
+  test('rådgiver fyller ut begge deler → sak + rådgiverfirma/fullmakt i mottatte data', async ({
+    page,
+  }) => {
+    test.setTimeout(120000); // 11 steg + async Kafka-mottak + DB-polling
+
+    const auth = new SkjemaAuthHelper(page);
+    await auth.login('30056928150'); // KARAFFEL — opptrer som rådgiver
+
+    const soknad = new SoknadArbeidsgiverPage(page);
+    const { skjemaId, referanse } = await soknad.fyllUtOgSendInnRadgiverBeggeDeler({
+      radgiverfirmaOrgnr: '974761076', // Skatteetaten (EREG-oppslag)
+      radgiverfirmaNavn: 'Skatteetaten',
+      arbeidsgiverOrgnr: '999999999', // Ståles Stål AS (Altinn-tilgang)
+      arbeidstakerFnr: '12928056706', // LANSEN LANSANSEN (fullmakt)
+      land: 'Frankrike',
+    });
+    expect(referanse).toMatch(/^[A-Z0-9]{5,6}$/);
+    console.log('📨 Rådgiver-søknad sendt:', { skjemaId, referanse });
+
+    const mottak = new SkjemaMottakAssertions();
+    const { saksnummer } = await mottak.ventPaaSakForSkjema(skjemaId);
+    await mottak.verifiserSakOgBehandling(saksnummer); // UTSENDT_ARBEIDSTAKER / FØRSTEGANG
+
+    // Det rådgiver-spesifikke: rådgivingsfirmaet (orgnr + navn) og rådgiver-med-fullmakt-
+    // representasjonen er bevart i dataene melosys-api mottok.
+    await mottak.verifiserOriginalDataInneholder(skjemaId, [
+      'RADGIVER_MED_FULLMAKT',
+      '974761076',
+      'Skatteetaten',
+    ]);
+  });
+});

--- a/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-saksbehandlingsflyt.spec.ts
+++ b/tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-saksbehandlingsflyt.spec.ts
@@ -23,7 +23,7 @@ import {waitForProcessInstances} from '../../../helpers/api-helper';
 import {TestPeriods} from '../../../helpers/date-helper';
 import {withDatabase} from '../../../helpers/db-helper';
 import {withFaktureringDatabase} from '../../../helpers/pg-db-helper';
-import {setupPensjonistUtenGrunnlagMedAutoAarsavregning} from '../../eu-eos/pensjonist-aarsavregning-setup';
+import {setupPensjonistUtenGrunnlagMedAutoAarsavregning} from '../../aarsavregning/pensjonist-aarsavregning-setup';
 
 /**
  * MELOSYS-8148: Automatisk sende innhentingsbrev ved opprettelse av årsavregning i flytene


### PR DESCRIPTION
## Hva

Neste runde e2e-tester mot **melosys-skjema-web/-api** (digital «Utsendt arbeidstaker»-søknad), bygger videre på PR #290 (T0+T1+T2). Inkluderer også en kritisk hotfix og en CI-gating-forbedring.

### T1b — arbeidsgiver-variant (begge deler)
Dominerende prod-flyt: KARAFFEL → Ståles Stål (Altinn) → på vegne av LANSEN (fullmakt), alle 11 steg inkl. de fire arbeidsgiver-stegene DEG SELV ikke har, vedlegg, innsending → kvittering. Ny POM `pages/skjema/soknad-arbeidsgiver.page.ts` (dekker både «begge deler» og «kun arbeidsgiver-del»); delte steg-hjelpere i `pages/skjema/skjema-utils.ts`; AT-/hale-steg gjenbrukes fra DEG SELV-POM via komposisjon; vedlegg-opplasting i `fyllVedlegg()`.

### T3 — begge deler kobles til samme sak (kryss-tjeneste)
AG-del sendes FØRST → melosys-api **AVVENT_DOK_PART**. AT-del (DEG SELV, samme arbeidsgiver/periode) → skjema-api kobler delene → melosys-api ruter til **eksisterende** sak, behandling → **VURDER_DOKUMENT**, ingen ny sak. Asserterer mot Oracle + skjema-api Postgres + Joark-mock: én fagsak/behandling, statusovergang, samme saksnummer m/ to distinkte journalpost-id-er, vedlegg på journalposten, `innsending.saksnummer` satt for begge. To innlogginger = to browser-contexts; rydder skjema-Postgres for deterministisk kobling.

### T1c — rådgiver med fullmakt (RADGIVER_MED_FULLMAKT)
Rollevalg RÅDGIVER har et eget rådgiverfirma-valg (fritt EREG-org.nr-oppslag, ikke Altinn-begrenset). KARAFFEL opptrer som rådgiver for Skatteetaten 974761076. Cross-service: verifiserer sak/behandling + at rådgiverfirma og RADGIVER_MED_FULLMAKT fulgte med til melosys-api (`SKJEMA_SAK_MAPPING.ORIGINAL_DATA`).

### 🔧 Hotfix: stale import brøt HELE e2e-suiten (falsk grønn)
`aarsavregning-innhentingsbrev-saksbehandlingsflyt.spec.ts` importerte `pensjonist-aarsavregning-setup` fra `../../eu-eos/`, men fila ligger i `../../aarsavregning/` (semantisk konflikt: #291 flyttet fila, #284 merget med gammel sti). Playwright laster ALLE spec-filer ved `--grep`, så denne ene døde importen ga «Cannot find module» → 0 tester samlet → reporteren rapporterte falskt «passed». **Hele suiten var stille brutt på main.** Retter stien (104 tester samles igjen) + legger til en vakt i workflowen som feiler kjøringen hvis 0 tester samles/kjøres.

### CI: gate skjema-stack til skjema-scope
Skjema-tjenestene + full-flow-oppvarmingen kjørte på HVER e2e-kjøring. Lagt under compose-profilen `skjema`; workflowen setter `COMPOSE_PROFILES=skjema` + warm-up kun når skjema er i scope (tom test_grep = full suite, eller test_grep nevner «skjema»). Pre-pull + vente-steg gates likt. Saksbehandler-fokuserte kjøringer slipper skjema-kostnaden.

## Test
- Lokalt grønn: hele `tests/skjema/`-suiten 6/6.
- CI (gated workflow): `test_grep=skjema-web` → `COMPOSE_PROFILES=skjema`, 5–6 skjema-tester kjører og er grønne. Skip-path (`test_grep`=ikke-skjema) verifisert separat.

## Terminologi
«Utsendt arbeidstaker»-søknad (ikke «A1-søknad»).
