### PR TITLE
Spar CI-ressurser: artefakter kun ved retry + 2t timeout

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -63,9 +63,9 @@ permissions:
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest-8-cores
-    # Coverage runs additionally build melosys-api (~4 min cached, ~11 min cold) before
-    # the ~44 min suite, so they need generous headroom over the normal 60 min ceiling.
-    timeout-minutes: ${{ inputs.collect_coverage && 120 || 60 }}
+    # 2 hour ceiling gives headroom for the ~44 min suite plus, on coverage runs,
+    # the extra melosys-api build (~4 min cached, ~11 min cold).
+    timeout-minutes: 120
 
     steps:
       - name: Checkout code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,9 +318,9 @@ Oracle database connection (configured via `.env` or environment variables):
 Key settings in `playwright.config.ts`:
 
 - **Base URL**: `http://localhost:3000`
-- **Trace**: Always on (`trace: 'on'`)
-- **Screenshots**: Always captured (`screenshot: 'on'`)
-- **Video**: Always recorded (`video: 'on'`)
+- **Trace**: On retry only (`trace: 'on-first-retry'`) - spares ressurser på grønne kjøringer; på CI (retries=1) fanges trace fra 2. forsøk. Lokalt (retries=0) skjer ingen retry → bruk `--trace on` ved behov.
+- **Screenshots**: On failure only (`screenshot: 'only-on-failure'`)
+- **Video**: On retry only (`video: 'on-first-retry'`) - samme retry-logikk som trace
 - **Slow motion**: 100ms delay between actions (`slowMo: 100`)
 - **Parallel execution**: Disabled (`fullyParallel: false`)
 - **Workers**: 1 on CI, unlimited locally
@@ -842,7 +842,7 @@ Key steps:
 - **Always run Docker Compose services first** - Tests will fail if services aren't running
 - **Use FormHelper for dynamic forms** - Many fields trigger API calls that need explicit waits
 - **Database verification is optional** - Commented out by default, uncomment when needed
-- **Traces are always captured** - Even for successful tests, useful for understanding workflows
+- **Traces/video captured on retry only** - `on-first-retry` sparer ressurser; grønne kjøringer produserer ingen tunge artefakter. Screenshot kun ved feil.
 - **Tests run sequentially** - `fullyParallel: false` to avoid race conditions
 - **Network must be idle on Trygdeavgift page** - Wait for calculations to complete before proceeding
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -51,14 +51,12 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: 'http://localhost:3000',
 
-    /* Collect trace on ALL runs - you can view replays of successful tests */
-    trace: 'on',  // Always record traces
-    
-    /* Screenshot on ALL runs - so you can see what happened */
-    screenshot: 'on',
-    
-    /* Video recording - record ALL tests */
-    video: 'on',
+    /* Artefakter kun ved behov for å spare ressurser: trace/video tas først når
+     * en test kjøres på nytt (retry), skjermbilde kun ved feil. Første grønne
+     * kjøring produserer altså ingen tunge artefakter. */
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'on-first-retry',
     
     /* Maximum time each action such as `click()` can take */
     actionTimeout: 10000,


### PR DESCRIPTION
Reduserer ressursbruk på E2E-kjøringene ved å bare fange trace/video/skjermbilder når vi faktisk trenger dem, og hever job-timeouten til 2 timer.

Trace-, video- og skjermbildeopptak på hver eneste kjøring brukte unødvendig disk, tid og opplastingsbåndbredde selv når alt var grønt. Med `retries: 1` på CI fanges artefakter fortsatt fra 2. forsøk når en test faktisk feiler — som er når vi trenger dem. Timeouten heves samtidig fordi suiten har vokst og 60-minutterstaket ga for lite margin utenom coverage-kjøringer.

- Playwright: `trace`/`video` → `on-first-retry`, `screenshot` → `only-on-failure`
- `e2e-tests.yml`: job-timeout flat på 120 min (var 60, eller 120 kun ved coverage)
- CLAUDE.md oppdatert til å beskrive den nye oppførselen

## Merk
- Lokalt er `retries: 0`, så da tas verken trace eller video. Bruk `npx playwright test --trace on` eller UI-mode ved lokal debugging.

## Testing
- [ ] Manuell CI-kjøring (workflow_dispatch) for å bekrefte at artefakter fortsatt lastes opp ved en reell feil