### PR TITLE
Scope skjema-oppvarming til skjema-tester som blir eget setup-prosjekt

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -500,7 +500,9 @@ jobs:
           # Using an array instead of string + eval ensures arguments with
           # spaces or special characters (e.g. "EØS Medlemskap Lovvalg")
           # are passed correctly to Playwright as a single --grep value.
-          PLAYWRIGHT_ARGS=(test --project=chromium)
+          # Inkluderer både 'chromium' (alle ikke-skjema-tester) og 'skjema' (skjema-tester med
+          # oppvarmings-avhengighet). Uten 'skjema' her ville skjema-testene blitt hoppet over.
+          PLAYWRIGHT_ARGS=(test --project=chromium --project=skjema)
 
           # Add test filter if specified
           if [ -n "$TEST_GREP" ]; then

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -5,10 +5,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import { chromium } from '@playwright/test';
 import { MetricsHelper } from './helpers/metrics-helper';
-import { SkjemaAuthHelper } from './helpers/skjema-auth-helper';
-import { SoknadUtsendtArbeidstakerPage } from './pages/skjema/soknad-utsendt-arbeidstaker.page';
 
 const EESSI_BASE_URL = process.env.EESSI_BASE_URL || 'http://localhost:8081';
 
@@ -53,59 +50,6 @@ async function assertEessiAvailable(): Promise<void> {
   );
 }
 
-/**
- * Varm opp skjema-stacken med én innlogging FØR de tidsbegrensede testene kjører.
- *
- * Kald oppstart (skjema-api JVM, wonderwall sin første OIDC-veksling, skjema-web sin første
- * render) gjorde at den FØRSTE skjema-testen kunne time ut på 60s og passere på retry. Ved å
- * betale kald-start-kostnaden her — utenfor test-timeouten — blir første ekte test rask.
- *
- * Best-effort: hopper raskt over hvis skjema-web ikke svarer (ikke-skjema-kjøringer eller stack
- * uten skjema-profil), og svelger alle feil — oppvarming skal ALDRI velte testkjøringen.
- * Skru av lokalt med SKIP_SKJEMA_WARMUP=true.
- */
-async function warmUpSkjema(): Promise<void> {
-  if (process.env.SKIP_SKJEMA_WARMUP === 'true') {
-    console.log('⏭️  SKIP_SKJEMA_WARMUP=true → hopper over skjema-oppvarming');
-    return;
-  }
-
-  // Rask tilgjengelighetssjekk — hopp ut umiddelbart hvis skjema-stacken ikke kjører.
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 3000);
-  try {
-    await fetch(SkjemaAuthHelper.BASE_URL, { redirect: 'manual', signal: controller.signal });
-  } catch {
-    console.log('⏭️  Skjema-web svarer ikke — hopper over oppvarming (ikke-skjema-kjøring?)');
-    return;
-  } finally {
-    clearTimeout(timer);
-  }
-
-  console.log('🔥 Varmer opp skjema-stacken (én innlogging)...');
-  let browser;
-  try {
-    // Samme host-resolver-regel som testene: nettleseren må nå host.docker.internal:8082.
-    browser = await chromium.launch({
-      args: ['--host-resolver-rules=MAP host.docker.internal 127.0.0.1'],
-    });
-    const page = await browser.newPage();
-    const auth = new SkjemaAuthHelper(page);
-    await auth.login(); // browser → wonderwall → mock-oauth2 → skjema-web → /representasjon
-    // Kjør én KOMPLETT innsending, slik at alle skjema-api-endepunktene (opprett utkast, lagre
-    // hvert steg, send inn) og step-renderne er JVM-varme før første ekte test. En login-only
-    // oppvarming holdt ikke: første test stallet på "Start søknad" (kald create-draft-POST).
-    // Bonus: varmer også melosys-api sin Kafka-consumer for mottaket.
-    const soknad = new SoknadUtsendtArbeidstakerPage(page);
-    const { referanse } = await soknad.fyllUtOgSendInnKomplettSoknad();
-    console.log(`✅ Skjema-stacken er varmet opp (komplett innsending, ref ${referanse})`);
-  } catch (e) {
-    console.warn('⚠️  Skjema-oppvarming feilet (ikke-fatalt):', (e as Error).message);
-  } finally {
-    await browser?.close();
-  }
-}
-
 export default async function globalSetup() {
   console.log('🚀 Global setup: Docker log monitoring enabled for each test');
   console.log(
@@ -132,7 +76,4 @@ export default async function globalSetup() {
   } catch (error) {
     console.warn('⚠️  Could not capture metrics (API not running?):', (error as Error).message);
   }
-
-  // Varm opp skjema-stacken til slutt, slik at første skjema-test slipper kald-start-flaket.
-  await warmUpSkjema();
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,20 @@ import { defineConfig, devices } from '@playwright/test';
 // require('dotenv').config();
 
 /**
+ * Felles Chromium-launch-options. Deles mellom hovedprosjektet, skjema-prosjektet og
+ * skjema-oppvarmings-setupet slik at host-resolver-regelen (wonderwall → host.docker.internal)
+ * gjelder overalt der skjema-innlogging skjer.
+ */
+const chromiumLaunchOptions = {
+  slowMo: 100,
+  // Skjema-innlogging: wonderwall redirecter nettleseren til host.docker.internal:8082
+  // (mock-oauth2). Chromium leser ikke pålitelig /etc/hosts, så vi tvinger mappingen på
+  // browser-nivå. Uskadelig for øvrige tester (ingen annen nettlesertrafikk går dit), og
+  // fungerer både lokalt og på CI (mock-oauth2 er publisert på localhost:8082 begge steder).
+  args: ['--host-resolver-rules=MAP host.docker.internal 127.0.0.1'],
+};
+
+/**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
@@ -71,17 +85,35 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { 
+      use: {
         ...devices['Desktop Chrome'],
         // Slow down actions slightly for more stable tests
-        launchOptions: {
-          slowMo: 100,
-          // Skjema-innlogging: wonderwall redirecter nettleseren til host.docker.internal:8082
-          // (mock-oauth2). Chromium leser ikke pålitelig /etc/hosts, så vi tvinger mappingen på
-          // browser-nivå. Uskadelig for øvrige tester (ingen annen nettlesertrafikk går dit), og
-          // fungerer både lokalt og på CI (mock-oauth2 er publisert på localhost:8082 begge steder).
-          args: ['--host-resolver-rules=MAP host.docker.internal 127.0.0.1'],
-        }
+        launchOptions: chromiumLaunchOptions,
+      },
+      // Skjema-testene kjøres av det dedikerte 'skjema'-prosjektet (med oppvarmings-avhengighet),
+      // så de ekskluderes her for å unngå dobbeltkjøring.
+      testIgnore: /tests\/skjema\//,
+    },
+
+    // Skjema-oppvarming: kjøres ÉN gang før skjema-testene, og kun når skjema-tester faktisk er
+    // valgt (fordi 'skjema'-prosjektet avhenger av dette setupet). Matcher *.setup.ts.
+    {
+      name: 'skjema-setup',
+      testMatch: /tests\/skjema\/.*\.setup\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: chromiumLaunchOptions,
+      },
+    },
+
+    // Skjema-testene som egen prosjekt-enhet, slik at oppvarmingen kun trigges når disse kjøres.
+    {
+      name: 'skjema',
+      testMatch: /tests\/skjema\/.*\.spec\.ts/,
+      dependencies: ['skjema-setup'],
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: chromiumLaunchOptions,
       },
     },
 

--- a/tests/skjema/skjema.setup.ts
+++ b/tests/skjema/skjema.setup.ts
@@ -1,0 +1,54 @@
+import { test as setup } from '@playwright/test';
+import { SkjemaAuthHelper } from '../../helpers/skjema-auth-helper';
+import { SoknadUtsendtArbeidstakerPage } from '../../pages/skjema/soknad-utsendt-arbeidstaker.page';
+
+/**
+ * Oppvarming av skjema-stacken — kjøres som et eget Playwright "setup"-prosjekt FØR de
+ * tidsbegrensede skjema-testene, men KUN når skjema-tester faktisk er valgt for kjøring.
+ *
+ * Tidligere lå dette i global-setup.ts og ble derfor betalt på HVER kjøring, også når ingen
+ * skjema-tester kjørte. Ved å gjøre det til et setup-prosjekt som skjema-spec-ene avhenger av
+ * (se `dependencies: ['skjema-setup']` i playwright.config.ts), kjører oppvarmingen kun når
+ * Playwright faktisk skal kjøre skjema-tester — og nøyaktig én gang for hele gruppen.
+ *
+ * Hvorfor i det hele tatt varme opp: kald oppstart (skjema-api JVM, wonderwall sin første
+ * OIDC-veksling, skjema-web sin første render + kald create-draft-POST) gjorde at den FØRSTE
+ * skjema-testen kunne time ut på 60 s og passere på retry. Vi betaler kald-start-kostnaden her —
+ * utenfor test-timeouten — slik at første ekte test blir rask.
+ *
+ * Best-effort: hopper raskt over hvis skjema-web ikke svarer, og svelger alle feil —
+ * oppvarming skal ALDRI velte testkjøringen. Skru av lokalt med SKIP_SKJEMA_WARMUP=true.
+ */
+setup('varm opp skjema-stacken', async ({ page }) => {
+  if (process.env.SKIP_SKJEMA_WARMUP === 'true') {
+    console.log('⏭️  SKIP_SKJEMA_WARMUP=true → hopper over skjema-oppvarming');
+    return;
+  }
+
+  // Rask tilgjengelighetssjekk — hopp ut umiddelbart hvis skjema-stacken ikke kjører.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 3000);
+  try {
+    await fetch(SkjemaAuthHelper.BASE_URL, { redirect: 'manual', signal: controller.signal });
+  } catch {
+    console.log('⏭️  Skjema-web svarer ikke — hopper over oppvarming (ikke-skjema-kjøring?)');
+    return;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  console.log('🔥 Varmer opp skjema-stacken (én innlogging)...');
+  try {
+    const auth = new SkjemaAuthHelper(page);
+    await auth.login(); // browser → wonderwall → mock-oauth2 → skjema-web → /representasjon
+    // Kjør én KOMPLETT innsending, slik at alle skjema-api-endepunktene (opprett utkast, lagre
+    // hvert steg, send inn) og step-renderne er JVM-varme før første ekte test. En login-only
+    // oppvarming holdt ikke: første test stallet på "Start søknad" (kald create-draft-POST).
+    // Bonus: varmer også melosys-api sin Kafka-consumer for mottaket.
+    const soknad = new SoknadUtsendtArbeidstakerPage(page);
+    const { referanse } = await soknad.fyllUtOgSendInnKomplettSoknad();
+    console.log(`✅ Skjema-stacken er varmet opp (komplett innsending, ref ${referanse})`);
+  } catch (e) {
+    console.warn('⚠️  Skjema-oppvarming feilet (ikke-fatalt):', (e as Error).message);
+  }
+});


### PR DESCRIPTION
Oppvarmingen lå i global-setup.ts og ble brukt på HVER kjøring, også når
ingen skjema-tester kjørte

Oppvarmingen flyttes til et Playwright setup-prosjekt (tests/skjema/skjema.setup.ts) som
skjema-spec-ene avhenger av via dependencies: ['skjema-setup']. Da kjøres
oppvarmingen kun når skjema-tester faktisk er valgt, og kun én gang.
