### PR TITLE
Fiks flaky steg-overgang: verifyHeadingChange + scoped timeout

### DIFF
--- a/pages/behandling/resultat-periode.page.ts
+++ b/pages/behandling/resultat-periode.page.ts
@@ -97,7 +97,16 @@ export class ResultatPeriodePage extends BasePage {
    * Click "Bekreft og fortsett" button with retry logic for reliable step transitions
    */
   async klikkBekreftOgFortsett(): Promise<void> {
-    await this.clickStepButtonWithRetry(this.bekreftOgFortsettButton);
+    // verifyHeadingChange: klikket Perioder→Trygdeavgift kan «droppes» av React
+    // på en lastet CI-runner (step-transition-race) — da returnerte metoden mens
+    // vi fortsatt sto på «Medlemskapsperioder», og neste steg (trygdeavgift.
+    // ventPåSideLastet) timet ut på en «Skattepliktig»-gruppe som aldri fantes
+    // på den siden. Med heading-change-verifisering re-klikkes overgangen til
+    // stegoverskriften faktisk endrer seg (samme robuste mønster som eu-eos-/
+    // aarsavregning-POM-ene bruker).
+    await this.clickStepButtonWithRetry(this.bekreftOgFortsettButton, {
+      verifyHeadingChange: true,
+    });
   }
 
   /**

--- a/pages/behandling/trygdeavtale-behandling.page.ts
+++ b/pages/behandling/trygdeavtale-behandling.page.ts
@@ -171,7 +171,13 @@ export class TrygdeavtaleBehandlingPage extends BasePage {
    * Click "Bekreft og fortsett" button with retry logic for reliable step transitions
    */
   async klikkBekreftOgFortsett(): Promise<void> {
-    await this.clickStepButtonWithRetry(this.bekreftOgFortsettButton);
+    // verifyHeadingChange: samme step-transition-robusthet som de øvrige
+    // behandlings-POM-ene — re-klikk til stegoverskriften faktisk endrer seg
+    // slik at en «droppet» overgang på lastet CI ikke etterlater flyten på
+    // forrige steg (bl.a. trygdeavtale-nyvurdering var flaky her).
+    await this.clickStepButtonWithRetry(this.bekreftOgFortsettButton, {
+      verifyHeadingChange: true,
+    });
   }
 
   /**

--- a/tests/utenfor-avtaleland/nyvurdering-endring-skattestatus.spec.ts
+++ b/tests/utenfor-avtaleland/nyvurdering-endring-skattestatus.spec.ts
@@ -22,6 +22,12 @@ test.describe('Nyvurdering - Endring av skattestatus', () => {
             page,
             request
         }) => {
+        // Tung NV-skattestatus-flyt: to fulle vedtak + nyvurdering + faktura +
+        // flere prosessinstans-venter ligger nær 60s-taket og tipper over på en
+        // lastet CI-runner (tyngre full-stack etter at skjema ble en del av
+        // full-run). Scoped hev til 120s — global timeout beholdes på 60s.
+        test.setTimeout(120000);
+
         // Setup: Authentication
         const auth = new AuthHelper(page);
         const unleash = new UnleashHelper(request);
@@ -165,6 +171,12 @@ test.describe('Nyvurdering - Endring av skattestatus', () => {
             page,
             request
         }) => {
+        // Tung NV-skattestatus-flyt: to fulle vedtak + nyvurdering + faktura +
+        // flere prosessinstans-venter ligger nær 60s-taket og tipper over på en
+        // lastet CI-runner (tyngre full-stack etter at skjema ble en del av
+        // full-run). Scoped hev til 120s — global timeout beholdes på 60s.
+        test.setTimeout(120000);
+
         // Setup: Authentication
         const auth = new AuthHelper(page);
         const unleash = new UnleashHelper(request);


### PR DESCRIPTION
Herder to steg-overganger i behandlings-POM-ene og hever per-test-timeout på de to tyngste NV-skattestatus-testene, for å fjerne flakynes som kom tilbake på main-E2E 2026-07-02.

Flakynes dukket opp igjen (runs [28620126971](https://github.com/navikt/melosys-e2e-tests/actions/runs/28620126971)/[28620055700](https://github.com/navikt/melosys-e2e-tests/actions/runs/28620055700), 4 flaky hver) etter 100+ grønne kjøringer. Testtallet er identisk med grønn baseline (28434763093), så det er **ikke nye tester**, og docker-loggene er rene, så det er **ikke backend**. Rotårsaken er en step-transition-race: `resultat-periode`- og `trygdeavtale-behandling`-POM-ene kalte `clickStepButtonWithRetry` **uten** heading-change-verifisering. På en lastet CI-runner «droppes» Perioder→Trygdeavgift-klikket av React, metoden returnerer mens flyten fortsatt står på «Medlemskapsperioder», og neste steg timer ut på en «Skattepliktig»-gruppe som aldri finnes på den siden. Alle seks flaky-instanser går via disse to metodene (også aarsavregning-testene via `opprettVedtattIkkeSkattepliktigSak` → `fyllUtResultatPeriode`). Marginen ble tynn nok til å tippe nå fordi full-run-stacken ble tyngre (skjema-stack fra 06-29, tyngre web-bundle 07-02).

- `verifyHeadingChange: true` på `klikkBekreftOgFortsett` i `resultat-periode.page.ts` og `trygdeavtale-behandling.page.ts` (samme robuste mønster som eu-eos-/aarsavregning-POM-ene alt bruker — re-klikker til stegoverskriften faktisk endrer seg)
- Scoped `test.setTimeout(120000)` på begge `nyvurdering-endring-skattestatus`-testene, som legitimt kjører >60s (to fulle vedtak + nyvurdering + faktura; lokal grønn kjøring = 66s). Global timeout beholdes på 60s.

## Testing
- [x] Reproduert flaken lokalt (feilet ved manglende verifyHeadingChange), deretter grønt lokalt med fiksen (3 berørte tester)
- [x] Fokusert CI-flake-kjøring dispatchet mot `latest` med `repeat_each=3` + `disable_retries=true` ([run 28643950640](https://github.com/navikt/melosys-e2e-tests/actions/runs/28643950640))
- [ ] Full suite-kjøring (PR-en trigger den) — `resultat-periode` er en delt POM, så bekreft ingen regresjon i andre tester som bruker den

## Notes
`verifyHeadingChange` utvider ikke disabled-knapp-budsjettet (fortsatt 30s). Hvis `trygdeavtale-nyvurdering`-flaken noen gang var en genuint treg auto-save (>30s disabled) og ikke et droppet klikk, kan den trenge egen await-på-PUT — men den er grønn lokalt og den droppet-klikk-escapen dekker det observerte signaturet.