### PR TITLE
Fiks flaky ikke-skattepliktig: kutt resultat-periode-dødtid

### DIFF
--- a/pages/behandling/resultat-periode.page.ts
+++ b/pages/behandling/resultat-periode.page.ts
@@ -104,8 +104,14 @@ export class ResultatPeriodePage extends BasePage {
     // på den siden. Med heading-change-verifisering re-klikkes overgangen til
     // stegoverskriften faktisk endrer seg (samme robuste mønster som eu-eos-/
     // aarsavregning-POM-ene bruker).
+    // Resultat-periode-steget auto-lagrer ikke (Perioder→Trygdeavgift byttes
+    // klientsidig, ingen avklartefakta/vilkaar-POST). Uten kort apiResponseTimeout
+    // venter waitForResponse hele 10s forgjeves på hvert klikk («Ingen API-respons»)
+    // — ren dødtid som presser lange tester (f.eks. ikke-skattepliktig) over 60s.
+    // Heading-endringen er uansett det reelle signalet for stegovergangen.
     await this.clickStepButtonWithRetry(this.bekreftOgFortsettButton, {
       verifyHeadingChange: true,
+      apiResponseTimeout: 1500,
     });
   }
 

--- a/pages/shared/base.page.ts
+++ b/pages/shared/base.page.ts
@@ -220,6 +220,7 @@ export abstract class BasePage {
       waitForContentTimeout?: number;
       apiPatterns?: string[];
       verifyHeadingChange?: boolean;
+      apiResponseTimeout?: number;
     },
   ): Promise<void> {
     const {
@@ -227,6 +228,11 @@ export abstract class BasePage {
       waitForContentTimeout = 45000,
       apiPatterns = ['/api/avklartefakta/', '/api/vilkaar/'],
       verifyHeadingChange = false,
+      // Hvor lenge vi venter på en auto-save-POST etter klikk (heading-change-modus).
+      // Steg som IKKE auto-lagrer (f.eks. resultat-periode, som kun bytter steg
+      // klientsidig) har ingen matchende POST — da er 10s ren dødtid. Slike POM-er
+      // sender en kort timeout; heading-endringen er uansett det reelle signalet.
+      apiResponseTimeout = 10000,
     } = options || {};
 
     console.log('🔄 Klikker "Bekreft og fortsett"...');
@@ -296,7 +302,7 @@ export abstract class BasePage {
           (response: Response) =>
             apiPatterns.some(p => response.url().includes(p)) &&
             response.request().method() === 'POST',
-          { timeout: 10000 },
+          { timeout: apiResponseTimeout },
         ).catch(() => null);
 
         await button.click();

--- a/tests/aarsavregning/aarsavregning-ikke-skattepliktig.spec.ts
+++ b/tests/aarsavregning/aarsavregning-ikke-skattepliktig.spec.ts
@@ -19,6 +19,13 @@ import {verifiserAarsavregningBehandling} from '../../pages/behandling/aarsavreg
 
 test.describe('Årsavregning - Ikke-skattepliktige saker', () => {
     test('skal opprette årsavregning for ikke-skattepliktig bruker', async ({page, request}) => {
+        // Full saksflyt → fatt vedtak → async ikke-skattepliktig-jobb → polling +
+        // ~15s Unleash toggle-bekreftelser ligger legitimt nær 60s. På en lastet
+        // CI-runner tipper den over default-timeouten (både grønn baseline-kjøring
+        // og denne lå på 60-62s). Scoped 120s — samme mønster som nyvurdering-
+        // skattestatus-testene (#305) — uten å røre global timeout.
+        test.setTimeout(120000);
+
         // Setup: Authentication
         const auth = new AuthHelper(page);
         const unleash = new UnleashHelper(request);


### PR DESCRIPTION
Fjerner en deterministisk ~10s dødtid i resultat-periode-steget og gir ikke-skattepliktig-testen scoped 120s timeout, slik at den ikke lenger tipper over 60s-grensen på lastet CI-runner.

E2E-run 28648316834 (trigget av `melosys-api-published` for #3409-image `0017fb51`) feilet med at `aarsavregning-ikke-skattepliktig` timet ut (60000ms, begge forsøk). Mistanken falt på api-endringen, men rotårsaken var test-kode fra #305: `verifyHeadingChange` på resultat-periode-POM-en venter på en auto-save-POST som det steget aldri sender (Perioder→Trygdeavgift byttes klientsidig) → hele 10s ren dødtid per klikk («Ingen API-respons»). Det presset den allerede lange testen (full saksflyt + fatt vedtak + async jobb + polling + ~15s Unleash-toggle-bekreftelser, lå på 60-62s også på grønn baseline) over grensen. #305 satte scoped 120s på de to NV-skattestatus-testene, men glemte denne. Heading-endringen er uansett det reelle signalet for stegovergangen.

- `apiResponseTimeout` gjort konfigurerbar i `clickStepButtonWithRetry` (default uendret 10000ms)
- Resultat-periode-POM-en sender 1500ms (steget auto-lagrer ikke)
- Scoped `test.setTimeout(120000)` på ikke-skattepliktig-testen

## Testing
- [x] Kjørt lokalt mot nøyaktig det feilende api-imaget `melosys-api:0017fb51` (`sha256:96ebdcf1`): 4/4 grønn (1 solo + `--repeat-each=3`)
- [x] E2E full suite på CI pinned til `0017fb51` (run 28655868666)
- [ ] Manuell verifisering