### PR TITLE
Fiks Kafka-leak i fire-and-forget skjema-innsendingstester

### DIFF
--- a/tests/skjema/skjema-arbeidsgiver-innsending.spec.ts
+++ b/tests/skjema/skjema-arbeidsgiver-innsending.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import * as path from 'path';
 import { SkjemaAuthHelper } from '../../helpers/skjema-auth-helper';
 import { SoknadArbeidsgiverPage } from '../../pages/skjema/soknad-arbeidsgiver.page';
+import { SkjemaMottakAssertions } from '../../pages/skjema/skjema-mottak.assertions';
 
 /**
  * T1b — full happy-path innsending av digital «Utsendt arbeidstaker»-søknad, variant ARBEIDSGIVER
@@ -24,7 +25,7 @@ test.describe('skjema-web innsending (arbeidsgiver)', () => {
   test('arbeidsgiver fyller ut og sender inn «Utsendt arbeidstaker»-søknad for begge deler', async ({
     page,
   }) => {
-    test.setTimeout(90000); // 11 steg + vedlegg-opplasting (ClamAV) tar lengre tid enn DEG SELV
+    test.setTimeout(120000); // 11 steg + vedlegg-opplasting (ClamAV) + drain (Kafka-konsum)
 
     const auth = new SkjemaAuthHelper(page);
     await auth.login('30056928150'); // KARAFFEL TRIVIELL, daglig leder
@@ -42,5 +43,13 @@ test.describe('skjema-web innsending (arbeidsgiver)', () => {
     expect(skjemaId).toMatch(/^[0-9a-f-]{36}$/i);
     expect(referanse).toMatch(/^[A-Z0-9]{5,6}$/);
     console.log('✅ Arbeidsgiver-søknad (begge deler) sendt inn, referanse:', referanse);
+
+    // Drain-at-source: vent til melosys-api har konsumert Kafka-meldingen (SKJEMA_SAK_MAPPING
+    // opprettet) FØR testen avslutter. Uten dette lever meldingen videre og konsumeres først
+    // etter at NESTE tests cleanup har tømt Oracle → en stray fagsak som velter tellingen i
+    // etterfølgende tester (f.eks. skjema-begge-deler «kun én fagsak»). Se
+    // memory/skjema_begge_deler_flake_kafka_leak.md.
+    await new SkjemaMottakAssertions().ventPaaSakForSkjema(skjemaId);
+    console.log('✅ Kafka-melding konsumert av melosys-api (drain OK)');
   });
 });

--- a/tests/skjema/skjema-arbeidsgiver-innsending.spec.ts
+++ b/tests/skjema/skjema-arbeidsgiver-innsending.spec.ts
@@ -44,12 +44,14 @@ test.describe('skjema-web innsending (arbeidsgiver)', () => {
     expect(referanse).toMatch(/^[A-Z0-9]{5,6}$/);
     console.log('✅ Arbeidsgiver-søknad (begge deler) sendt inn, referanse:', referanse);
 
-    // Drain-at-source: vent til melosys-api har konsumert Kafka-meldingen (SKJEMA_SAK_MAPPING
-    // opprettet) FØR testen avslutter. Uten dette lever meldingen videre og konsumeres først
-    // etter at NESTE tests cleanup har tømt Oracle → en stray fagsak som velter tellingen i
-    // etterfølgende tester (f.eks. skjema-begge-deler «kun én fagsak»). Se
-    // memory/skjema_begge_deler_flake_kafka_leak.md.
-    await new SkjemaMottakAssertions().ventPaaSakForSkjema(skjemaId);
-    console.log('✅ Kafka-melding konsumert av melosys-api (drain OK)');
+    // Drain-at-source: vent til melosys-api har kjørt HELE mottakssagaen (sak + journalføring i
+    // Oracle) FØR testen avslutter. Uten dette lever Kafka-meldingen videre og konsumeres først
+    // etter at NESTE tests cleanup har tømt Oracle. To skadevarianter: (1) sak opprettes etter
+    // clean → stray fagsak velter tellinger i etterfølgende tester (f.eks. skjema-begge-deler
+    // «kun én fagsak», CI run 28596547580); (2) journalførings-halen krysser grensen → naboens
+    // clean sletter sak/behandling midt i sagaen → melosys-api logger ERROR → docker-logs-fixturen
+    // feller en urelatert nabotest. Å draine helt til JOURNALPOST_ID er satt dekker begge.
+    await new SkjemaMottakAssertions().ventPaaJournalpostForSkjema(skjemaId);
+    console.log('✅ Mottakssaga ferdig i melosys-api (sak + journalpost, drain OK)');
   });
 });

--- a/tests/skjema/skjema-begge-deler-samme-sak.spec.ts
+++ b/tests/skjema/skjema-begge-deler-samme-sak.spec.ts
@@ -49,6 +49,11 @@ test.describe('skjema-web → melosys-api: begge deler kobles til samme sak', ()
     // deler er SENDT for arbeidstakeren — ellers kan koblingen treffe en gammel arbeidsgiver-del).
     await withPgDatabase('melosys-skjema', (db) => db.cleanDatabase(true));
 
+    // Leak-vakt: Oracle er tømt av cleanup-fixturen før testen. Er det likevel en fagsak her, har
+    // en tidligere innsendingstest lekket en Kafka-melding forbi cleanup (drain manglet) → fail
+    // tidlig og tydelig her i stedet for forvirrende på «kun én fagsak» midt i flyten.
+    expect(await mottak.tellFagsaker(), 'ingen fagsaker ved teststart (Kafka-leak-vakt)').toBe(0);
+
     // ---- 1. Arbeidsgiver sender KUN sin del (context 1) -----------------------------------
     const auth = new SkjemaAuthHelper(page);
     await auth.login('30056928150'); // KARAFFEL

--- a/tests/skjema/skjema-deg-selv-innsending.spec.ts
+++ b/tests/skjema/skjema-deg-selv-innsending.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { SkjemaAuthHelper } from '../../helpers/skjema-auth-helper';
 import { SoknadUtsendtArbeidstakerPage } from '../../pages/skjema/soknad-utsendt-arbeidstaker.page';
+import { SkjemaMottakAssertions } from '../../pages/skjema/skjema-mottak.assertions';
 
 /**
  * T1 — full happy-path innsending av digital «Utsendt arbeidstaker»-søknad, variant DEG SELV.
@@ -18,15 +19,25 @@ import { SoknadUtsendtArbeidstakerPage } from '../../pages/skjema/soknad-utsendt
  */
 test.describe('skjema-web innsending', () => {
   test('innbygger fyller ut og sender inn «Utsendt arbeidstaker»-søknad som DEG SELV', async ({ page }) => {
+    test.setTimeout(90000); // innsending + drain (venter på at melosys-api konsumerer Kafka-meldingen)
+
     const auth = new SkjemaAuthHelper(page);
     await auth.login('12928056706');
 
     const soknad = new SoknadUtsendtArbeidstakerPage(page);
-    const { referanse } = await soknad.fyllUtOgSendInnKomplettSoknad('999999999', 'Frankrike');
+    const { skjemaId, referanse } = await soknad.fyllUtOgSendInnKomplettSoknad('999999999', 'Frankrike');
 
     // Kvitteringen viser et referansenummer (alfanumerisk kode) — beviser at innsendingen
     // ble persistert i skjema-api.
     expect(referanse).toMatch(/^[A-Z0-9]{5,6}$/);
     console.log('✅ Søknad sendt inn, referanse:', referanse);
+
+    // Drain-at-source: vent til melosys-api har konsumert Kafka-meldingen (SKJEMA_SAK_MAPPING
+    // opprettet) FØR testen avslutter. Uten dette lever meldingen videre og konsumeres først
+    // etter at NESTE tests cleanup har tømt Oracle → en stray fagsak som velter tellingen i
+    // etterfølgende tester (f.eks. skjema-begge-deler «kun én fagsak»). Se
+    // memory/skjema_begge_deler_flake_kafka_leak.md.
+    await new SkjemaMottakAssertions().ventPaaSakForSkjema(skjemaId);
+    console.log('✅ Kafka-melding konsumert av melosys-api (drain OK)');
   });
 });

--- a/tests/skjema/skjema-deg-selv-innsending.spec.ts
+++ b/tests/skjema/skjema-deg-selv-innsending.spec.ts
@@ -32,12 +32,14 @@ test.describe('skjema-web innsending', () => {
     expect(referanse).toMatch(/^[A-Z0-9]{5,6}$/);
     console.log('✅ Søknad sendt inn, referanse:', referanse);
 
-    // Drain-at-source: vent til melosys-api har konsumert Kafka-meldingen (SKJEMA_SAK_MAPPING
-    // opprettet) FØR testen avslutter. Uten dette lever meldingen videre og konsumeres først
-    // etter at NESTE tests cleanup har tømt Oracle → en stray fagsak som velter tellingen i
-    // etterfølgende tester (f.eks. skjema-begge-deler «kun én fagsak»). Se
-    // memory/skjema_begge_deler_flake_kafka_leak.md.
-    await new SkjemaMottakAssertions().ventPaaSakForSkjema(skjemaId);
-    console.log('✅ Kafka-melding konsumert av melosys-api (drain OK)');
+    // Drain-at-source: vent til melosys-api har kjørt HELE mottakssagaen (sak + journalføring i
+    // Oracle) FØR testen avslutter. Uten dette lever Kafka-meldingen videre og konsumeres først
+    // etter at NESTE tests cleanup har tømt Oracle. To skadevarianter: (1) sak opprettes etter
+    // clean → stray fagsak velter tellinger i etterfølgende tester (f.eks. skjema-begge-deler
+    // «kun én fagsak», CI run 28596547580); (2) journalførings-halen krysser grensen → naboens
+    // clean sletter sak/behandling midt i sagaen → melosys-api logger ERROR → docker-logs-fixturen
+    // feller en urelatert nabotest. Å draine helt til JOURNALPOST_ID er satt dekker begge.
+    await new SkjemaMottakAssertions().ventPaaJournalpostForSkjema(skjemaId);
+    console.log('✅ Mottakssaga ferdig i melosys-api (sak + journalpost, drain OK)');
   });
 });


### PR DESCRIPTION
Fjerner en rekkefølge-avhengig flake i skjema-e2e-testene ved å la de to fire-and-forget-innsendingstestene vente på at melosys-api har kjørt hele mottakssagaen før de avslutter.

skjema-arbeidsgiver-innsending og skjema-deg-selv-innsending sendte inn en søknad og avsluttet uten å vente på Kafka-konsum. Meldingen ble da konsumert av melosys-api FØRST etter at neste tests cleanup hadde tømt Oracle → en stray fagsak som veltet «kun én fagsak»-tellingen i skjema-begge-deler-samme-sak (feilet forsøk 1, passerte på retry — CI run 28596547580, linje 71). Drain hos avsenderen er deterministisk; expect.poll ville ikke hjulpet siden stray-saken aldri forsvinner.

- Drain-at-source: begge innsendingstestene venter nå til JOURNALPOST_ID er satt (hele Oracle/Joark-sagaen ferdig, ikke bare sak) — så journalførings-halen ikke krysser testgrensen og feller en nabotest via docker-logs-fixturen
- Leak-vakt i begge-deler-testen: `tellFagsaker() === 0` ved teststart → en fremtidig leak feiler tidlig og tydelig
- Timeout-headroom for drain-polleren

## Testing
- [x] Lokal kjøring: hele `tests/skjema/` grønn i sekvens (6 passed, retries=0), i leak-rekkefølgen
- [ ] CI (workflow_dispatch, test_grep=skjema) — run 28617340389