### PR TITLE
NOJIRA Forbered delt test-infrastruktur for opt-in BDD-tester

### DIFF
--- a/fixtures/docker-logs.ts
+++ b/fixtures/docker-logs.ts
@@ -264,8 +264,13 @@ export const dockerLogsFixture = base.extend<{ dockerLogChecker: void }>({
     }
 
     // Tests tagged with @expect-docker-errors intentionally trigger backend errors
-    // (e.g., navigating to non-existent resources to test error handling)
-    if (testInfo.title.includes('@expect-docker-errors')) {
+    // (e.g., navigating to non-existent resources to test error handling).
+    // Check both the test title (plain Playwright specs put the tag in the title)
+    // and testInfo.tags (playwright-bdd emits Gherkin @tags into testInfo.tags).
+    const expectDockerErrors =
+      testInfo.title.includes('@expect-docker-errors') ||
+      testInfo.tags.some(tag => tag === '@expect-docker-errors');
+    if (expectDockerErrors) {
       console.log(`\n⏭️  Skipping docker log check (@expect-docker-errors tag)`);
       return;
     }

--- a/fixtures/docker-logs.ts
+++ b/fixtures/docker-logs.ts
@@ -1,5 +1,6 @@
 import { test as base } from '@playwright/test';
 import { execSync } from 'child_process';
+import { hasTag } from '../lib/test-tags';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -265,12 +266,9 @@ export const dockerLogsFixture = base.extend<{ dockerLogChecker: void }>({
 
     // Tests tagged with @expect-docker-errors intentionally trigger backend errors
     // (e.g., navigating to non-existent resources to test error handling).
-    // Check both the test title (plain Playwright specs put the tag in the title)
-    // and testInfo.tags (playwright-bdd emits Gherkin @tags into testInfo.tags).
-    const expectDockerErrors =
-      testInfo.title.includes('@expect-docker-errors') ||
-      testInfo.tags.some(tag => tag === '@expect-docker-errors');
-    if (expectDockerErrors) {
+    // Tag may live in the title (plain specs) or in testInfo.tags (playwright-bdd
+    // Gherkin @tags) — hasTag covers both with one shared, case-insensitive semantics.
+    if (hasTag(testInfo, '@expect-docker-errors')) {
       console.log(`\n⏭️  Skipping docker log check (@expect-docker-errors tag)`);
       return;
     }

--- a/fixtures/known-error.ts
+++ b/fixtures/known-error.ts
@@ -25,10 +25,13 @@ import { test as base } from '@playwright/test';
  * ```
  */
 export const test = base.extend<{ autoTestFixture: void }>({
-  // Auto-detect @known-error tag in test title
+  // Auto-detect @known-error tag in test title or tags
   autoTestFixture: [async ({}, use, testInfo) => {
-    // Check if test title contains @known-error tag (case-insensitive)
-    if (testInfo.title.toLowerCase().includes('@known-error')) {
+    // Check both the test title (plain Playwright specs put the tag in the title)
+    // and testInfo.tags (playwright-bdd emits Gherkin @tags into testInfo.tags).
+    const inTitle = testInfo.title.toLowerCase().includes('@known-error');
+    const inTags = testInfo.tags.some(tag => tag.toLowerCase() === '@known-error');
+    if (inTitle || inTags) {
       // Add annotation to mark this test as tracking a known bug
       // The reporter will handle this specially:
       // - If it fails: Don't count as real failure (expected behavior)

--- a/fixtures/known-error.ts
+++ b/fixtures/known-error.ts
@@ -1,4 +1,5 @@
 import { test as base } from '@playwright/test';
+import { hasTag } from '../lib/test-tags';
 
 /**
  * Fixture that automatically marks tests tagged with @known-error.
@@ -27,11 +28,9 @@ import { test as base } from '@playwright/test';
 export const test = base.extend<{ autoTestFixture: void }>({
   // Auto-detect @known-error tag in test title or tags
   autoTestFixture: [async ({}, use, testInfo) => {
-    // Check both the test title (plain Playwright specs put the tag in the title)
-    // and testInfo.tags (playwright-bdd emits Gherkin @tags into testInfo.tags).
-    const inTitle = testInfo.title.toLowerCase().includes('@known-error');
-    const inTags = testInfo.tags.some(tag => tag.toLowerCase() === '@known-error');
-    if (inTitle || inTags) {
+    // Tag may live in the title (plain specs) or in testInfo.tags (playwright-bdd
+    // Gherkin @tags) — hasTag covers both with one shared, case-insensitive semantics.
+    if (hasTag(testInfo, '@known-error')) {
       // Add annotation to mark this test as tracking a known bug
       // The reporter will handle this specially:
       // - If it fails: Don't count as real failure (expected behavior)

--- a/lib/summary-generator.test.ts
+++ b/lib/summary-generator.test.ts
@@ -530,6 +530,30 @@ describe('Summary Generator', () => {
       assert(result.indexOf('## ❗ Needs Attention') < result.indexOf('## 📊 Test Results'));
     });
 
+    test('should group playwright-bdd generated specs by domain and strip the .feature.spec suffix', () => {
+      const data: TestSummaryData = {
+        status: 'passed',
+        duration: 10000,
+        tests: [
+          createTest({
+            title: 'Innvilget trygdeavtale-vedtak',
+            // playwright-bdd emits absolute paths into .features-gen/features/<domain>/…
+            file: '/Users/dev/melosys-e2e-tests/.features-gen/features/trygdeavtale/trygdeavtale-vedtak.feature.spec.js'
+          }),
+        ]
+      };
+
+      const result = generateMarkdownSummary(data);
+
+      // Grouped under the real domain, not collapsed into "root"
+      assert(result.includes('<strong>trygdeavtale</strong>'));
+      assert(!result.includes('<strong>root</strong>'));
+      // Redundant "trygdeavtale-" prefix and ".feature.spec.js" suffix are stripped
+      assert(result.includes('📄 vedtak'));
+      assert(!result.includes('feature.spec.js'));
+      assert(!result.includes('📄 trygdeavtale-vedtak'));
+    });
+
   });
 
   describe('Duration Rollup', () => {

--- a/lib/summary-generator.test.ts
+++ b/lib/summary-generator.test.ts
@@ -554,6 +554,54 @@ describe('Summary Generator', () => {
       assert(!result.includes('📄 trygdeavtale-vedtak'));
     });
 
+    test('should group generated specs by domain regardless of the features root dir name', () => {
+      const data: TestSummaryData = {
+        status: 'passed',
+        duration: 10000,
+        tests: [
+          // features glob rooted in specs/ instead of features/
+          createTest({
+            title: 'scenario A',
+            file: '/Users/dev/melosys-e2e-tests/.features-gen/specs/trygdeavtale/trygdeavtale-vedtak.feature.spec.js'
+          }),
+          // custom featuresRoot: no mirrored root segment at all
+          createTest({
+            title: 'scenario B',
+            file: '/Users/dev/melosys-e2e-tests/.features-gen/aarsavregning/aarsavregning-ftrl.feature.spec.js'
+          }),
+        ]
+      };
+
+      const result = generateMarkdownSummary(data);
+
+      assert(result.includes('<strong>trygdeavtale</strong>'));
+      assert(result.includes('<strong>aarsavregning</strong>'));
+      assert(!result.includes('<strong>root</strong>'));
+      assert(!result.includes('<strong>specs</strong>'));
+    });
+
+    test('should show the real domain folder for failed BDD tests in the Failed Tests section', () => {
+      const data: TestSummaryData = {
+        status: 'failed',
+        duration: 10000,
+        tests: [
+          createTest({
+            title: 'Innvilget trygdeavtale-vedtak',
+            status: 'failed',
+            file: '/Users/dev/melosys-e2e-tests/.features-gen/features/trygdeavtale/trygdeavtale-vedtak.feature.spec.js',
+            error: 'Forventet AVSLUTTET, fikk UNDER_BEHANDLING'
+          }),
+        ]
+      };
+
+      const result = generateMarkdownSummary(data);
+
+      // Same parsing as the domain table — not the old 'root' fallback
+      assert(result.includes('**Folder:** `trygdeavtale`'));
+      assert(result.includes('**File:** `trygdeavtale-vedtak.feature.spec.js`'));
+      assert(!result.includes('**Folder:** `root`'));
+    });
+
   });
 
   describe('Duration Rollup', () => {

--- a/lib/summary-generator.ts
+++ b/lib/summary-generator.ts
@@ -229,16 +229,23 @@ interface ParsedTestPath {
 /**
  * Parse a test file path into domain / file label, stripping the redundant
  * leading "<domain>-" so file labels don't repeat the folder name.
+ *
+ * Handwritten specs live under `tests/<domain>/…`; playwright-bdd generated
+ * specs live under `.features-gen/features/<domain>/…`. Anchor on whichever
+ * root segment is present so BDD tests get grouped by domain too (rather than
+ * collapsing into a single "root" bucket).
  */
 function parseTestPath(file: string): ParsedTestPath {
   const parts = file.split('/');
-  const i = parts.indexOf('tests');
+  let i = parts.indexOf('tests');
+  if (i === -1) i = parts.indexOf('features'); // .features-gen/features/<domain>/…
   const after = i !== -1 ? parts.slice(i + 1) : parts.slice(-1);
   const base = after[after.length - 1];
   const domain = after.length > 1 ? after[0] : 'root';
   const sub = after.length > 2 ? after.slice(1, -1).join('/') : '';
 
-  let label = base.replace(/\.spec\.ts$/, '');
+  // Handwritten: <name>.spec.ts. Generated: <name>.feature.spec.js.
+  let label = base.replace(/\.(feature\.)?spec\.(ts|js)$/, '');
   if (domain !== 'root' && label.startsWith(`${domain}-`)) {
     label = label.slice(domain.length + 1);
   }

--- a/lib/summary-generator.ts
+++ b/lib/summary-generator.ts
@@ -231,15 +231,27 @@ interface ParsedTestPath {
  * leading "<domain>-" so file labels don't repeat the folder name.
  *
  * Handwritten specs live under `tests/<domain>/…`; playwright-bdd generated
- * specs live under `.features-gen/features/<domain>/…`. Anchor on whichever
- * root segment is present so BDD tests get grouped by domain too (rather than
- * collapsing into a single "root" bucket).
+ * specs live under `.features-gen/…`, mirroring the features root dir (e.g.
+ * `.features-gen/features/<domain>/…`). Anchor on the machine-generated
+ * `.features-gen` segment — not a folder that happens to be named "features" —
+ * so BDD tests group by domain regardless of where the .feature files live.
  */
 function parseTestPath(file: string): ParsedTestPath {
   const parts = file.split('/');
-  let i = parts.indexOf('tests');
-  if (i === -1) i = parts.indexOf('features'); // .features-gen/features/<domain>/…
-  const after = i !== -1 ? parts.slice(i + 1) : parts.slice(-1);
+  const testsIdx = parts.indexOf('tests');
+  const genIdx = parts.indexOf('.features-gen');
+  let after: string[];
+  if (testsIdx !== -1) {
+    after = parts.slice(testsIdx + 1);
+  } else if (genIdx !== -1) {
+    after = parts.slice(genIdx + 1);
+    // Drop the mirrored features-root segment ('features/', 'specs/', …) so the
+    // domain folder comes first; with a custom featuresRoot there is no mirrored
+    // segment (only <domain>/<file>), hence the length guard.
+    if (after.length > 2) after = after.slice(1);
+  } else {
+    after = parts.slice(-1);
+  }
   const base = after[after.length - 1];
   const domain = after.length > 1 ? after[0] : 'root';
   const sub = after.length > 2 ? after.slice(1, -1).join('/') : '';
@@ -305,7 +317,15 @@ interface FileGroup {
   hasFail: boolean;
 }
 
-/** Group a domain's tests by file label; failing files (and tests) sort first. */
+/**
+ * Group a domain's tests by file label; failing files (and tests) sort first.
+ *
+ * Known limitation: the key is the parsed label, so a handwritten spec and a
+ * BDD-generated twin with the same base name (tests/<d>/x.spec.ts and
+ * .features-gen/…/<d>/x.feature.spec.js) would merge into one entry. No such
+ * name pair exists today, and bdd/chromium report per invocation — revisit the
+ * key if the two ever land in the same run.
+ */
 function groupTestsByFile(tests: TestData[]): FileGroup[] {
   const map = new Map<string, TestData[]>();
   for (const t of tests) {
@@ -450,22 +470,14 @@ function generateFailedTestsSection(failedTests: TestData[]): string {
   let md = `## ❌ Failed Tests (${failedTests.length})\n\n`;
 
   for (const testInfo of failedTests) {
-    const filePath = testInfo.file;
-    const parts = filePath.split('/');
-    const fileName = parts[parts.length - 1];
-
-    // Find "tests" directory index
-    const testsIndex = parts.indexOf('tests');
-    let folderPath = 'root';
-
-    if (testsIndex !== -1 && testsIndex < parts.length - 1) {
-      const foldersAfterTests = parts.slice(testsIndex + 1, parts.length - 1);
-      folderPath = foldersAfterTests.length > 0 ? foldersAfterTests.join('/') : 'root';
-    }
+    // Same parsing as the domain grouping, so Folder/File here never disagree
+    // with the summary table (covers both tests/ and .features-gen/ paths).
+    const { domain, sub, base } = parseTestPath(testInfo.file);
+    const folderPath = domain === 'root' ? 'root' : (sub ? `${domain}/${sub}` : domain);
 
     md += `### ${testInfo.title}\n\n`;
     md += `**Folder:** \`${folderPath}\`  \n`;
-    md += `**File:** \`${fileName}\`  \n`;
+    md += `**File:** \`${base}\`  \n`;
     md += `**Attempts:** ${testInfo.totalAttempts} (${testInfo.failedAttempts} failed)  \n`;
     md += `**Duration:** ${Math.round(testInfo.duration / 1000)}s\n\n`;
 

--- a/lib/test-tags.test.ts
+++ b/lib/test-tags.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for the shared tag-detection helper.
+ *
+ * Run tests:
+ *   npm run test:unit
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { hasTag } from './test-tags';
+
+describe('hasTag', () => {
+
+  test('finds tag embedded in the title (plain Playwright specs)', () => {
+    assert(hasTag({ title: 'skal håndtere kjent feil @known-error #MELOSYS-123' }, '@known-error'));
+  });
+
+  test('finds tag in the tags array (playwright-bdd Gherkin @tags)', () => {
+    assert(hasTag({ title: 'Innvilget vedtak', tags: ['@known-error'] }, '@known-error'));
+  });
+
+  test('is case-insensitive in both title and tags', () => {
+    assert(hasTag({ title: 'skal feile @Known-Error' }, '@known-error'));
+    assert(hasTag({ title: 'Innvilget vedtak', tags: ['@Expect-Docker-Errors'] }, '@expect-docker-errors'));
+  });
+
+  test('tolerates punctuation adjacent to a title tag', () => {
+    assert(hasTag({ title: 'skal feile (@known-error, se MELOSYS-123)' }, '@known-error'));
+  });
+
+  test('does not match a different tag', () => {
+    assert(!hasTag({ title: 'vanlig test', tags: ['@manual'] }, '@known-error'));
+  });
+
+  test('handles missing tags array', () => {
+    assert(!hasTag({ title: 'vanlig test' }, '@known-error'));
+  });
+
+});

--- a/lib/test-tags.ts
+++ b/lib/test-tags.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared tag detection for Playwright tests — ONE semantics for all consumers
+ * (fixtures and reporters), so tag matching can't drift between call sites.
+ *
+ * A tag can live in two places depending on how the test was authored:
+ * - Plain Playwright specs put tags in the test title ("skal … @known-error #MELOSYS-123")
+ * - playwright-bdd emits Gherkin @tags into testInfo.tags / TestCase.tags
+ *
+ * Playwright's own `tags` getter also extracts title-embedded @-words, but the
+ * title fallback is kept deliberately: the extraction regex (`@[\S]+`) swallows
+ * adjacent punctuation ("@known-error," would fail an exact tag compare), while
+ * substring matching on the title tolerates it.
+ *
+ * Matching is case-insensitive in both branches (Gherkin allows any tag casing).
+ */
+export function hasTag(info: { title: string; tags?: string[] }, tag: string): boolean {
+  const wanted = tag.toLowerCase();
+  return (
+    info.title.toLowerCase().includes(wanted) ||
+    (info.tags ?? []).some(t => t.toLowerCase() === wanted)
+  );
+}

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "End-to-end tests for Melosys using Playwright",
   "main": "index.js",
   "scripts": {
-    "test": "playwright test",
-    "test:headed": "playwright test --headed",
-    "test:debug": "playwright test --debug",
-    "test:ui": "playwright test --ui",
+    "test": "playwright test --project=chromium",
+    "test:headed": "playwright test --project=chromium --headed",
+    "test:debug": "playwright test --project=chromium --debug",
+    "test:ui": "playwright test --project=chromium --ui",
     "test:unit": "node --require ts-node/register --test lib/**/*.test.ts",
     "check:tests": "node scripts/check-vacuous-tests.mjs",
-    "test:record": "RECORD_API=true playwright test",
+    "test:record": "RECORD_API=true playwright test --project=chromium",
     "replay": "ts-node scripts/replay-api-calls.ts",
 
     "generate-summary": "ts-node scripts/generate-summary-from-json.ts",

--- a/reporters/test-summary.ts
+++ b/reporters/test-summary.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { generateMarkdownSummary } from '../lib/summary-generator';
 import { TestSummaryData, TestData } from '../lib/types';
+import { hasTag } from '../lib/test-tags';
 
 /**
  * Custom Playwright reporter that creates a test summary
@@ -36,9 +37,11 @@ class TestSummaryReporter implements Reporter {
     // Create unique key for test (file + title)
     const key = `${test.location.file}::${test.title}`;
 
-    // Check if test is marked as known-error
+    // Check if test is marked as known-error: the fixture pushes an annotation,
+    // but tests that bypass the shared fixtures (e.g. plain @playwright/test specs
+    // or Gherkin scenarios tagged via test.tags) are covered by hasTag directly.
     const isKnownError = test.annotations.some(a => a.type === 'known-error') ||
-                        test.title.toLowerCase().includes('@known-error');
+                        hasTag({ title: test.title, tags: test.tags }, '@known-error');
 
     // Get or create test info
     let testInfo = this.testsByKey.get(key);


### PR DESCRIPTION
Isolerer den delte test-infrastrukturen som ATDD-eksempelet (PR 2) bygger på, i en liten PR med høyest regresjonsrisiko. Første av to PR-er fra ATDD-planen.

playwright-bdd legger Gherkin-tagger i `testInfo.tags` og ikke i tittelen, så fixturene for `@known-error` og `@expect-docker-errors` må utvides for at BDD-scenarioer skal detekteres. Samtidig grupperer rapporten genererte spec-er på domene, og npm-scriptene pinnes til chromium slik at BDD blir reelt opt-in. Alle endringene er no-op mot dagens main-suite.

- Detekter `@known-error` og `@expect-docker-errors` via `testInfo.tags` i tillegg til tittel
- Grupper `.features-gen`-genererte spec-er på domene i rapporten med renset label
- Pin `test`/`test:headed`/`test:debug`/`test:ui`/`test:record` til `--project=chromium`

## Oppfølging etter code-review (`4029c08`)

Multi-agent-review (8 finder-vinkler + verifisering per funn) ga 6 verifiserte funn; alle adressert:

- **Felles `hasTag()`-helper** (`lib/test-tags.ts`): tag-deteksjonen var duplisert i de to fixturene med divergerende case-sensitivitet — nå én case-insensitiv semantikk. Reporteren sjekker nå også `test.tags`, så tester som bevisst går utenom fixturene (f.eks. skjema-testene med ren `@playwright/test`) dekkes.
- **Failed Tests-seksjonen** gjenbruker `parseTestPath` i stedet for en egen duplisert parsing med kun `tests`-anker — en feilende BDD-test viste `Folder: root` der domenetabellen viste riktig domene.
- **Robust anker**: `parseTestPath` ankrer på det maskingenererte `.features-gen`-segmentet i stedet for et mappenavn som tilfeldigvis heter `features` — grupperingen overlever at feature-filene flyttes (f.eks. til `specs/`).
- Bevisst ikke endret: grupperingsnøkkelen kan i teorien slå sammen en håndskrevet spec og en BDD-tvilling med samme basenavn — latent (ingen navnekollisjon i dag), dokumentert i kommentar.

## Testing
- [x] Enhetstester (`npm run test:unit` — 64 grønne, inkl. `hasTag`-tester og nye `.features-gen`-caser)
- [x] `npm run check:tests` grønt
- [x] `npx playwright test --list --project=chromium` — samlingen laster
- [x] E2E-røyk lokalt mot kjørende stack: `tests/core/sok-og-navigasjon.spec.ts` 5/5 grønne (fixtures verifisert i praksis)
- [x] E2E-suite mot main uendret — dispatch-CI grønn, 105/105 passed ([run 28886906366](https://github.com/navikt/melosys-e2e-tests/actions/runs/28886906366))
