### PR TITLE
Fiks tidsavhengig årsgrense i nyvurdering-skattestatus-test

### DIFF
--- a/tests/utenfor-avtaleland/nyvurdering-endring-skattestatus.spec.ts
+++ b/tests/utenfor-avtaleland/nyvurdering-endring-skattestatus.spec.ts
@@ -304,8 +304,12 @@ test.describe('Nyvurdering - Endring av skattestatus', () => {
 
         await unleash.enableFeature('melosys.faktureringskomponenten.ikke-tidligere-perioder');
 
-        // Use dynamic dates for the API call - search current year to find the test period
-        const apiPeriod = TestPeriodsISO.currentYearPeriod;
+        // Use full current year (Jan 1 - Dec 31) for the API call. currentYearPeriod ender
+        // på "første i måneden +6 mnd", som i andre halvår ruller inn i neste kalenderår
+        // (f.eks. 2027-01-01). Backend krever fom/tom i samme år
+        // (ÅrsavregningIkkeSkattepliktigeProsessGenerator), så den async-jobben feilet stille
+        // og antallProsessert ble 0. fullCurrentYearPeriod holder seg innenfor året.
+        const apiPeriod = TestPeriodsISO.fullCurrentYearPeriod;
         await adminApi.finnIkkeSkattepliktigeSaker(
             request,
             apiPeriod.start,


### PR DESCRIPTION
Fjerner en tidsavhengig flake i nyvurdering-endring-skattestatus-testen som feiler deterministisk når den kjøres i andre halvår.

Testens avsluttende ikke-skattepliktige-API-kall brukte `TestPeriodsISO.currentYearPeriod`, som slutter på «første i måneden + 6 mnd». Kjørt 2. juli ble tom-dato 2027-01-01, og backend (ÅrsavregningIkkeSkattepliktigeProsessGenerator) krever at fom og tom er i samme år. Den async-genererte jobben feilet da stille med IllegalArgumentException, ingen prosessinstans ble laget, og assert på `antallProsessert === 1` feilet (CI run 28596547580). fullCurrentYearPeriod holder seg alltid innenfor inneværende år.

- Bytter den avsluttende API-perioden fra `currentYearPeriod` til `fullCurrentYearPeriod` (2026-01-01 → 2026-12-31)

## Testing
- [x] Full CI-suite grønn (run 28606268672)
- [x] Filtrert CI grønn (run 28605708828)