### PR TITLE
8170 E2E: varsel-lenke preutfyller arbeidsgivers orgnr på DEG SELV

### DIFF
--- a/pages/skjema/soknad-utsendt-arbeidstaker.page.ts
+++ b/pages/skjema/soknad-utsendt-arbeidstaker.page.ts
@@ -1,4 +1,5 @@
 import { Page, expect } from '@playwright/test';
+import { SkjemaAuthHelper } from '../../helpers/skjema-auth-helper';
 import { ddmmyyyy, lagreOgFortsett, standardUtsendingsperiode, svarRadio } from './skjema-utils';
 
 /**
@@ -32,6 +33,50 @@ export class SoknadUtsendtArbeidstakerPage {
     await page.getByRole('checkbox', { name: /Jeg bekrefter/ }).check();
     await page.getByRole('button', { name: 'Start søknad' }).click();
 
+    await page.waitForURL(/\/skjema\/[^/]+\/utsendingsperiode-og-land/);
+    return hentSkjemaIdFraUrl(page);
+  }
+
+  /**
+   * MELOSYS-8170: Åpne DEG SELV-søknaden via varsel-lenken arbeidstaker får når arbeidsgiver har
+   * sendt inn sin del UTEN fullmakt. Skjema-api bygger lenken som VARSLING_ARBEIDSTAKER_SKJEMA_LENKE
+   * + `/oversikt?representasjonstype=DEG_SELV&arbeidsgiverOrgnr=…`, så arbeidstaker lander rett på
+   * /oversikt med arbeidsgivers orgnr FORHÅNDSUTFYLT (og EREG-resolvet) — hen slipper å taste det
+   * inn selv. I motsetning til {@link startSoknadSomDegSelv} går vi altså IKKE via rollevalget.
+   * Forutsetter innlogget bruker (kjør SkjemaAuthHelper.login() først).
+   *
+   * Verifiserer kjernen i 8170 før den starter søknaden:
+   *  - orgnr-feltet har lenkens orgnr som VERDI (satt av lenken, ikke tastet av testen),
+   *  - EREG-oppslaget lenken utløser har resolvet arbeidsgiveren (navnet vises),
+   *  - bekreftelsen er IKKE auto-huket (lenken forhåndsutfyller kun orgnr; arbeidstaker må fortsatt
+   *    aktivt bekrefte før start).
+   *
+   * @param arbeidsgiverOrgnr        orgnr lenken bærer (= arbeidsgivers innsendte orgnr).
+   * @param forventetArbeidsgiverNavn navnet EREG resolver orgnr til (ventes på før start).
+   * @returns søknads-id (UUID) fra URL-en.
+   */
+  async startSoknadViaVarselLenke(
+    arbeidsgiverOrgnr = '999999999',
+    forventetArbeidsgiverNavn = 'Ståles Stål AS'
+  ): Promise<string> {
+    const page = this.page;
+    const varselLenke = new URL(
+      `oversikt?representasjonstype=DEG_SELV&arbeidsgiverOrgnr=${arbeidsgiverOrgnr}`,
+      SkjemaAuthHelper.BASE_URL
+    ).toString();
+    await page.goto(varselLenke);
+    await page.waitForURL(/\/oversikt/);
+
+    await expect(
+      page.getByRole('textbox', { name: 'Arbeidsgivers organisasjonsnummer' })
+    ).toHaveValue(arbeidsgiverOrgnr);
+    await expect(page.getByText(forventetArbeidsgiverNavn)).toBeVisible({ timeout: 10000 });
+
+    const bekreftelse = page.getByRole('checkbox', { name: /Jeg bekrefter/ });
+    await expect(bekreftelse, 'lenken skal kun forhåndsutfylle orgnr, ikke auto-bekrefte').not.toBeChecked();
+    await bekreftelse.check();
+
+    await page.getByRole('button', { name: 'Start søknad' }).click();
     await page.waitForURL(/\/skjema\/[^/]+\/utsendingsperiode-og-land/);
     return hentSkjemaIdFraUrl(page);
   }

--- a/tests/skjema/skjema-deg-selv-varsel-deeplink.spec.ts
+++ b/tests/skjema/skjema-deg-selv-varsel-deeplink.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import { SkjemaAuthHelper } from '../../helpers/skjema-auth-helper';
+import { SoknadUtsendtArbeidstakerPage } from '../../pages/skjema/soknad-utsendt-arbeidstaker.page';
+
+/**
+ * MELOSYS-8170 — varsel-lenken ruter arbeidstaker rett til DEG SELV med arbeidsgivers orgnr
+ * forhåndsutfylt.
+ *
+ * Når arbeidsgiver (eller rådgiver) har sendt inn sin del UTEN fullmakt, får arbeidstaker et varsel
+ * med en lenke. Fra og med 8170 bærer lenken `?representasjonstype=DEG_SELV&arbeidsgiverOrgnr=<AG>`,
+ * så arbeidstaker lander rett på /oversikt med organisasjonsnummeret ferdig utfylt og EREG-resolvet
+ * — hen slipper å taste det inn selv. Bekreftelsen må fortsatt hukes av før søknaden kan startes.
+ *
+ * Dette dekker frontend-halvdelen av 8170 ende-til-ende (skjema-web + skjema-api + EREG-mock):
+ * deeplink-landing → forhåndsutfylt orgnr → EREG-resolvet arbeidsgiver → bekreftelse-gating → start.
+ * Backend-halvdelen (at varselet faktisk BYGGER denne lenken) dekkes av enhetstest i skjema-api
+ * (ArbeidstakerVarslingServiceTest).
+ *
+ * Ren @playwright/test (ingen sak opprettes i melosys-api, så ingen Oracle/Unleash-fixture trengs).
+ * Krever skjema-stacken oppe:
+ *   cd ../melosys-docker-compose && make dev-skjema
+ *   SKIP_EESSI_GATE=true npx playwright test tests/skjema/ --project=chromium
+ *
+ * Testbruker: 12928056706 (LANSEN, arbeidstaker), arbeidsgiver 999999999 (Ståles Stål AS).
+ */
+test.describe('skjema-web: 8170 varsel-lenke preutfyller arbeidsgivers orgnr', () => {
+  test('arbeidstaker følger varsel-lenken og lander på DEG SELV med orgnr forhåndsutfylt', async ({
+    page,
+  }) => {
+    const auth = new SkjemaAuthHelper(page);
+    await auth.login('12928056706');
+
+    const soknad = new SoknadUtsendtArbeidstakerPage(page);
+    // Verifiserer forhåndsutfylling + EREG-resolving + bekreftelse-gating, og starter søknaden.
+    const skjemaId = await soknad.startSoknadViaVarselLenke('999999999', 'Ståles Stål AS');
+
+    // En gyldig skjema-id (UUID) beviser at hele preutfyll → bekreft → start-flyten gikk igjennom
+    // skjema-api (uten at testen tastet inn orgnr).
+    expect(skjemaId).toMatch(/^[0-9a-f-]{36}$/i);
+    console.log('✅ 8170: varsel-lenke preutfylte orgnr og startet DEG SELV-søknad:', skjemaId);
+  });
+});


### PR DESCRIPTION
E2E-dekning for frontend-halvdelen av MELOSYS-8170: varsel-lenken ruter arbeidstaker rett til
DEG SELV med arbeidsgivers orgnr forhåndsutfylt.

Når arbeidsgiver/rådgiver har sendt inn sin del UTEN fullmakt, får arbeidstaker et varsel med en
lenke. Fra 8170 bærer lenken `?representasjonstype=DEG_SELV&arbeidsgiverOrgnr=<AG>`, så arbeidstaker
lander rett på `/oversikt` med organisasjonsnummeret ferdig utfylt og EREG-resolvet — hen slipper å
taste det inn selv. Bekreftelsen må fortsatt hukes av før søknaden kan startes.

Testen kjører den faktiske 8170-brukerreisen ende-til-ende (skjema-web + skjema-api + EREG-mock):
deeplink-landing → forhåndsutfylt orgnr (verifiserer feltets VERDI, ikke tastet av testen) →
EREG-resolvet arbeidsgiver (navn vises) → bekreftelse er IKKE auto-huket → bekreft → start.
At «Start søknad» går videre beviser at det forhåndsutfylte orgnummeret ble resolvet
(skjemavalideringen krever en resolvet arbeidsgiver).

Backend-halvdelen (at varselet faktisk BYGGER denne lenken) dekkes av enhetstest i skjema-api
(`ArbeidstakerVarslingServiceTest`).

- `SoknadUtsendtArbeidstakerPage.startSoknadViaVarselLenke(...)` — ny POM-metode: åpner deeplinken
  (rekonstruert fra `SkjemaAuthHelper.BASE_URL`, = samme host-only lenke som stacken bruker i
  `VARSLING_ARBEIDSTAKER_SKJEMA_LENKE`), asserter forhåndsutfylling + gating, starter søknaden.
- `tests/skjema/skjema-deg-selv-varsel-deeplink.spec.ts` — ny spec (ren @playwright/test, ingen
  Oracle/Unleash-fixture; ingen sak opprettes i melosys-api).

### Testing
- [x] `npm run check:tests` grønn (vacuous-test-guard: ekte assertions, ingen tautologi/null-assert)
- [x] `tsc --noEmit`: ingen typefeil i de nye filene
- [ ] Kjørt mot live skjema-stack (`make dev-skjema`) — verifiseres i CI / lokalt med stacken oppe

### Notat
Krever skjema-profilen: `cd ../melosys-docker-compose && make dev-skjema`. Testbruker 12928056706
(LANSEN), arbeidsgiver 999999999 (Ståles Stål AS).
