### PR TITLE
Ta imot dispatch fra melosys-skjema-api og -web

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -54,6 +54,8 @@ on:
       - melosys-inngangsvilkar-published
       - melosys-eessi-published
       - melosys-mock-published
+      - melosys-skjema-api-published
+      - melosys-skjema-web-published
 
 permissions:
   contents: read
@@ -136,10 +138,20 @@ jobs:
             MELOSYS_EESSI_TAG="latest"
             MELOSYS_MOCK_TAG="latest"
             MELOSYS_DOKGEN_TAG="latest"
+            MELOSYS_SKJEMA_API_TAG="latest"
+            MELOSYS_SKJEMA_WEB_TAG="latest"
 
             # Override with specific tag based on which service triggered
             if [ "${{ github.event.action }}" = "melosys-api-published" ]; then
               MELOSYS_API_TAG="${{ github.event.client_payload.image_tag }}"
+            fi
+
+            if [ "${{ github.event.action }}" = "melosys-skjema-api-published" ]; then
+              MELOSYS_SKJEMA_API_TAG="${{ github.event.client_payload.image_tag }}"
+            fi
+
+            if [ "${{ github.event.action }}" = "melosys-skjema-web-published" ]; then
+              MELOSYS_SKJEMA_WEB_TAG="${{ github.event.client_payload.image_tag }}"
             fi
 
             if [ "${{ github.event.action }}" = "faktureringskomponenten-published" ]; then
@@ -188,6 +200,8 @@ jobs:
             MELOSYS_EESSI_TAG="latest"
             MELOSYS_MOCK_TAG="latest"
             MELOSYS_DOKGEN_TAG="latest"
+            MELOSYS_SKJEMA_API_TAG="latest"
+            MELOSYS_SKJEMA_WEB_TAG="latest"
 
             # Check if input contains service:tag format (has colon)
             if [[ "$INPUT_ENV" == *":"* ]]; then
@@ -230,6 +244,12 @@ jobs:
                   melosys-dokgen)
                     MELOSYS_DOKGEN_TAG="$tag"
                     ;;
+                  melosys-skjema-api)
+                    MELOSYS_SKJEMA_API_TAG="$tag"
+                    ;;
+                  melosys-skjema-web)
+                    MELOSYS_SKJEMA_WEB_TAG="$tag"
+                    ;;
                   *)
                     echo "  ⚠️  Unknown service: $service (ignored)"
                     ;;
@@ -252,6 +272,8 @@ jobs:
           echo "melosys_eessi_tag=$MELOSYS_EESSI_TAG" >> $GITHUB_OUTPUT
           echo "melosys_mock_tag=$MELOSYS_MOCK_TAG" >> $GITHUB_OUTPUT
           echo "melosys_dokgen_tag=$MELOSYS_DOKGEN_TAG" >> $GITHUB_OUTPUT
+          echo "melosys_skjema_api_tag=$MELOSYS_SKJEMA_API_TAG" >> $GITHUB_OUTPUT
+          echo "melosys_skjema_web_tag=$MELOSYS_SKJEMA_WEB_TAG" >> $GITHUB_OUTPUT
 
           echo ""
           echo "📋 Docker Image Tags (non-latest only):"
@@ -265,6 +287,8 @@ jobs:
           [ "$MELOSYS_EESSI_TAG" != "latest" ] && echo "  melosys-eessi: $MELOSYS_EESSI_TAG" && NON_LATEST_FOUND=true || true
           [ "$MELOSYS_MOCK_TAG" != "latest" ] && echo "  melosys-mock: $MELOSYS_MOCK_TAG" && NON_LATEST_FOUND=true || true
           [ "$MELOSYS_DOKGEN_TAG" != "latest" ] && echo "  melosys-dokgen: $MELOSYS_DOKGEN_TAG" && NON_LATEST_FOUND=true || true
+          [ "$MELOSYS_SKJEMA_API_TAG" != "latest" ] && echo "  melosys-skjema-api: $MELOSYS_SKJEMA_API_TAG" && NON_LATEST_FOUND=true || true
+          [ "$MELOSYS_SKJEMA_WEB_TAG" != "latest" ] && echo "  melosys-skjema-web: $MELOSYS_SKJEMA_WEB_TAG" && NON_LATEST_FOUND=true || true
           [ "$NON_LATEST_FOUND" = false ] && echo "  (all services using latest)" || true
 
       - name: Set environment variables for GitHub Actions
@@ -280,6 +304,8 @@ jobs:
           echo "MELOSYS_EESSI_TAG=${{ steps.image-tags.outputs.melosys_eessi_tag }}" >> $GITHUB_ENV
           echo "MELOSYS_MOCK_TAG=${{ steps.image-tags.outputs.melosys_mock_tag }}" >> $GITHUB_ENV
           echo "MELOSYS_DOKGEN_TAG=${{ steps.image-tags.outputs.melosys_dokgen_tag }}" >> $GITHUB_ENV
+          echo "MELOSYS_SKJEMA_API_TAG=${{ steps.image-tags.outputs.melosys_skjema_api_tag }}" >> $GITHUB_ENV
+          echo "MELOSYS_SKJEMA_WEB_TAG=${{ steps.image-tags.outputs.melosys_skjema_web_tag }}" >> $GITHUB_ENV
 
       - name: Download JaCoCo agent for E2E coverage
         if: inputs.collect_coverage
@@ -364,8 +390,8 @@ jobs:
           docker pull --platform linux/amd64 unleashorg/unleash-server:latest &
           # Skjema-stack (digital «Utsendt arbeidstaker»-søknad) — kun når skjema er i scope.
           if [ "$SKJEMA_IN_SCOPE" = "true" ]; then
-            docker pull --platform linux/amd64 europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-skjema-api:latest &
-            docker pull --platform linux/amd64 europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-skjema-web:latest &
+            docker pull --platform linux/amd64 europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-skjema-api:${{ steps.image-tags.outputs.melosys_skjema_api_tag }} &
+            docker pull --platform linux/amd64 europe-north1-docker.pkg.dev/nais-management-233d/teammelosys/melosys-skjema-web:${{ steps.image-tags.outputs.melosys_skjema_web_tag }} &
             docker pull --platform linux/amd64 ghcr.io/nais/wonderwall:latest &
           fi
           wait
@@ -383,6 +409,8 @@ jobs:
           MELOSYS_TRYGDEAVTALE_TAG: ${{ steps.image-tags.outputs.melosys_trygdeavtale_tag }}
           MELOSYS_INNGANGSVILKAR_TAG: ${{ steps.image-tags.outputs.melosys_inngangsvilkar_tag }}
           MELOSYS_EESSI_TAG: ${{ steps.image-tags.outputs.melosys_eessi_tag }}
+          MELOSYS_SKJEMA_API_TAG: ${{ steps.image-tags.outputs.melosys_skjema_api_tag }}
+          MELOSYS_SKJEMA_WEB_TAG: ${{ steps.image-tags.outputs.melosys_skjema_web_tag }}
           MELOSYS_MOCK_TAG: ${{ steps.image-tags.outputs.melosys_mock_tag }}
           MELOSYS_DOKGEN_TAG: ${{ steps.image-tags.outputs.melosys_dokgen_tag }}
           JACOCO_AGENT_OPTS: ${{ inputs.collect_coverage && '-javaagent:/jacoco/jacocoagent.jar=output=tcpserver,address=*,port=6300' || '' }}


### PR DESCRIPTION
## Hva
Registrerer to nye `repository_dispatch`-typer: `melosys-skjema-api-published` og `melosys-skjema-web-published`, slik at deploy-til-dev i melosys-skjema-api/-web kan trigge e2e-suiten (mønsteret vi allerede har for melosys-api m.fl.).

## Detaljer
- `image_tag` (commit-sha) fra skjema-repoene trades gjennom til `MELOSYS_SKJEMA_API_TAG`/`MELOSYS_SKJEMA_WEB_TAG` — både i warmup-pull og `docker compose` — så suiten kjøres mot nøyaktig det nettopp bygde imaget (ikke bare `latest`).
- Manuell `workflow_dispatch` støtter nå også `melosys-skjema-api:<tag>`/`melosys-skjema-web:<tag>` i `service:tag`-formatet.
- `docker-compose.yml` støttet allerede disse env-variablene (default `latest`), så ingen compose-endring nødvendig.
- Skjema-stacken startes kun når skjema er i scope (uendret); en skjema-dispatch har tom `test_grep` → full suite → skjema i scope.

## Søster-PR-er
- navikt/melosys-skjema-api#339
- navikt/melosys-skjema-web#546

🤖 Generated with [Claude Code](https://claude.com/claude-code)