### PR TITLE
8161 E2E-test: årsavregning duplikat-gate (uten/med år)

### DIFF
--- a/helpers/db-helper.ts
+++ b/helpers/db-helper.ts
@@ -69,6 +69,30 @@ export class DatabaseHelper {
   }
 
   /**
+   * Execute a DML statement (INSERT/UPDATE/DELETE) with autoCommit, so the change
+   * is immediately visible to melosys-api (which uses a separate connection).
+   *
+   * `query`/`queryOne` run without autoCommit and are meant for reads; use this for
+   * test setup that must persist. Returns the number of affected rows.
+   *
+   * @example
+   * await db.execute(
+   *   "INSERT INTO BEHANDLING (SAKSNUMMER, STATUS, BEH_TYPE, ...) VALUES (:s, 'OPPRETTET', ...)",
+   *   { s: saksnummer }
+   * );
+   */
+  async execute(sql: string, binds: any = {}): Promise<number> {
+    if (!this.connection) {
+      throw new Error('Database not connected. Call connect() first.');
+    }
+    const result = await this.connection.execute(sql, binds, {
+      autoCommit: true,
+      outFormat: oracledb.OUT_FORMAT_OBJECT,
+    });
+    return result.rowsAffected ?? 0;
+  }
+
+  /**
    * Clean all data tables except lookup tables and PROSESS_STEG
    * Excludes: tables ending with _TYPE, _TEMA, _STATUS, and PROSESS_STEG
    * @param silent - If true, suppress console output

--- a/specs/aarsavregning-uten-aar-blokkerer-ikke.md
+++ b/specs/aarsavregning-uten-aar-blokkerer-ikke.md
@@ -1,0 +1,292 @@
+---
+jira: MELOSYS-8161
+epic: MELOSYS-7080 — Støtte til endringer i medlemskap og trygdeavgift for tidligere år
+status: implemented  # ny test skrevet foran melosys-api-fiksen; ikke CI-verifisert (se status-merknad)
+test: tests/aarsavregning/aarsavregning-uten-aar-blokkerer-ikke.spec.ts
+toggles: {}          # default-state; per-trigger-koreografi av melosys.faktureringskomponenten.ikke-tidligere-perioder er testmekanikk (se binding)
+tags: [årsavregning, ny-vurdering, tidligere-år, ftrl, auto-opprettelse, regresjon]
+analysis_trace_id: 2441d3f7-a196-4bbe-938a-5daf1a55252b
+---
+
+# Automatisk opprettelse av årsavregningsbehandling — ufullstendig åpen behandling uten år skal ikke blokkere
+
+## Forretningsregel
+
+Når Melosys fatter vedtak på en FTRL-sak med avgiftspliktige perioder i et foregående kalenderår, **skal systemet automatisk opprette en årsavregningsbehandling for det aktuelle året** (hjemmel: skatteforvaltningsforskriften § 2-13-2, jf. ftrl. § 23-3). Opprettelse skal *ikke* skje dersom det allerede finnes en åpen årsavregningsbehandling som gjelder samme år — i så fall skal den eksisterende behandlingen tilbakestilles slik at saksbehandler kan starte på nytt (MELOSYS-7826).
+
+En åpen årsavregningsbehandling som ennå **ikke har fått fastsatt år** er ufullstendig og representerer ikke en årsavregning for noe bestemt år. En slik behandling skal ikke tolkes som en eksisterende årsavregning for det aktuelle året og skal ikke blokkere automatisk opprettelse.
+
+*Kilde: [MELOSYS-7826](https://jira.adeo.no/browse/MELOSYS-7826), faglig avklaring bekreftet av Yvonne Jacobs (referert i MELOSYS-8045): «ny ÅRSAVREGNING SKAL opprettes når åpen mangler år».*
+
+## Scenario 1 — Automatisk opprettelse når eksisterende årsavregningsbehandling mangler år
+
+```gherkin
+Gitt en FTRL-sak (PENSJONIST) med avgiftspliktige perioder i et foregående kalenderår
+  Og det finnes allerede en åpen årsavregningsbehandling på saken
+  Og den åpne behandlingen har ikke fått fastsatt et år ennå
+
+ Når saksbehandler fatter vedtak med endring i den avgiftspliktige perioden for det foregående året
+
+ Så skal Melosys automatisk opprette en ny årsavregningsbehandling for det foregående kalenderåret
+  Og den nye behandlingen skal knyttes til korrekt kalenderår
+  Og den ufullstendige behandlingen (uten år) skal ikke ha hindret opprettelsen
+  Og det skal ikke vises en misvisende feilmelding rettet mot manuell saksbehandling
+```
+
+## Scenario 2 — Normal blokkering gjelder fortsatt — åpen behandling MED år for samme år
+
+```gherkin
+Gitt en FTRL-sak (PENSJONIST) med avgiftspliktige perioder i et foregående kalenderår
+  Og det finnes allerede en åpen årsavregningsbehandling på saken
+  Og den åpne behandlingen er knyttet til det aktuelle foregående kalenderåret
+
+ Når saksbehandler fatter vedtak med endring i den avgiftspliktige perioden for det foregående året
+
+ Så skal Melosys IKKE automatisk opprette en ny årsavregningsbehandling
+  Og den eksisterende årsavregningsbehandlingen for det aktuelle året skal tilbakestilles
+  Og saksbehandler skal behandle den tilbakestilte behandlingen på nytt
+```
+
+## Akseptansekriterier (det fagperson signerer av på)
+
+- [ ] Når det finnes en åpen årsavregningsbehandling uten fastsatt år, skal automatisk opprettelse for et foregående kalenderår gjennomføres uten feil
+- [ ] Den nyopprettede årsavregningsbehandlingen skal ha korrekt kalenderår satt
+- [ ] En ufullstendig behandling uten år skal ikke anses som en eksisterende årsavregning for noe bestemt år og skal ikke blokkere ny opprettelse
+- [ ] Saksbehandler skal ikke se en feilmelding som gir inntrykk av at det finnes en åpen årsavregning de må håndtere manuelt, når det ikke er tilfelle
+- [ ] Dersom det finnes en åpen årsavregningsbehandling med år satt til det aktuelle foregående kalenderåret, gjelder fremdeles eksisterende regel: ingen ny opprettes, den eksisterende tilbakestilles *(utledet — bekreft med fagperson at denne regelen er uendret)*
+
+## Kjente avgrensninger (ikke dekket her)
+
+- **Hva skjer med den ufullstendige behandlingen (uten år)?** Speken krever ikke at den avsluttes automatisk — kun at den ikke blokkerer. Avklaring av om slike behandlinger skal ryddes opp automatisk hører hjemme i en separat sak.
+- **FTRL YRKESAKTIV og ikke-skattepliktige:** Samme prinsipp er allerede fikset for tilsvarende flyt (MELOSYS-8045). Denne speken dekker kun `OppretteÅrsavregningVedEndring`-flyten; andre generatorer er ikke vurdert her.
+- **Flere foregående år i samme vedtak:** Kombinasjonen «ufullstendig behandling uten år» + «vedtak som berører flere foregående år» er ikke eksplisitt scenariosatt her — bekreft med fagperson om det trengs egne scenarier.
+- **EØS Pensjonist / Offentlig Tjenestepensjon:** Disse sakstypene kan ha tilsvarende flyt; dekkes ikke av denne speken uten eksplisitt avklaring.
+
+---
+
+## Teknisk binding
+*(for testagenten — domeneleseren kan stoppe over linjen)*
+
+> **Verbatim-regel:** verdier merket `(verbatim)` er flyt-spesifikke `selectOption`-argumenter
+> og skal brukes **ordrett**. Ikke "korriger" dem mot eksempelverdier i POM-ens JSDoc — samme
+> dropdown bruker ulike koder i ulike flyter.
+
+> **Status-merknad (les denne før du tolker «rød/grønn»):**
+> 1. **Fiksen er ikke implementert i melosys-api ennå.** Det finnes ingen `8161`-branch
+>    (verifisert `git branch -a | grep 8161` → tom 2026-06-30). Denne testen er skrevet *foran*
+>    fiksen — samme mønster som [`aarsavregning-innhentingsbrev-saksbehandlingsflyt.md`](aarsavregning-innhentingsbrev-saksbehandlingsflyt.md) (8148)
+>    ble skrevet foran sin api-feature. Den skal CI-verifiseres mot fiks-branchen i en **egen
+>    orkestreringsrunde** (Hivemind/CI), ikke i spec-from-analysis-leveransen.
+> 2. **Reproduksjonen av selve pre-fiks-feilen er subtil.** Statisk lesning av
+>    `OppretteÅrsavregningVedEndring.opprettÅrsavregning()` + `ÅrsavregningService.finnÅrsavregningerPåFagsak()`
+>    viser at en *ren* «uten år»-behandling (uten `aarsavregning`-rad) faller bort i
+>    `.mapNotNull { it.årsavregning }` → `harAktivÅrsavregningforÅr = false` → opprettelse går videre.
+>    Dvs. nettopp den kanoniske «uten år»-tilstanden denne speken beskriver kan allerede være
+>    håndtert i *denne* kodestien, slik at testen kan bli **grønn mot main**. Det er i seg selv et
+>    nyttig funn (da ligger pre-fiks-feilen i en mer spesifikk tilstand, jf. analyserapportens
+>    «Mangler/uklarheter»). Testen binder derfor **målatferden** (akseptansekriteriet) som en
+>    aksept-/regresjonstest, ikke en garantert rød-til-fikset-reproduksjon. Når fiks-branchen
+>    finnes: bekreft reproduksjon og stram inn precondition-tilstanden om nødvendig.
+
+### Bug-mekanikk (for den som binder/verifiserer)
+
+Feil sitter i `melosys-api` `saksflyt/.../OppretteÅrsavregningVedEndring.opprettÅrsavregning()`:
+
+```kotlin
+val harAktivÅrsavregningforÅr =
+    årsavregningService.finnÅrsavregningerPåFagsak(saksnummer, potensieltÅr, IKKE_FASTSATT).isNotEmpty()
+if (!harAktivÅrsavregningforÅr) { opprettArsavregningsBehandlingProsessflyt(...) }
+```
+
+`finnÅrsavregningerPåFagsak` (`service/.../ÅrsavregningService.kt`) gjør `.mapNotNull { it.årsavregning }`
+— en åpen ÅRSAVREGNING-behandling **uten `aarsavregning`-rad** («uten år») forsvinner her. Den
+parallelle, allerede fiksede flyten (MELOSYS-8045, `ÅrsavregningIkkeSkattepliktigeProsessGenerator`)
+definerer den kanoniske tolkningen i `hentÅrFraBehandlingDefensivt`:
+
+> «Returnerer null hvis åpen ÅRSAVREGNING-behandling mangler aarsavregning-rad (`hentÅrsavregning()`
+> kaster) … slik at ny ÅRSAVREGNING blir opprettet for året per fag-avklaring.»
+
+Den misvisende feilmeldingen (når den utløses) kastes i `ÅrsavregningService.opprettÅrsavregning()`
+via `AarsavregningRepository.finnAntallÅrsavregningerPåFagsakForÅr` (SQL teller `aarsavregning`-rader
+med `a.aar = :aar` på ikke-AVSLUTTET ÅRSAVREGNING-behandlinger): *«Det finnes en annen åpen
+årsavregningsbehandling for samme år på saken. Vurder hvilken behandling du vil fortsette med …»* —
+misvisende fordi opprettelsen er automatisk, ikke saksbehandlerinitiert.
+
+### Definisjon: «årsavregningsbehandling uten år»
+
+= en `BEHANDLING` med `BEH_TYPE = 'ÅRSAVREGNING'`, status ≠ `AVSLUTTET`, som har et
+`BEHANDLINGSRESULTAT` men **ingen `AARSAVREGNING`-rad** (`AARSAVREGNING.BEHANDLINGSRESULTAT_ID`
+peker ikke på behandlingsresultatet). Dette er nøyaktig tilstanden en saksbehandler etterlater når
+en årsavregning opprettes manuelt og året ennå ikke er valgt på selve årsavregningssiden (jf.
+manuell-opprettelse-scenariet i 8148-speken: «Året velges først på selve årsavregningssiden — på
+opprettelsestidspunktet er det ikke valgt»).
+
+### Trigger (kjørbar) — saksbehandlingsflyt via ny vurdering, samme mønster som 8148 scenario 1
+
+Endringen som berører tidligere år gjøres som **ny vurdering** (NV): førstegangsvedtaket gjelder
+*inneværende* år, NV endrer perioden til *kun forrige år* slik at `OppretteÅrsavregningVedEndring`
+(NV-grenen, `årMedEndringer = {forrige år}`) auto-oppretter årsavregningen.
+
+> **Kilde for de eksakte verdiene:** Selve trinn-for-trinn-oppskriften (førstegangsverdier + NV-verdier)
+> er **byte-for-byte den verifiserte 8148 scenario 1** i
+> `tests/utenfor-avtaleland/workflows/aarsavregning-innhentingsbrev-saksbehandlingsflyt.spec.ts`
+> (`opprettVedtattSakInneværendeÅr` + NV-blokken). `tests/aarsavregning/komplett-sak-nyvurdering-periode-endres-til-kun-tidligere-aar.spec.ts`
+> er kun referert for NV-trigger-**formen** (endre periode til kun forrige år → auto-årsavregning) —
+> den bruker *andre* førstegangsverdier (`velgFlereLandIkkeKjentHvilke()` + `ARBEIDSINNTEKT`, ingen
+> `velgBetalesAga`) og er **ikke** fasiten for verdiene under. Bruk 8148-verdiene ordrett.
+
+**Felles forutsetning (førstegangsvedtak, inneværende år)** — `opprettVedtattSakInneværendeÅr`-mønsteret:
+- bruker: `USER_ID_VALID` (`30056928150`, "TRIVIELL KARAFFEL")
+- `OpprettNySakPage.opprettStandardSak(USER_ID_VALID)` (FTRL / MEDLEMSKAP_LOVVALG / YRKESAKTIV / SØKNAD)
+- `MedlemskapPage`: `velgPeriode(...)` med **`TestPeriods.currentYearPeriod`** ·
+  `velgLand('Afghanistan')` · `velgTrygdedekning('FTRL_2_9_FØRSTE_LEDD_C_HELSE_PENSJON')` **(verbatim)** ·
+  `klikkBekreftOgFortsett()`
+- `ArbeidsforholdPage.fyllUtArbeidsforhold('Ståles Stål AS')`
+- `LovvalgPage`: `velgBestemmelse('FTRL_KAP2_2_8_FØRSTE_LEDD_A')` **(verbatim)** ·
+  `svarJaPaaFørsteSpørsmål()` · Ja på "Har søker vært medlem i minst" og "Har søker nær tilknytning til" ·
+  `klikkBekreftOgFortsett()`
+- `ResultatPeriodePage.fyllUtResultatPeriode('INNVILGET')`
+- `TrygdeavgiftPage`: `ventPåSideLastet()` · `velgSkattepliktig(false)` ·
+  `velgInntektskilde('INNTEKT_FRA_UTLANDET')` **(verbatim)** · `velgBetalesAga(false)` ·
+  `fyllInnBruttoinntektMedApiVent('100000')` · `klikkBekreftOgFortsett()`
+- `VedtakPage.klikkFattVedtak()` · `waitForProcessInstances(page.request, 30)`
+
+**Toggle-koreografi** (`UnleashHelper`, toggle `melosys.faktureringskomponenten.ikke-tidligere-perioder`):
+- **AV** under førstegangsvedtaket for inneværende år,
+- sett faktura-radene til `BESTILT` via `withFaktureringDatabase` (`UPDATE faktura SET status = 'BESTILT'`)
+  — NV-avregningen går ellers ikke gjennom,
+- **PÅ** igjen før ny vurdering (`OppretteÅrsavregningVedEndring` returnerer tidlig hvis toggle er av).
+
+**Ny vurdering (perioden endres til kun forrige år):**
+- `HovedsidePage.klikkOpprettNySak()` · `OpprettNySakPage.opprettNyVurdering(USER_ID_VALID, 'SØKNAD')` ·
+  `waitForProcessInstances(page.request, 30)` · åpne saken på nytt (`getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).first()`)
+- `MedlemskapPage.velgPeriode(...)` med **`TestPeriods.previousYearPeriod`** · `klikkBekreftOgFortsett()`
+- `ArbeidsforholdPage.fyllUtArbeidsforhold('Ståles Stål AS')`
+- `LovvalgPage`: `velgBestemmelse('FTRL_KAP2_2_1')` **(verbatim)** ·
+  `velgBrukersSituasjon('MIDLERTIDIG_ARBEID_2_1_FJERDE_LEDD')` **(verbatim)** ·
+  `svarJaPaaFørsteSpørsmål()` · Ja på "Er søkers arbeidsoppdrag i", "Plikter arbeidsgiver å betale",
+  "Har søker lovlig opphold i" · `klikkBekreftOgFortsett()`
+- `ResultatPeriodePage.klikkBekreftOgFortsett()` · `TrygdeavgiftPage.klikkBekreftOgFortsett()`
+- `VedtakPage.fattVedtakForNyVurdering('FEIL_I_BEHANDLING')` **(verbatim)** · `waitForProcessInstances(page.request, 30)`
+
+> **Domene-merknad:** Domenelaget sier «FTRL (PENSJONIST)», men `harTemaOgTypeSomSkalBehandles` i
+> `OppretteÅrsavregningVedEndring` behandler **både** FTRL YRKESAKTIV og FTRL PENSJONIST identisk for
+> denne regelen (begge → `true`). Den kjørbare triggeren bruker FTRL **YRKESAKTIV** fordi det er den
+> eneste fullt POM-dekkede, verifiserte flyten i repoet (8148 scenario 1). Regelen som testes
+> («uten år blokkerer ikke») er sakstype-uavhengig innenfor scope.
+
+### Precondition (kjørbar) — injiser «åpen årsavregning uten år»
+
+Den kanoniske «uten år»-tilstanden konstrueres deterministisk via DB-injeksjon (det finnes ingen
+verifisert UI-sti for å lage en manuell, ufullført årsavregning på en *eksisterende* FTRL-sak; å
+gjette en slik UI-flyt bryter med spec-from-analysis-regelen om å ikke gjette UI). Injeksjonen er
+skjemagrunnet mot live Oracle (alle NOT NULL-kolonner + FK-enum-verdier verifisert 2026-06-30 — det
+finnes ingen ekstra NOT NULL-kolonner utover de under):
+
+- les saksnummer fra **`FAGSAK.SAKSNUMMER`** (IKKE `GSAK_SAKSNUMMER` — det er arkivsak-koblingen):
+  `SELECT SAKSNUMMER FROM FAGSAK` (cleanup-fixturen gir nøyaktig én fagsak per test → én rad),
+- `INSERT INTO BEHANDLING (SAKSNUMMER, STATUS, BEH_TYPE, REGISTRERT_DATO, ENDRET_DATO, BEH_TEMA, BEHANDLINGSFRIST)`
+  `VALUES (:s, 'OPPRETTET', 'ÅRSAVREGNING', SYSTIMESTAMP, SYSTIMESTAMP, 'YRKESAKTIV', SYSDATE)`
+  (`BEHANDLING.ID` har sekvens-default → **ikke** sett i INSERT). `DatabaseHelper.execute()` returnerer
+  kun `rowsAffected` (ingen out-binds), så `RETURNING ID` kan **ikke** brukes — hent ID-en via
+  select-back: `SELECT ID FROM BEHANDLING WHERE SAKSNUMMER = :s AND BEH_TYPE = 'ÅRSAVREGNING'`. På
+  injeksjonstidspunktet (før NV-vedtaket) er dette den **eneste** ÅRSAVREGNING-behandlingen på saken
+  (førstegang = FØRSTEGANG, NV = NY_VURDERING) → entydig select-back.
+- `INSERT INTO BEHANDLINGSRESULTAT (BEHANDLING_ID, BEHANDLINGSMAATE, RESULTAT_TYPE, REGISTRERT_DATO, ENDRET_DATO)`
+  `VALUES (:id, 'MANUELT', 'IKKE_FASTSATT', SYSTIMESTAMP, SYSTIMESTAMP)`,
+- **ingen** `AARSAVREGNING`-rad → behandlingen er «uten år».
+
+**Plassering (viktig):** injiser **etter at all UI-navigasjon for NV-en er ferdig**, rett **før**
+`VedtakPage.fattVedtakForNyVurdering(...)` (som fyrer `OppretteÅrsavregningVedEndring`). Da unngås all
+risiko for at den ekstra åpne behandlingen påvirker `opprettNyVurdering`-UI-en — preconditionen
+trenger kun å eksistere i det øyeblikket vedtaket fattes. (Saksnummeret leses tidligere, rett etter at
+den vedtatte saken finnes.)
+
+Helper i testfila: `gittÅpenÅrsavregningUtenÅr(saksnummer): Promise<number>` (returnerer injisert
+behandlingId). Bruker `DatabaseHelper.execute()` (autoCommit) for INSERTs slik at api-en (egen
+connection) ser dem. Etter injeksjon **verifiseres** preconditionen via DB (ÅRSAVREGNING-behandling
+finnes, ingen AARSAVREGNING-rad: `SELECT COUNT(*) FROM AARSAVREGNING WHERE BEHANDLINGSRESULTAT_ID = :id`
+skal være 0) slik at en mislykket injeksjon feiler ved et tydelig, merket punkt — ikke som en
+forvirrende nedstrøms-feil.
+
+> **DB-injeksjon — vær obs:** dette er den eneste injeksjonen av en hel `BEHANDLING` i repoet (øvrige
+> tester kun `UPDATE`/`SELECT`). Den er skjemagrunnet, men ikke kjørt ende-til-ende (full stack/web
+> nede ved skriving). Hibernate-cache er ikke et problem her: `finnÅrsavregningerPåFagsak` kaller
+> `fagsakService.hentFagsak` på nytt (ny transaksjon) og re-leser `behandlinger` fra DB.
+
+### Assertions (binder «Så»-linjene i scenario 1)
+
+Etter NV-vedtaket + `waitForProcessInstances`:
+
+1. **«auto-opprette en ny årsavregningsbehandling for det foregående kalenderåret» + «knyttes til
+   korrekt kalenderår»:** finn ÅRSAVREGNING-behandlingen som **har** en `AARSAVREGNING`-rad med
+   `AAR = FORRIGE_AAR` (den injiserte uten-år-behandlingen har ingen slik rad → ekskluderes av
+   JOIN-en). `BEHANDLINGSRESULTAT` har `BEHANDLING_ID` som PK, og `AARSAVREGNING.BEHANDLINGSRESULTAT_ID`
+   er derfor behandlingens ID direkte, så JOIN-en er:
+   `SELECT b.ID FROM BEHANDLING b JOIN AARSAVREGNING a ON a.BEHANDLINGSRESULTAT_ID = b.ID WHERE b.BEH_TYPE='ÅRSAVREGNING' AND a.AAR = :aar AND b.ID <> :utenÅrId`.
+   Auto-opprettelsen er asynkron → `expect.poll` på dette oppslaget. Assert deretter fokusert:
+   `BEH_TYPE='ÅRSAVREGNING'`, `STATUS != 'AVSLUTTET'` (åpen), et `BEHANDLINGSRESULTAT` finnes, og
+   `AARSAVREGNING.AAR = FORRIGE_AAR`.
+   > **Ikke** `verifiserAarsavregningBehandling` her: den defaulter `forventetStatus` til `AVSLUTTET`
+   > og krever at **alle** prosessinstanser er FERDIG. Den nye årsavregningen er nettopp auto-opprettet
+   > i flyten og ennå ikke saksbehandlet → den er åpen (status `OPPRETTET` *eller* `UNDER_BEHANDLING`,
+   > jf. `aarsavregning.assertions.ts`) og kan ha prosesser som ikke er FERDIG ennå. Status pinnes
+   > derfor ikke til en bestemt åpen verdi.
+2. **«den ufullstendige behandlingen (uten år) skal ikke ha hindret opprettelsen»:** assert at det nå
+   finnes **≥ 2** ÅRSAVREGNING-behandlinger på saken — den injiserte uten-år (uten AARSAVREGNING-rad,
+   fortsatt åpen) **og** den nye med-år. Den injiserte behandlingen skal fortsatt finnes (ble ikke
+   feilaktig avsluttet).
+3. **«ikke en misvisende feilmelding rettet mot manuell saksbehandling»:** `waitForProcessInstances`
+   kaster på feilede prosessinstanser — den misvisende `FunksjonellException` ville feilet
+   `OPPRETT_NY_BEHANDLING_AARSAVREGNING`-prosessflyten. I tillegg fanger docker-log-fixturen et evt.
+   `FunksjonellException` i api-loggen (ikke `@expect-docker-errors`-tagget). Bærende bevis er at den
+   nye årsavregningen (assertion 1) faktisk ble opprettet.
+
+Avslutt testen med `waitForProcessInstances(page.request, 30)` slik at cleanup-fixturen ikke treffer
+aktive prosessinstanser.
+
+### Scenario 2 (test.fixme) — normal blokkering MED år
+
+Bundet som `test.fixme`. Domenelagets AC for scenario 2 er eksplisitt markert «*utledet — bekreft med
+fagperson at denne regelen er uendret*», og det beskriver **pre-eksisterende** atferd (ikke det 8161
+endrer). Konstruksjons-sti for senere aktivering: injiser en åpen ÅRSAVREGNING-behandling **med**
+`AARSAVREGNING`-rad `AAR = FORRIGE_AAR` og `RESULTAT_TYPE='IKKE_FASTSATT'` (da gir
+`finnÅrsavregningerPåFagsak(..., IKKE_FASTSATT)` treff → `harAktivÅrsavregningforÅr=true` → ingen ny
+opprettes), kjør samme NV-trigger, og assert at det fremdeles finnes **nøyaktig én** ÅRSAVREGNING for
+`FORRIGE_AAR`. «Tilbakestilles» (`resetEksisterendeÅrsavregning`, MELOSYS-7826) krever egen
+verifisering av at saksbehandler-input nullstilles; bekreft med fagperson før binding.
+
+**Page Objects:** `HovedsidePage`, `OpprettNySakPage`, `MedlemskapPage`, `ArbeidsforholdPage`,
+`LovvalgPage`, `ResultatPeriodePage`, `TrygdeavgiftPage`, `VedtakPage`
+**Konstanter:** `pages/shared/constants.ts` (`USER_ID_VALID`, `FORRIGE_AAR`)
+**Hjelpere:** `helpers/api-helper.ts` (`waitForProcessInstances`),
+`helpers/db-helper.ts` (`withDatabase`, ny `execute` — autoCommit-DML for precondition-injeksjon),
+`helpers/pg-db-helper.ts` (`withFaktureringDatabase`), `helpers/date-helper.ts` (`TestPeriods`),
+`helpers/unleash-helper.ts` (`UnleashHelper`)
+
+### Endringslogg (teknisk binding)
+
+- 2026-06-30: Spec opprettet for MELOSYS-8161 fra godkjent domenespec (analysis_trace_id
+  2441d3f7-…). Trigger gjenbruker den verifiserte 8148 scenario 1 NV→tidligere-år-flyten. Precondition
+  («åpen årsavregning uten år») injiseres via DB (skjemagrunnet mot live Oracle). Scenario 1 kjørbar
+  (aksept-/regresjonstest av målatferd), scenario 2 `test.fixme` (pre-eksisterende blokkeringsregel,
+  AC markert «utledet/bekreft»). **Ikke CI-verifisert**: ingen 8161-fix-branch i melosys-api ennå, og
+  full stack (web:3000) nede ved skriving. Statisk analyse: ren «uten år» kan allerede være håndtert
+  i `OppretteÅrsavregningVedEndring` (mapNotNull-bortfall) → testen kan bli grønn mot main; flagget i
+  status-merknaden.
+- 2026-06-30 (assertion-robusthet): byttet ut `verifiserAarsavregningBehandling(forventetStatus:'OPPRETTET',
+  …)` med en fokusert DB-assertion (`STATUS != 'AVSLUTTET'` + behandlingsresultat + `AARSAVREGNING.AAR`
+  + `OPPRETT_NY_BEHANDLING_AARSAVREGNING` FERDIG). Grunn: flyt-auto-opprettede (NV) årsavregninger er
+  åpne og kan være `OPPRETTET` *eller* `UNDER_BEHANDLING` med ikke-FERDIG prosesser; den delte helperen
+  defaulter til `AVSLUTTET` + krever alle prosesser FERDIG → ville feilet av feil grunn. La til en
+  gjenbrukbar `DatabaseHelper.execute()` (autoCommit) for precondition-injeksjonen (Oracle-helperen
+  manglet committende DML; mirrorer `pg-db-helper`).
+- 2026-06-30 (round-trip): blind-agent regenererte testen fra speken alene; folde inn funn (spec-feil
+  rettet, testen var allerede korrekt): (a) `RETURNING ID` er ikke mulig med `execute()` → speket sier
+  nå INSERT + select-back; (b) navngitt `FAGSAK.SAKSNUMMER` eksplisitt (ikke `GSAK_SAKSNUMMER`);
+  (c) pinnet dato-verdier (`SYSTIMESTAMP`/`SYSDATE`); (d) pinnet injeksjons-plassering (etter NV-UI,
+  rett før fatte vedtak); (e) klargjort at førstegangsverdiene er 8148s (ikke komplett-NV-testens) og
+  rettet path-drift (`tests/utenfor-avtaleland/workflows/...`); (f) lagt inn JOIN-fakta
+  `AARSAVREGNING.BEHANDLINGSRESULTAT_ID = BEHANDLING.ID` i assertion 1. Agenten beholdt
+  `forventetStatus:'OPPRETTET'` ordrett (mot gammel spec) — bekrefter at status-over-pinningen var en
+  reell felle, allerede fjernet i assertion-robusthet-endringen over.

--- a/specs/aarsavregning-uten-aar-blokkerer-ikke.md
+++ b/specs/aarsavregning-uten-aar-blokkerer-ikke.md
@@ -1,7 +1,7 @@
 ---
 jira: MELOSYS-8161
 epic: MELOSYS-7080 — Støtte til endringer i medlemskap og trygdeavgift for tidligere år
-status: implemented  # ny test skrevet foran melosys-api-fiksen; ikke CI-verifisert (se status-merknad)
+status: verified  # lokalt + CI rød-mot-master / grønn-mot-8161-fiks (run 28441194646 grønn fiks-image, 28441548657 rød latest). Sc.2 rød mot latest til api-fiks (PR #3408) merges. Se status-merknad.
 test: tests/aarsavregning/aarsavregning-uten-aar-blokkerer-ikke.spec.ts
 toggles: {}          # default-state; per-trigger-koreografi av melosys.faktureringskomponenten.ikke-tidligere-perioder er testmekanikk (se binding)
 tags: [årsavregning, ny-vurdering, tidligere-år, ftrl, auto-opprettelse, regresjon]
@@ -71,22 +71,31 @@ Gitt en FTRL-sak (PENSJONIST) med avgiftspliktige perioder i et foregående kale
 > og skal brukes **ordrett**. Ikke "korriger" dem mot eksempelverdier i POM-ens JSDoc — samme
 > dropdown bruker ulike koder i ulike flyter.
 
-> **Status-merknad (les denne før du tolker «rød/grønn»):**
-> 1. **Fiksen er ikke implementert i melosys-api ennå.** Det finnes ingen `8161`-branch
->    (verifisert `git branch -a | grep 8161` → tom 2026-06-30). Denne testen er skrevet *foran*
->    fiksen — samme mønster som [`aarsavregning-innhentingsbrev-saksbehandlingsflyt.md`](aarsavregning-innhentingsbrev-saksbehandlingsflyt.md) (8148)
->    ble skrevet foran sin api-feature. Den skal CI-verifiseres mot fiks-branchen i en **egen
->    orkestreringsrunde** (Hivemind/CI), ikke i spec-from-analysis-leveransen.
-> 2. **Reproduksjonen av selve pre-fiks-feilen er subtil.** Statisk lesning av
->    `OppretteÅrsavregningVedEndring.opprettÅrsavregning()` + `ÅrsavregningService.finnÅrsavregningerPåFagsak()`
->    viser at en *ren* «uten år»-behandling (uten `aarsavregning`-rad) faller bort i
->    `.mapNotNull { it.årsavregning }` → `harAktivÅrsavregningforÅr = false` → opprettelse går videre.
->    Dvs. nettopp den kanoniske «uten år»-tilstanden denne speken beskriver kan allerede være
->    håndtert i *denne* kodestien, slik at testen kan bli **grønn mot main**. Det er i seg selv et
->    nyttig funn (da ligger pre-fiks-feilen i en mer spesifikk tilstand, jf. analyserapportens
->    «Mangler/uklarheter»). Testen binder derfor **målatferden** (akseptansekriteriet) som en
->    aksept-/regresjonstest, ikke en garantert rød-til-fikset-reproduksjon. Når fiks-branchen
->    finnes: bekreft reproduksjon og stram inn precondition-tilstanden om nødvendig.
+> **Status-merknad (les denne før du tolker «rød/grønn») — oppdatert 2026-06-30 etter lokal kjøring:**
+> 1. **Fiksen er implementert** på melosys-api-branch `8161-aarsavregning-uten-aar`: gaten i
+>    `OppretteÅrsavregningVedEndring` byttet fra `finnÅrsavregningerPåFagsak(..., IKKE_FASTSATT)` til
+>    den nye `ÅrsavregningService.harAktivÅrsavregningForÅr` (sjekker ALLE aktive ÅRSAVREGNING-er
+>    defensivt, 8045-mønster). Apien har egne tester: unit (`ÅrsavregningServiceTest`,
+>    `OppretteÅrsavregningVedEndringTest`) + IT mot ekte DB (`ÅrsavregningDuplikatGateIT`).
+> 2. **To scenarier, ulik rød/grønn-profil — viktig:**
+>    - **Scenario 1 (uten år):** en *ren* «uten år»-behandling (uten `aarsavregning`-rad) faller bort
+>      i `.mapNotNull { it.årsavregning }` i den GAMLE gaten OG gir `null` defensivt i den NYE → begge
+>      gir `harAktiv = false` → opprettelse går videre. Denne er derfor **grønn mot BÅDE master og
+>      fiks** og tester *ikke* selve fiksen. Den er en regresjon for domenets scenario 1.
+>    - **Scenario 2 (den faktiske feilstien fiksen lukker):** en aktiv (ikke-AVSLUTTET) ÅRSAVREGNING
+>      **MED år** men med `RESULTAT_TYPE != IKKE_FASTSATT` (testen bruker `MEDLEM_I_FOLKETRYGDEN`).
+>      Den gamle gaten filtrerte på IKKE_FASTSATT og **bommet** på den, mens den nedstrøms SQL-guarden
+>      (`finnAntallÅrsavregningerPåFagsakForÅr`, kun `status != AVSLUTTET`) **telte** den → opprettelse
+>      startet → SQL-guarden kastet den misvisende `FunksjonellException`-en. **Verifisert RØD lokalt
+>      2026-06-30** mot master-gaten (reproduserte nøyaktig «Det finnes en annen åpen
+>      årsavregningsbehandling for samme år…» fra `ÅrsavregningService.opprettÅrsavregning:91`).
+>      Mot fiksen er gate og SQL-guard enige → blokkerer rent → **GRØNN**. Speiler api-IT-en
+>      `ÅrsavregningDuplikatGateIT` på e2e-nivå (full saksbehandlingsflyt).
+> 3. **Lærdom (MELOSYS-8161):** den opprinnelige «ren uten år»-e2e-en var grønn mot master og testet
+>    derfor ikke fiksen. Det avdekkes KUN ved å kjøre testen lokalt mot base/main FØR man melder grønt
+>    (se HARD GATE i `orchestrate-e2e-flow`). `erAktiv()` er `true` for `OPPRETTET`/`UNDER_BEHANDLING`
+>    (kun `AVSLUTTET`/`MIDLERTIDIG_LOVVALGSBESLUTNING` er inaktive), så en OPPRETTET-injeksjon fanges
+>    av den nye gaten.
 
 ### Bug-mekanikk (for den som binder/verifiserer)
 
@@ -209,10 +218,12 @@ finnes, ingen AARSAVREGNING-rad: `SELECT COUNT(*) FROM AARSAVREGNING WHERE BEHAN
 skal være 0) slik at en mislykket injeksjon feiler ved et tydelig, merket punkt — ikke som en
 forvirrende nedstrøms-feil.
 
-> **DB-injeksjon — vær obs:** dette er den eneste injeksjonen av en hel `BEHANDLING` i repoet (øvrige
-> tester kun `UPDATE`/`SELECT`). Den er skjemagrunnet, men ikke kjørt ende-til-ende (full stack/web
-> nede ved skriving). Hibernate-cache er ikke et problem her: `finnÅrsavregningerPåFagsak` kaller
-> `fagsakService.hentFagsak` på nytt (ny transaksjon) og re-leser `behandlinger` fra DB.
+> **DB-injeksjon — bekreftet:** dette er den eneste injeksjonen av en hel `BEHANDLING` i repoet (øvrige
+> tester kun `UPDATE`/`SELECT`). **Verifisert ende-til-ende lokalt 2026-06-30** (begge scenarier kjørt
+> mot levende stack). Hibernate-cache er ikke et problem: gaten kaller `fagsakService.hentFagsak` på
+> nytt (ny transaksjon) og re-leser `behandlinger` fra DB, så den injiserte behandlingen er synlig.
+> `scenario 2`-injeksjonen (status `OPPRETTET`) fanges av `harAktivÅrsavregningForÅr` fordi
+> `erAktiv()` = `!(erAvsluttet() || erMidlertidigLovvalgsbeslutning())` → `true` for `OPPRETTET`.
 
 ### Assertions (binder «Så»-linjene i scenario 1)
 
@@ -245,16 +256,34 @@ Etter NV-vedtaket + `waitForProcessInstances`:
 Avslutt testen med `waitForProcessInstances(page.request, 30)` slik at cleanup-fixturen ikke treffer
 aktive prosessinstanser.
 
-### Scenario 2 (test.fixme) — normal blokkering MED år
+### Scenario 2 (kjørbar — DEKKER FIKSEN) — aktiv årsavregning MED år, resultattype ≠ IKKE_FASTSATT
 
-Bundet som `test.fixme`. Domenelagets AC for scenario 2 er eksplisitt markert «*utledet — bekreft med
-fagperson at denne regelen er uendret*», og det beskriver **pre-eksisterende** atferd (ikke det 8161
-endrer). Konstruksjons-sti for senere aktivering: injiser en åpen ÅRSAVREGNING-behandling **med**
-`AARSAVREGNING`-rad `AAR = FORRIGE_AAR` og `RESULTAT_TYPE='IKKE_FASTSATT'` (da gir
-`finnÅrsavregningerPåFagsak(..., IKKE_FASTSATT)` treff → `harAktivÅrsavregningforÅr=true` → ingen ny
-opprettes), kjør samme NV-trigger, og assert at det fremdeles finnes **nøyaktig én** ÅRSAVREGNING for
-`FORRIGE_AAR`. «Tilbakestilles» (`resetEksisterendeÅrsavregning`, MELOSYS-7826) krever egen
-verifisering av at saksbehandler-input nullstilles; bekreft med fagperson før binding.
+Dette er den faktiske feilstien 8161 lukker, og den eneste av de to scenariene som faktisk skiller
+fiks fra master. Precondition (helper `gittÅpenÅrsavregningMedÅr(saksnummer, FORRIGE_AAR)`): injiser
+en åpen (status `OPPRETTET`, dvs. `erAktiv()=true`) ÅRSAVREGNING **med** `AARSAVREGNING`-rad
+`AAR = FORRIGE_AAR`, men `RESULTAT_TYPE = 'MEDLEM_I_FOLKETRYGDEN'` **(verbatim — må være ≠ IKKE_FASTSATT)**:
+
+- `INSERT INTO BEHANDLINGSRESULTAT (..., RESULTAT_TYPE, ...) VALUES (:id, 'MANUELT', 'MEDLEM_I_FOLKETRYGDEN', ...)`
+- `INSERT INTO AARSAVREGNING (BEHANDLINGSRESULTAT_ID, AAR) VALUES (:id, :aar)` (begge NOT NULL; `BEHANDLINGSRESULTAT_ID` = behandlingens ID).
+
+Kjør samme NV-trigger som scenario 1. **Forventet atferd:**
+- **mot master (gammel gate `finnÅrsavregningerPåFagsak(..., IKKE_FASTSATT)`):** den år-satte
+  behandlingen filtreres bort av IKKE_FASTSATT-filteret → `harAktiv=false` → opprettelse starter →
+  SQL-guarden (`finnAntallÅrsavregningerPåFagsakForÅr`, teller alle ikke-AVSLUTTET) treffer →
+  `opprettÅrsavregning` kaster den misvisende `FunksjonellException`-en → `OPPRETT_NY_BEHANDLING_AARSAVREGNING`
+  feiler → **RØD**.
+- **mot fiks (ny gate `harAktivÅrsavregningForÅr`):** gaten ser den aktive år-satte behandlingen →
+  `harAktiv=true` → ingen ny opprettes, ingen feil → **GRØNN**.
+
+**Assertions (binder scenario 2):**
+- `waitForProcessInstances` rett etter vedtaket — **bærende rød/grønn-diskriminator** (kaster på den
+  feilede `OPPRETT_NY_BEHANDLING_AARSAVREGNING`-prosessen mot master).
+- nøyaktig **én** ÅRSAVREGNING for `FORRIGE_AAR` (den injiserte) — ingen duplikat.
+- den injiserte behandlingen finnes fortsatt.
+
+> «Tilbakestilles» (`resetEksisterendeÅrsavregning`, MELOSYS-7826) er pre-eksisterende atferd og ikke
+> bundet her — domenelagets scenario-2-AC er markert «utledet/bekreft», så vi binder kun
+> «ingen ny + ingen misvisende feil» (det 8161 faktisk endrer).
 
 **Page Objects:** `HovedsidePage`, `OpprettNySakPage`, `MedlemskapPage`, `ArbeidsforholdPage`,
 `LovvalgPage`, `ResultatPeriodePage`, `TrygdeavgiftPage`, `VedtakPage`
@@ -290,3 +319,15 @@ verifisering av at saksbehandler-input nullstilles; bekreft med fagperson før b
   `AARSAVREGNING.BEHANDLINGSRESULTAT_ID = BEHANDLING.ID` i assertion 1. Agenten beholdt
   `forventetStatus:'OPPRETTET'` ordrett (mot gammel spec) — bekrefter at status-over-pinningen var en
   reell felle, allerede fjernet i assertion-robusthet-endringen over.
+- 2026-06-30 (KRITISK — testet faktisk fiksen): kjørte testen lokalt og oppdaget at den opprinnelige
+  «ren uten år»-varianten var **grønn også mot master** → testet ikke fiksen. Leste den faktiske
+  melosys-api-fiksen (branch `8161-aarsavregning-uten-aar`: ny `harAktivÅrsavregningForÅr`-gate +
+  api-IT `ÅrsavregningDuplikatGateIT`). Endret scenario 2 fra `test.fixme` til en **kjørbar** test som
+  injiserer den FAKTISKE feilstien: aktiv ÅRSAVREGNING MED år men `RESULTAT_TYPE='MEDLEM_I_FOLKETRYGDEN'`
+  (≠ IKKE_FASTSATT). **Verifisert lokalt:** scenario 2 RØD mot master-gaten (reproduserte
+  `FunksjonellException: «Det finnes en annen åpen årsavregningsbehandling...»` fra
+  `ÅrsavregningService.opprettÅrsavregning:91`), GRØNN mot 8161-fiks-gaten. Scenario 1 (uten år) grønn
+  begge veier. **Bekreftet i CI:** fiks-image grønn (run 28441194646, 2 passed), latest rød på
+  scenario 2 med eksakt ticket-feil (run 28441548657). Lærdom (lokal-først HARD GATE): kjør testen
+  lokalt RØD-mot-base FØR du melder grønt — en test som er grønn mot base tester ikke fiksen. Kodifisert
+  i `orchestrate-e2e-flow` + `muninn-delegation-handler`.

--- a/tests/aarsavregning/aarsavregning-uten-aar-blokkerer-ikke.spec.ts
+++ b/tests/aarsavregning/aarsavregning-uten-aar-blokkerer-ikke.spec.ts
@@ -125,10 +125,16 @@ async function lesEnesteSaksnummer(): Promise<string> {
  */
 async function gittÅpenÅrsavregningUtenÅr(saksnummer: string): Promise<number> {
     return withDatabase(async (db) => {
+        // REGISTRERT_AV/ENDRET_AV settes (saksbehandler-ident, som alle ekte behandlinger) slik at
+        // stubben kan åpnes i GUI-en. Uten ident gir GET /api/behandlinger/{id} HTTP 500
+        // (AzureAdService.hentSaksbehandlerNavn(ident: String) er non-null), GUI-en faller tilbake til
+        // ingen-flyt-ruten med behandlingID=-1. Påvirker ikke assertene (kun DB-tilstand verifiseres).
         await db.execute(
             `INSERT INTO BEHANDLING
-                 (SAKSNUMMER, STATUS, BEH_TYPE, REGISTRERT_DATO, ENDRET_DATO, BEH_TEMA, BEHANDLINGSFRIST)
-             VALUES (:s, 'OPPRETTET', 'ÅRSAVREGNING', SYSTIMESTAMP, SYSTIMESTAMP, 'YRKESAKTIV', SYSDATE)`,
+                 (SAKSNUMMER, STATUS, BEH_TYPE, REGISTRERT_DATO, ENDRET_DATO,
+                  REGISTRERT_AV, ENDRET_AV, BEH_TEMA, BEHANDLINGSFRIST)
+             VALUES (:s, 'OPPRETTET', 'ÅRSAVREGNING', SYSTIMESTAMP, SYSTIMESTAMP,
+                     'Z123456', 'Z123456', 'YRKESAKTIV', SYSDATE)`,
             {s: saksnummer}
         );
 
@@ -195,8 +201,10 @@ async function gittÅpenÅrsavregningMedÅr(saksnummer: string, aar: number): Pr
     return withDatabase(async (db) => {
         await db.execute(
             `INSERT INTO BEHANDLING
-                 (SAKSNUMMER, STATUS, BEH_TYPE, REGISTRERT_DATO, ENDRET_DATO, BEH_TEMA, BEHANDLINGSFRIST)
-             VALUES (:s, 'OPPRETTET', 'ÅRSAVREGNING', SYSTIMESTAMP, SYSTIMESTAMP, 'YRKESAKTIV', SYSDATE)`,
+                 (SAKSNUMMER, STATUS, BEH_TYPE, REGISTRERT_DATO, ENDRET_DATO,
+                  REGISTRERT_AV, ENDRET_AV, BEH_TEMA, BEHANDLINGSFRIST)
+             VALUES (:s, 'OPPRETTET', 'ÅRSAVREGNING', SYSTIMESTAMP, SYSTIMESTAMP,
+                     'Z123456', 'Z123456', 'YRKESAKTIV', SYSDATE)`,
             {s: saksnummer}
         );
 

--- a/tests/aarsavregning/aarsavregning-uten-aar-blokkerer-ikke.spec.ts
+++ b/tests/aarsavregning/aarsavregning-uten-aar-blokkerer-ikke.spec.ts
@@ -1,5 +1,5 @@
 import {expect, test} from '../../fixtures';
-import type {Page} from '@playwright/test';
+import type {APIRequestContext, Page} from '@playwright/test';
 import {AuthHelper} from '../../helpers/auth-helper';
 import {HovedsidePage} from '../../pages/hovedside.page';
 import {OpprettNySakPage} from '../../pages/opprett-ny-sak/opprett-ny-sak.page';
@@ -182,6 +182,124 @@ async function finnNyÅrsavregningMedÅr(aar: number, ekskluderBehandlingId: num
     });
 }
 
+/**
+ * Gitt: en ÅPEN ÅRSAVREGNING-behandling MED år (aar) på saken, men med behandlingsresultattype
+ * != IKKE_FASTSATT. Dette er nettopp feilstien fiksen lukker: den gamle gaten filtrerte på
+ * IKKE_FASTSATT og BOMMET på denne, mens den nedstrøms SQL-guarden (kun status != AVSLUTTET) talte
+ * den → «opprett-så-kast» med den misvisende feilmeldingen. Enum-verdier FK-verifisert mot live
+ * Oracle (AARSAVREGNING-PK = (BEHANDLINGSRESULTAT_ID, AAR), begge NOT NULL).
+ *
+ * @returns BEHANDLING.ID for den injiserte med-år-behandlingen.
+ */
+async function gittÅpenÅrsavregningMedÅr(saksnummer: string, aar: number): Promise<number> {
+    return withDatabase(async (db) => {
+        await db.execute(
+            `INSERT INTO BEHANDLING
+                 (SAKSNUMMER, STATUS, BEH_TYPE, REGISTRERT_DATO, ENDRET_DATO, BEH_TEMA, BEHANDLINGSFRIST)
+             VALUES (:s, 'OPPRETTET', 'ÅRSAVREGNING', SYSTIMESTAMP, SYSTIMESTAMP, 'YRKESAKTIV', SYSDATE)`,
+            {s: saksnummer}
+        );
+
+        // På injeksjonstidspunktet (før NV-vedtaket) er dette den ENESTE ÅRSAVREGNING-behandlingen.
+        const rad = await db.queryOne<IdRad>(
+            `SELECT ID FROM BEHANDLING WHERE SAKSNUMMER = :s AND BEH_TYPE = 'ÅRSAVREGNING'`,
+            {s: saksnummer}
+        );
+        expect(rad, 'Injeksjon feilet: fant ikke den injiserte ÅRSAVREGNING-behandlingen').not.toBeNull();
+        const id = Number(rad!.ID);
+
+        await db.execute(
+            `INSERT INTO BEHANDLINGSRESULTAT
+                 (BEHANDLING_ID, BEHANDLINGSMAATE, RESULTAT_TYPE, REGISTRERT_DATO, ENDRET_DATO)
+             VALUES (:id, 'MANUELT', 'MEDLEM_I_FOLKETRYGDEN', SYSTIMESTAMP, SYSTIMESTAMP)`,
+            {id}
+        );
+        await db.execute(
+            `INSERT INTO AARSAVREGNING (BEHANDLINGSRESULTAT_ID, AAR) VALUES (:id, :aar)`,
+            {id, aar}
+        );
+
+        const medÅr = await db.queryOne<{N: number}>(
+            'SELECT COUNT(*) AS N FROM AARSAVREGNING WHERE BEHANDLINGSRESULTAT_ID = :id AND AAR = :aar',
+            {id, aar}
+        );
+        expect(
+            Number(medÅr!.N),
+            'Precondition: injisert årsavregning skal HA år (AARSAVREGNING-rad for året)'
+        ).toBe(1);
+
+        console.log(`📌 Injisert åpen ÅRSAVREGNING-behandling MED år=${aar}: behandlingId=${id} (sak ${saksnummer})`);
+        return id;
+    });
+}
+
+/**
+ * Felles flyt for scenariene: vedtatt FTRL-sak (inneværende år) + ny vurdering som flytter perioden
+ * til kun forrige år, helt fram til (men ikke medregnet) vedtaksfattingen. Returnerer saksnummeret
+ * og VedtakPage slik at hver test kan injisere sin precondition rett før vedtaket fattes.
+ */
+async function settOppSakOgNyVurderingTilbakeITid(
+    page: Page,
+    request: APIRequestContext
+): Promise<{saksnummer: string; vedtak: VedtakPage}> {
+    const auth = new AuthHelper(page);
+    const unleash = new UnleashHelper(request);
+
+    await unleash.disableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+    await auth.login();
+
+    await opprettVedtattSakInneværendeÅr(page);
+
+    // Fakturaene må være BESTILT for at NV-avregningen skal gå gjennom.
+    await withFaktureringDatabase(async (db) => {
+        const updated = await db.execute("UPDATE faktura SET status = 'BESTILT'");
+        console.log(`📝 Satte ${updated} faktura-rader til BESTILT`);
+    });
+
+    await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+
+    const saksnummer = await lesEnesteSaksnummer();
+
+    const hovedside = new HovedsidePage(page);
+    const opprettSak = new OpprettNySakPage(page);
+    const medlemskap = new MedlemskapPage(page);
+    const arbeidsforhold = new ArbeidsforholdPage(page);
+    const lovvalg = new LovvalgPage(page);
+    const resultatPeriode = new ResultatPeriodePage(page);
+    const trygdeavgift = new TrygdeavgiftPage(page);
+    const vedtak = new VedtakPage(page);
+
+    console.log('📝 Oppretter ny vurdering...');
+    await hovedside.klikkOpprettNySak();
+    await opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD');
+    await waitForProcessInstances(page.request, 30);
+
+    await hovedside.goto();
+    await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).first().click();
+
+    const periodeNV = TestPeriods.previousYearPeriod;
+    console.log(`📝 NV medlemskap (${periodeNV.start} - ${periodeNV.end})...`);
+    await medlemskap.velgPeriode(periodeNV.start, periodeNV.end);
+    await medlemskap.klikkBekreftOgFortsett();
+
+    await arbeidsforhold.fyllUtArbeidsforhold('Ståles Stål AS');
+
+    console.log('📝 NV lovvalg (FTRL 2-1 fjerde ledd)...');
+    await lovvalg.velgBestemmelse('FTRL_KAP2_2_1');
+    await lovvalg.velgBrukersSituasjon('MIDLERTIDIG_ARBEID_2_1_FJERDE_LEDD');
+    await lovvalg.svarJaPaaFørsteSpørsmål();
+    await lovvalg.svarJaPaaSpørsmålIGruppe('Er søkers arbeidsoppdrag i');
+    await lovvalg.svarJaPaaSpørsmålIGruppe('Plikter arbeidsgiver å betale');
+    await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker lovlig opphold i');
+    await lovvalg.klikkBekreftOgFortsett();
+
+    // Resultat og trygdeavgift beholdes fra forrige behandling.
+    await resultatPeriode.klikkBekreftOgFortsett();
+    await trygdeavgift.klikkBekreftOgFortsett();
+
+    return {saksnummer, vedtak};
+}
+
 test.describe('Årsavregning uten år blokkerer ikke automatisk opprettelse (MELOSYS-8161)', () => {
     test('åpen årsavregning uten år hindrer ikke auto-opprettelse for tidligere år', async ({
         page,
@@ -361,21 +479,62 @@ test.describe('Årsavregning uten år blokkerer ikke automatisk opprettelse (MEL
         console.log('✅ Uten-år-behandlingen blokkerte ikke auto-opprettelsen.');
     });
 
-    // Scenario 2 — normal blokkering MED år (regresjon).
+    // Scenario 2 — eksisterende åpen årsavregning MED år (feilstien) blokkerer fortsatt.
     //
-    // Bundet som fixme. Domenelagets AC for scenario 2 er eksplisitt markert «utledet — bekreft med
-    // fagperson at denne regelen er uendret», og beskriver PRE-EKSISTERENDE atferd (ikke det 8161
-    // endrer). Konstruksjons-sti for senere aktivering (se speken): injiser en åpen ÅRSAVREGNING-
-    // behandling MED AARSAVREGNING-rad AAR=FORRIGE_AAR og RESULTAT_TYPE='IKKE_FASTSATT' (da gir
-    // finnÅrsavregningerPåFagsak(..., IKKE_FASTSATT) treff → harAktivÅrsavregningforÅr=true → ingen ny
-    // opprettes), kjør samme NV-trigger, og assert at det fremdeles finnes NØYAKTIG ÉN ÅRSAVREGNING for
-    // FORRIGE_AAR. «Tilbakestilles» (resetEksisterendeÅrsavregning, MELOSYS-7826) krever egen
-    // verifisering av at saksbehandler-input nullstilles — bekreft med fagperson før binding.
-    test.fixme(
-        'åpen årsavregning MED år for samme år blokkerer fortsatt ny opprettelse',
-        async () => {
-            // Krever konstruksjon av «åpen årsavregning MED år» + verifisering av tilbakestilling.
-            // Se speken (specs/aarsavregning-uten-aar-blokkerer-ikke.md), scenario 2.
-        }
-    );
+    // Precondition strammet til den FAKTISKE feilstien (jf. spec-ens status-merknad): åpen ÅRSAVREGNING
+    // MED AARSAVREGNING-rad AAR=FORRIGE_AAR, men RESULTAT_TYPE != IKKE_FASTSATT. Mot master bommer den
+    // gamle IKKE_FASTSATT-filtrerte gaten på den → auto-opprettelsen går videre → SQL-guarden kaster
+    // den misvisende feilen (OPPRETT_NY_BEHANDLING_AARSAVREGNING feiler → waitForProcessInstances kaster
+    // = RØD). Med fiksen er gaten enig med SQL-guarden og blokkerer rent (GRØNN). «Tilbakestilles»
+    // (resetEksisterendeÅrsavregning, MELOSYS-7826) er pre-eksisterende atferd og ikke bundet her.
+    test('åpen årsavregning MED år (annen resultattype) blokkerer fortsatt — uten misvisende feil', async ({
+        page,
+        request,
+    }) => {
+        test.setTimeout(240_000);
+
+        const {saksnummer, vedtak} = await settOppSakOgNyVurderingTilbakeITid(page, request);
+
+        // GITT: en åpen ÅRSAVREGNING MED år (FORRIGE_AAR), behandlingsresultattype != IKKE_FASTSATT.
+        const medÅrBehandlingId = await gittÅpenÅrsavregningMedÅr(saksnummer, FORRIGE_AAR);
+
+        console.log('📝 Fatter vedtak for ny vurdering (med endring i forrige års periode)...');
+        await vedtak.fattVedtakForNyVurdering('FEIL_I_BEHANDLING');
+        // Med fiksen starter ingen opprett-prosess (gaten blokkerer) → ingen feilende prosess.
+        // Mot master ville OPPRETT_NY_BEHANDLING_AARSAVREGNING feilet → dette kallet kastet.
+        await waitForProcessInstances(page.request, 60);
+
+        // SÅ: ingen NY årsavregning opprettes for FORRIGE_AAR — fortsatt nøyaktig ÉN ÅRSAVREGNING med
+        // AARSAVREGNING-rad for året (den injiserte).
+        const nyId = await finnNyÅrsavregningMedÅr(FORRIGE_AAR, medÅrBehandlingId);
+        expect(
+            nyId,
+            'Ingen NY årsavregning skal opprettes når det finnes en åpen for samme år'
+        ).toBeUndefined();
+
+        const antallMedÅr = await withDatabase(async (db) =>
+            db.queryOne<{N: number}>(
+                `SELECT COUNT(*) AS N
+                 FROM BEHANDLING b
+                 JOIN AARSAVREGNING a ON a.BEHANDLINGSRESULTAT_ID = b.ID
+                 WHERE b.BEH_TYPE = 'ÅRSAVREGNING' AND a.AAR = :aar`,
+                {aar: FORRIGE_AAR}
+            )
+        );
+        expect(
+            Number(antallMedÅr!.N),
+            `Det skal finnes nøyaktig én ÅRSAVREGNING for ${FORRIGE_AAR} (den injiserte) — ingen ny`
+        ).toBe(1);
+
+        // Den injiserte behandlingen skal fortsatt finnes (ikke feilaktig avsluttet/ryddet).
+        const fortsatt = await withDatabase(async (db) =>
+            db.queryOne<{STATUS: string}>('SELECT STATUS FROM BEHANDLING WHERE ID = :id', {
+                id: medÅrBehandlingId,
+            })
+        );
+        expect(fortsatt, 'Den injiserte årsavregningsbehandlingen skal fortsatt finnes').not.toBeNull();
+
+        await waitForProcessInstances(page.request, 30);
+        console.log('✅ Eksisterende årsavregning MED år blokkerte ny opprettelse uten misvisende feil.');
+    });
 });

--- a/tests/aarsavregning/aarsavregning-uten-aar-blokkerer-ikke.spec.ts
+++ b/tests/aarsavregning/aarsavregning-uten-aar-blokkerer-ikke.spec.ts
@@ -1,0 +1,381 @@
+import {expect, test} from '../../fixtures';
+import type {Page} from '@playwright/test';
+import {AuthHelper} from '../../helpers/auth-helper';
+import {HovedsidePage} from '../../pages/hovedside.page';
+import {OpprettNySakPage} from '../../pages/opprett-ny-sak/opprett-ny-sak.page';
+import {MedlemskapPage} from '../../pages/behandling/medlemskap.page';
+import {ArbeidsforholdPage} from '../../pages/behandling/arbeidsforhold.page';
+import {LovvalgPage} from '../../pages/behandling/lovvalg.page';
+import {ResultatPeriodePage} from '../../pages/behandling/resultat-periode.page';
+import {TrygdeavgiftPage} from '../../pages/trygdeavgift/trygdeavgift.page';
+import {VedtakPage} from '../../pages/vedtak/vedtak.page';
+import {FORRIGE_AAR, USER_ID_VALID} from '../../pages/shared/constants';
+import {UnleashHelper} from '../../helpers/unleash-helper';
+import {waitForProcessInstances} from '../../helpers/api-helper';
+import {TestPeriods} from '../../helpers/date-helper';
+import {withDatabase} from '../../helpers/db-helper';
+import {withFaktureringDatabase} from '../../helpers/pg-db-helper';
+
+/**
+ * MELOSYS-8161: Årsavregningsbehandling blir ikke opprettet pga. åpen årsav. beh. uten år.
+ *
+ * Spec: specs/aarsavregning-uten-aar-blokkerer-ikke.md
+ *
+ * Når Melosys i en saksbehandlingsflyt automatisk skal opprette en årsavregningsbehandling for et
+ * tidligere år, og det allerede finnes en ÅPEN årsavregningsbehandling UTEN fastsatt år på saken,
+ * skal den ufullstendige behandlingen IKKE blokkere opprettelsen. Den nye årsavregningen skal
+ * likevel opprettes for det aktuelle året, uten en misvisende feilmelding rettet mot manuell
+ * saksbehandling.
+ *
+ * Samme bug-mønster som den allerede fiksede MELOSYS-8045 (ÅrsavregningIkkeSkattepliktigeProsessGenerator
+ * → hentÅrFraBehandlingDefensivt), men i OppretteÅrsavregningVedEndring-flyten.
+ *
+ * STATUS — les status-merknaden i speken:
+ *  - Det finnes INGEN 8161-fix-branch i melosys-api ennå → testen asserter målatferden og er IKKE
+ *    CI-verifisert (verifiseres mot fiks-branchen i en egen orkestreringsrunde).
+ *  - «Åpen årsavregning uten år» = ÅRSAVREGNING-behandling med behandlingsresultat, men UTEN
+ *    AARSAVREGNING-rad. Preconditionen injiseres deterministisk via DB (skjema/enum-verdier grunnet
+ *    mot live Oracle 2026-06-30) fordi det ikke finnes en verifisert UI-sti for å lage en manuell,
+ *    ufullført årsavregning på en eksisterende FTRL-sak.
+ */
+
+/** AktørId for USER_ID_VALID i PDL-mocken (ikke brukt direkte her, men dokumenterer testbrukeren). */
+const AKTOER_ID_VALID = '1111111111111';
+void AKTOER_ID_VALID;
+
+type IdRad = {ID: number};
+
+/**
+ * Felles forutsetning: vedtatt FTRL-sak med trygdeavgift som betales til NAV (ikke-skattepliktig).
+ * Førstegangsvedtaket gjelder INNEVÆRENDE år — tidligere-års-endringen gjøres etterpå som ny
+ * vurdering. Byte-for-byte samme oppskrift som MELOSYS-8148 scenario 1.
+ *
+ * Toggle melosys.faktureringskomponenten.ikke-tidligere-perioder må være AV under opprettelsen.
+ */
+async function opprettVedtattSakInneværendeÅr(page: Page): Promise<void> {
+    const hovedside = new HovedsidePage(page);
+    const opprettSak = new OpprettNySakPage(page);
+    const medlemskap = new MedlemskapPage(page);
+    const arbeidsforhold = new ArbeidsforholdPage(page);
+    const lovvalg = new LovvalgPage(page);
+    const resultatPeriode = new ResultatPeriodePage(page);
+    const trygdeavgift = new TrygdeavgiftPage(page);
+    const vedtak = new VedtakPage(page);
+
+    const periode = TestPeriods.currentYearPeriod;
+
+    console.log('📝 Oppretter sak (inneværende år)...');
+    await hovedside.gotoOgOpprettNySak();
+    await opprettSak.opprettStandardSak(USER_ID_VALID);
+    await opprettSak.assertions.verifiserBehandlingOpprettet();
+
+    await waitForProcessInstances(page.request, 30);
+    await hovedside.goto();
+    await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).click();
+
+    console.log(`📝 Medlemskap (${periode.start} - ${periode.end})...`);
+    await medlemskap.velgPeriode(periode.start, periode.end);
+    await medlemskap.velgLand('Afghanistan');
+    await medlemskap.velgTrygdedekning('FTRL_2_9_FØRSTE_LEDD_C_HELSE_PENSJON');
+    await medlemskap.klikkBekreftOgFortsett();
+
+    console.log('📝 Arbeidsforhold...');
+    await arbeidsforhold.fyllUtArbeidsforhold('Ståles Stål AS');
+
+    console.log('📝 Lovvalg...');
+    await lovvalg.velgBestemmelse('FTRL_KAP2_2_8_FØRSTE_LEDD_A');
+    await lovvalg.svarJaPaaFørsteSpørsmål();
+    await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker vært medlem i minst');
+    await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker nær tilknytning til');
+    await lovvalg.klikkBekreftOgFortsett();
+
+    console.log('📝 Resultat...');
+    await resultatPeriode.fyllUtResultatPeriode('INNVILGET');
+
+    console.log('📝 Trygdeavgift (ikke-skattepliktig)...');
+    await trygdeavgift.ventPåSideLastet();
+    await trygdeavgift.velgSkattepliktig(false);
+    await trygdeavgift.velgInntektskilde('INNTEKT_FRA_UTLANDET');
+    await trygdeavgift.velgBetalesAga(false);
+    await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
+    await trygdeavgift.klikkBekreftOgFortsett();
+
+    console.log('📝 Fatter førstegangsvedtak...');
+    await vedtak.klikkFattVedtak();
+    await waitForProcessInstances(page.request, 30);
+}
+
+/** Saksnummeret til den (eneste) fagsaken — cleanup-fixturen gir nøyaktig én fagsak per test. */
+async function lesEnesteSaksnummer(): Promise<string> {
+    return withDatabase(async (db) => {
+        const rader = await db.query<{SAKSNUMMER: string}>('SELECT SAKSNUMMER FROM FAGSAK', {});
+        expect(rader.length, 'Forventet nøyaktig én fagsak (ren DB per test)').toBe(1);
+        return rader[0].SAKSNUMMER;
+    });
+}
+
+/**
+ * Gitt: en ÅPEN ÅRSAVREGNING-behandling UTEN år på saken.
+ *
+ * Injiserer den kanoniske «uten år»-tilstanden: en BEHANDLING (BEH_TYPE='ÅRSAVREGNING', åpen) med et
+ * BEHANDLINGSRESULTAT, men UTEN AARSAVREGNING-rad. Enum-verdier er FK-verifisert mot live Oracle
+ * (BEHANDLING_STATUS/BEHANDLING_TYPE/BEHANDLING_TEMA/BEHANDLINGSMAATE/BEHANDLINGSRESULTAT_TYPE).
+ *
+ * @returns BEHANDLING.ID for den injiserte uten-år-behandlingen.
+ */
+async function gittÅpenÅrsavregningUtenÅr(saksnummer: string): Promise<number> {
+    return withDatabase(async (db) => {
+        await db.execute(
+            `INSERT INTO BEHANDLING
+                 (SAKSNUMMER, STATUS, BEH_TYPE, REGISTRERT_DATO, ENDRET_DATO, BEH_TEMA, BEHANDLINGSFRIST)
+             VALUES (:s, 'OPPRETTET', 'ÅRSAVREGNING', SYSTIMESTAMP, SYSTIMESTAMP, 'YRKESAKTIV', SYSDATE)`,
+            {s: saksnummer}
+        );
+
+        // På injeksjonstidspunktet (før NV-vedtaket fyrer auto-opprettelsen) er dette den ENESTE
+        // ÅRSAVREGNING-behandlingen på saken → entydig select-back av den genererte ID-en.
+        const rad = await db.queryOne<IdRad>(
+            `SELECT ID FROM BEHANDLING WHERE SAKSNUMMER = :s AND BEH_TYPE = 'ÅRSAVREGNING'`,
+            {s: saksnummer}
+        );
+        expect(rad, 'Injeksjon feilet: fant ikke den injiserte ÅRSAVREGNING-behandlingen').not.toBeNull();
+        const id = Number(rad!.ID);
+
+        await db.execute(
+            `INSERT INTO BEHANDLINGSRESULTAT
+                 (BEHANDLING_ID, BEHANDLINGSMAATE, RESULTAT_TYPE, REGISTRERT_DATO, ENDRET_DATO)
+             VALUES (:id, 'MANUELT', 'IKKE_FASTSATT', SYSTIMESTAMP, SYSTIMESTAMP)`,
+            {id}
+        );
+
+        // Verifiser preconditionen: ingen AARSAVREGNING-rad = «uten år». Slår en mislykket injeksjon
+        // av ved et tydelig, merket punkt i stedet for som en forvirrende nedstrøms-feil.
+        const utenÅr = await db.queryOne<{N: number}>(
+            'SELECT COUNT(*) AS N FROM AARSAVREGNING WHERE BEHANDLINGSRESULTAT_ID = :id',
+            {id}
+        );
+        expect(
+            Number(utenÅr!.N),
+            'Precondition: injisert årsavregning skal være UTEN år (ingen AARSAVREGNING-rad)'
+        ).toBe(0);
+
+        console.log(`📌 Injisert åpen ÅRSAVREGNING-behandling UTEN år: behandlingId=${id} (sak ${saksnummer})`);
+        return id;
+    });
+}
+
+/**
+ * Finn en ÅRSAVREGNING-behandling som HAR en AARSAVREGNING-rad for gitt år (ekskl. den injiserte
+ * uten-år-behandlingen, som per definisjon ikke har en slik rad). Returnerer undefined hvis ingen
+ * finnes ennå (auto-opprettelsen er asynkron → poll på denne).
+ */
+async function finnNyÅrsavregningMedÅr(aar: number, ekskluderBehandlingId: number): Promise<number | undefined> {
+    return withDatabase(async (db) => {
+        const rad = await db.queryOne<IdRad>(
+            `SELECT b.ID
+             FROM BEHANDLING b
+             JOIN AARSAVREGNING a ON a.BEHANDLINGSRESULTAT_ID = b.ID
+             WHERE b.BEH_TYPE = 'ÅRSAVREGNING' AND a.AAR = :aar AND b.ID <> :ekskluder`,
+            {aar, ekskluder: ekskluderBehandlingId}
+        );
+        return rad ? Number(rad.ID) : undefined;
+    });
+}
+
+test.describe('Årsavregning uten år blokkerer ikke automatisk opprettelse (MELOSYS-8161)', () => {
+    test('åpen årsavregning uten år hindrer ikke auto-opprettelse for tidligere år', async ({
+        page,
+        request,
+    }) => {
+        test.setTimeout(240_000);
+        const auth = new AuthHelper(page);
+        const unleash = new UnleashHelper(request);
+
+        // Endringen som berører tidligere år gjøres som ny vurdering: førstegangsvedtaket gjelder
+        // inneværende år (toggle AV — fakturering må akseptere serien), NV endrer perioden til kun
+        // forrige år med toggle PÅ slik at OppretteÅrsavregningVedEndring auto-oppretter årsavregningen.
+        await unleash.disableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+        await auth.login();
+
+        await opprettVedtattSakInneværendeÅr(page);
+
+        // Fakturaene må være BESTILT for at NV-avregningen skal gå gjennom.
+        await withFaktureringDatabase(async (db) => {
+            const updated = await db.execute("UPDATE faktura SET status = 'BESTILT'");
+            console.log(`📝 Satte ${updated} faktura-rader til BESTILT`);
+        });
+
+        await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
+
+        // Saksnummeret (én fagsak) — trengs for å injisere preconditionen på samme sak.
+        const saksnummer = await lesEnesteSaksnummer();
+
+        // Ny vurdering: perioden endres til kun forrige år.
+        const hovedside = new HovedsidePage(page);
+        const opprettSak = new OpprettNySakPage(page);
+        const medlemskap = new MedlemskapPage(page);
+        const arbeidsforhold = new ArbeidsforholdPage(page);
+        const lovvalg = new LovvalgPage(page);
+        const resultatPeriode = new ResultatPeriodePage(page);
+        const trygdeavgift = new TrygdeavgiftPage(page);
+        const vedtak = new VedtakPage(page);
+
+        console.log('📝 Oppretter ny vurdering...');
+        await hovedside.klikkOpprettNySak();
+        await opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD');
+        await waitForProcessInstances(page.request, 30);
+
+        await hovedside.goto();
+        await page.getByRole('link', {name: 'TRIVIELL KARAFFEL -'}).first().click();
+
+        const periodeNV = TestPeriods.previousYearPeriod;
+        console.log(`📝 NV medlemskap (${periodeNV.start} - ${periodeNV.end})...`);
+        await medlemskap.velgPeriode(periodeNV.start, periodeNV.end);
+        await medlemskap.klikkBekreftOgFortsett();
+
+        await arbeidsforhold.fyllUtArbeidsforhold('Ståles Stål AS');
+
+        console.log('📝 NV lovvalg (FTRL 2-1 fjerde ledd)...');
+        await lovvalg.velgBestemmelse('FTRL_KAP2_2_1');
+        await lovvalg.velgBrukersSituasjon('MIDLERTIDIG_ARBEID_2_1_FJERDE_LEDD');
+        await lovvalg.svarJaPaaFørsteSpørsmål();
+        await lovvalg.svarJaPaaSpørsmålIGruppe('Er søkers arbeidsoppdrag i');
+        await lovvalg.svarJaPaaSpørsmålIGruppe('Plikter arbeidsgiver å betale');
+        await lovvalg.svarJaPaaSpørsmålIGruppe('Har søker lovlig opphold i');
+        await lovvalg.klikkBekreftOgFortsett();
+
+        // Resultat og trygdeavgift beholdes fra forrige behandling.
+        await resultatPeriode.klikkBekreftOgFortsett();
+        await trygdeavgift.klikkBekreftOgFortsett();
+
+        // GITT: en åpen årsavregningsbehandling UTEN år finnes på saken når vedtaket fattes.
+        // Injiseres her — etter at all UI-navigasjon for NV-en er ferdig (null UI-interaksjonsrisiko)
+        // og rett før vedtaket fyrer OppretteÅrsavregningVedEndring.
+        const utenÅrBehandlingId = await gittÅpenÅrsavregningUtenÅr(saksnummer);
+
+        console.log('📝 Fatter vedtak for ny vurdering (med endring i forrige års periode)...');
+        await vedtak.fattVedtakForNyVurdering('FEIL_I_BEHANDLING');
+        await waitForProcessInstances(page.request, 60);
+
+        // SÅ: Melosys skal automatisk opprette en NY årsavregningsbehandling for FORRIGE_AAR — den
+        // injiserte uten-år-behandlingen skal ikke ha blokkert. Auto-opprettelsen er asynkron → poll.
+        console.log(`🔎 Venter på auto-opprettet ÅRSAVREGNING for ${FORRIGE_AAR}...`);
+        let nyÅrsavregningId: number | undefined;
+        await expect
+            .poll(
+                async () => {
+                    nyÅrsavregningId = await finnNyÅrsavregningMedÅr(FORRIGE_AAR, utenÅrBehandlingId);
+                    return nyÅrsavregningId !== undefined;
+                },
+                {
+                    message: `Forventet en auto-opprettet ÅRSAVREGNING-behandling for ${FORRIGE_AAR} (uten-år skal ikke blokkere)`,
+                    timeout: 30_000,
+                }
+            )
+            .toBe(true);
+
+        // «den nye behandlingen skal knyttes til korrekt kalenderår» + «ikke en misvisende feilmelding» —
+        // fokusert DB-sluttilstand. Den auto-opprettede årsavregningen er nettopp opprettet i flyten og
+        // ennå ikke saksbehandlet, så den er ÅPEN (ikke AVSLUTTET). Status pinnes IKKE til en bestemt
+        // åpen verdi: flyt-auto-opprettede årsavregninger kan være OPPRETTET eller UNDER_BEHANDLING (jf.
+        // aarsavregning.assertions.ts), og en åpen behandling kan ha prosesser som ennå ikke er FERDIG —
+        // derfor brukes ikke verifiserAarsavregningBehandling (som krever AVSLUTTET-default + alle
+        // prosesser FERDIG) her. Bærende: ÅRSAVREGNING-behandling med AARSAVREGNING-rad for FORRIGE_AAR
+        // + behandlingsresultat + at OPPRETT_NY_BEHANDLING_AARSAVREGNING-prosessen fullførte (FERDIG, ikke
+        // feilet med den misvisende FunksjonellException).
+        await withDatabase(async (db) => {
+            const beh = await db.queryOne<{STATUS: string; BEH_TYPE: string}>(
+                'SELECT STATUS, BEH_TYPE FROM BEHANDLING WHERE ID = :id',
+                {id: nyÅrsavregningId}
+            );
+            expect(beh, 'Den nye årsavregningsbehandlingen skal finnes i DB').not.toBeNull();
+            expect(beh!.BEH_TYPE, 'Den nye behandlingen skal være en ÅRSAVREGNING').toBe('ÅRSAVREGNING');
+            expect(
+                beh!.STATUS,
+                'Den nye, nettopp auto-opprettede årsavregningen skal være åpen (ikke AVSLUTTET)'
+            ).not.toBe('AVSLUTTET');
+
+            const resultat = await db.queryOne<{RESULTAT_TYPE: string}>(
+                'SELECT RESULTAT_TYPE FROM BEHANDLINGSRESULTAT WHERE BEHANDLING_ID = :id',
+                {id: nyÅrsavregningId}
+            );
+            expect(resultat, 'Den nye årsavregningen skal ha et behandlingsresultat').not.toBeNull();
+
+            const aar = await db.queryOne<{AAR: number}>(
+                'SELECT AAR FROM AARSAVREGNING WHERE BEHANDLINGSRESULTAT_ID = :id',
+                {id: nyÅrsavregningId}
+            );
+            expect(aar, 'Den nye årsavregningen skal ha en AARSAVREGNING-rad').not.toBeNull();
+            expect(Number(aar!.AAR), `Årsavregningen skal gjelde ${FORRIGE_AAR}`).toBe(FORRIGE_AAR);
+
+            // «ikke en misvisende feilmelding rettet mot manuell saksbehandling» — opprett-prosessen
+            // fullførte (ville feilet med FunksjonellException dersom uten-år hadde blokkert).
+            const opprettProsess = await db.queryOne<{STATUS: string}>(
+                `SELECT STATUS FROM PROSESSINSTANS
+                 WHERE BEHANDLING_ID = :id AND PROSESS_TYPE = 'OPPRETT_NY_BEHANDLING_AARSAVREGNING'`,
+                {id: nyÅrsavregningId}
+            );
+            expect(
+                opprettProsess,
+                'Forventet en OPPRETT_NY_BEHANDLING_AARSAVREGNING-prosess på den nye årsavregningen'
+            ).not.toBeNull();
+            expect(
+                opprettProsess!.STATUS,
+                'Opprett-prosessen skal være FERDIG (ingen blokkerende «åpen årsavregning for samme år»-feil)'
+            ).toBe('FERDIG');
+        });
+
+        // «den ufullstendige behandlingen (uten år) skal ikke ha hindret opprettelsen» — det finnes nå
+        // ≥ 2 ÅRSAVREGNING-behandlinger: den injiserte uten-år + den nye med-år.
+        const antallÅrsavregninger = await withDatabase(async (db) =>
+            db.queryOne<{N: number}>(
+                "SELECT COUNT(*) AS N FROM BEHANDLING WHERE BEH_TYPE = 'ÅRSAVREGNING'",
+                {}
+            )
+        );
+        expect(
+            Number(antallÅrsavregninger!.N),
+            'Det skal finnes minst 2 ÅRSAVREGNING-behandlinger (uten-år + den nye med-år)'
+        ).toBeGreaterThanOrEqual(2);
+
+        // Den injiserte uten-år-behandlingen skal fortsatt finnes (ble ikke feilaktig avsluttet ved
+        // opprettelsen) — den er fremdeles «uten år».
+        const utenÅrFortsattÅpen = await withDatabase(async (db) =>
+            db.queryOne<{STATUS: string}>('SELECT STATUS FROM BEHANDLING WHERE ID = :id', {
+                id: utenÅrBehandlingId,
+            })
+        );
+        expect(
+            utenÅrFortsattÅpen,
+            'Den uten-år årsavregningsbehandlingen skal fortsatt finnes på saken'
+        ).not.toBeNull();
+
+        // «det skal ikke vises en misvisende feilmelding rettet mot manuell saksbehandling» —
+        // den misvisende FunksjonellException ville feilet OPPRETT_NY_BEHANDLING_AARSAVREGNING-prosessen
+        // (waitForProcessInstances over kaster på feilede instanser) og blitt logget som api-ERROR
+        // (docker-log-fixturen fanger det; testen er IKKE @expect-docker-errors-tagget). Bærende bevis
+        // er at den nye årsavregningen faktisk ble opprettet (assertions over).
+
+        // Avslutt med waitForProcessInstances slik at cleanup-fixturen ikke treffer aktive prosesser.
+        await waitForProcessInstances(page.request, 30);
+        console.log('✅ Uten-år-behandlingen blokkerte ikke auto-opprettelsen.');
+    });
+
+    // Scenario 2 — normal blokkering MED år (regresjon).
+    //
+    // Bundet som fixme. Domenelagets AC for scenario 2 er eksplisitt markert «utledet — bekreft med
+    // fagperson at denne regelen er uendret», og beskriver PRE-EKSISTERENDE atferd (ikke det 8161
+    // endrer). Konstruksjons-sti for senere aktivering (se speken): injiser en åpen ÅRSAVREGNING-
+    // behandling MED AARSAVREGNING-rad AAR=FORRIGE_AAR og RESULTAT_TYPE='IKKE_FASTSATT' (da gir
+    // finnÅrsavregningerPåFagsak(..., IKKE_FASTSATT) treff → harAktivÅrsavregningforÅr=true → ingen ny
+    // opprettes), kjør samme NV-trigger, og assert at det fremdeles finnes NØYAKTIG ÉN ÅRSAVREGNING for
+    // FORRIGE_AAR. «Tilbakestilles» (resetEksisterendeÅrsavregning, MELOSYS-7826) krever egen
+    // verifisering av at saksbehandler-input nullstilles — bekreft med fagperson før binding.
+    test.fixme(
+        'åpen årsavregning MED år for samme år blokkerer fortsatt ny opprettelse',
+        async () => {
+            // Krever konstruksjon av «åpen årsavregning MED år» + verifisering av tilbakestilling.
+            // Se speken (specs/aarsavregning-uten-aar-blokkerer-ikke.md), scenario 2.
+        }
+    );
+});

--- a/tests/aarsavregning/aarsavregning-uten-aar-blokkerer-ikke.spec.ts
+++ b/tests/aarsavregning/aarsavregning-uten-aar-blokkerer-ikke.spec.ts
@@ -192,8 +192,15 @@ async function finnNyÅrsavregningMedÅr(aar: number, ekskluderBehandlingId: num
  * Gitt: en ÅPEN ÅRSAVREGNING-behandling MED år (aar) på saken, men med behandlingsresultattype
  * != IKKE_FASTSATT. Dette er nettopp feilstien fiksen lukker: den gamle gaten filtrerte på
  * IKKE_FASTSATT og BOMMET på denne, mens den nedstrøms SQL-guarden (kun status != AVSLUTTET) talte
- * den → «opprett-så-kast» med den misvisende feilmeldingen. Enum-verdier FK-verifisert mot live
- * Oracle (AARSAVREGNING-PK = (BEHANDLINGSRESULTAT_ID, AAR), begge NOT NULL).
+ * den → «opprett-så-kast» med den misvisende feilmeldingen.
+ *
+ * Tilstanden speiler den ENESTE måten en årsavregning faktisk er «åpen + type != IKKE_FASTSATT» på i
+ * prod: vinduet mellom vedtaksfatting og AVSLUTTET. ÅrsavregningVedtakService setter
+ * RESULTAT_TYPE=FASTSATT_TRYGDEAVGIFT og flytter behandlingen til IVERKSETTER_VEDTAK før
+ * iverksett-prosessen til slutt setter AVSLUTTET. Derfor injiseres nettopp STATUS=IVERKSETTER_VEDTAK +
+ * RESULTAT_TYPE=FASTSATT_TRYGDEAVGIFT (ikke MEDLEM_I_FOLKETRYGDEN — det er en FTRL førstegang/NV-
+ * resultattype, aldri en årsavregningstype). Enum-verdier FK-verifisert mot live Oracle
+ * (AARSAVREGNING-PK = (BEHANDLINGSRESULTAT_ID, AAR), begge NOT NULL).
  *
  * @returns BEHANDLING.ID for den injiserte med-år-behandlingen.
  */
@@ -203,7 +210,7 @@ async function gittÅpenÅrsavregningMedÅr(saksnummer: string, aar: number): Pr
             `INSERT INTO BEHANDLING
                  (SAKSNUMMER, STATUS, BEH_TYPE, REGISTRERT_DATO, ENDRET_DATO,
                   REGISTRERT_AV, ENDRET_AV, BEH_TEMA, BEHANDLINGSFRIST)
-             VALUES (:s, 'OPPRETTET', 'ÅRSAVREGNING', SYSTIMESTAMP, SYSTIMESTAMP,
+             VALUES (:s, 'IVERKSETTER_VEDTAK', 'ÅRSAVREGNING', SYSTIMESTAMP, SYSTIMESTAMP,
                      'Z123456', 'Z123456', 'YRKESAKTIV', SYSDATE)`,
             {s: saksnummer}
         );
@@ -219,7 +226,7 @@ async function gittÅpenÅrsavregningMedÅr(saksnummer: string, aar: number): Pr
         await db.execute(
             `INSERT INTO BEHANDLINGSRESULTAT
                  (BEHANDLING_ID, BEHANDLINGSMAATE, RESULTAT_TYPE, REGISTRERT_DATO, ENDRET_DATO)
-             VALUES (:id, 'MANUELT', 'MEDLEM_I_FOLKETRYGDEN', SYSTIMESTAMP, SYSTIMESTAMP)`,
+             VALUES (:id, 'MANUELT', 'FASTSATT_TRYGDEAVGIFT', SYSTIMESTAMP, SYSTIMESTAMP)`,
             {id}
         );
         await db.execute(


### PR DESCRIPTION
E2E-tester som verifiserer MELOSYS-8161-fiksen: en åpen årsavregningsbehandling skal ikke føre til den misvisende «det finnes en annen åpen årsavregningsbehandling for samme år»-feilen ved automatisk opprettelse av årsavregning for et tidligere år i saksbehandlingsflyten.

Den nye gaten harAktivÅrsavregningForÅr i OppretteÅrsavregningVedEndring gjør at gaten og den nedstrøms SQL-guarden er enige. Testene dekker begge sidene av regelen og er verifisert rød mot master / grønn mot fiks-branchen, både lokalt og i CI.
[MELOSYS-8161](https://nav.atlassian.net/browse/MELOSYS-8161)

- Scenario 1: åpen årsavregning UTEN år blokkerer ikke — ny opprettes likevel (regresjon, grønn mot både master og fiks)
- Scenario 2: aktiv årsavregning MED år (resultattype ≠ IKKE_FASTSATT) blokkerer rent uten misvisende feil — RØD mot master, GRØNN mot fiks
- Precondition injiseres deterministisk via DB; ny DatabaseHelper.execute() (autoCommit-DML)
- Spec specs/aarsavregning-uten-aar-blokkerer-ikke.md med domenelag + teknisk binding

## Testing
- [x] E2E lokalt mot fiks-api — begge scenarier grønne
- [x] E2E lokalt scenario 2 RØD mot master — reproduserer ticket-feilen
- [x] CI fiks-image grønn (run 28441194646), latest rød på scenario 2 (run 28441548657)

## Notater
Scenario 2 er RØD mot latest/main til melosys-api-fiksen (PR #3408) er merget — det er by design (testen reproduserer feilen før fiks). 