### PR TITLE
MELOSYS-8084 Tilpass e2e-tester til synk-steget i avslutt-flytene

### DIFF
--- a/pages/trygdeavtale/trygdeavtale-unntaksregistrering.assertions.ts
+++ b/pages/trygdeavtale/trygdeavtale-unntaksregistrering.assertions.ts
@@ -7,7 +7,8 @@ import { fetchMedlPeriode } from '../../helpers/mock-helper';
  *
  * Verifiserer DB-utfallet av unntaksregistrering på en trygdeavtale-sak
  * (prosess REGISTRERE_UNNTAK_FRA_MEDLEMSKAP: LAGRE_LOVVALGSPERIODE_MEDL →
- * AVSLUTT_SAK_OG_BEHANDLING) + MEDL-perioden i mock-registeret.
+ * AVSLUTT_SAK_OG_BEHANDLING → SYNK_SKJEMA_SAKSSTATUS) + MEDL-perioden i
+ * mock-registeret.
  *
  * Databasen renses før hver test (cleanup-fixture), så testens sak/behandling
  * er de eneste radene — ingen tidsfilter trengs.
@@ -20,7 +21,7 @@ export class TrygdeavtaleUnntaksregistreringAssertions {
    *  - behandlingen er AVSLUTTET, fagsaken LOVVALG_AVKLART (TRYGDEAVTALE/UNNTAK)
    *  - behandlingsresultat REGISTRERT_UNNTAK / GODKJENT / fastsatt av forventet land
    *  - prosessinstansen REGISTRERE_UNNTAK_FRA_MEDLEMSKAP er FERDIG med
-   *    SIST_FULLFORT_STEG=AVSLUTT_SAK_OG_BEHANDLING, og ingen prosesser FEILET
+   *    SIST_FULLFORT_STEG=SYNK_SKJEMA_SAKSSTATUS, og ingen prosesser FEILET
    *  - lovvalgsperioden er INNVILGET/UNNTATT/UTEN_DEKNING med riktig
    *    bestemmelse og MEDLPERIODE_ID satt (= overført til MEDL)
    *
@@ -154,7 +155,8 @@ export class TrygdeavtaleUnntaksregistreringAssertions {
   /**
    * Felles vakt: nøyaktig én behandling som er AVSLUTTET, prosessen
    * REGISTRERE_UNNTAK_FRA_MEDLEMSKAP FERDIG med sist fullført steg
-   * AVSLUTT_SAK_OG_BEHANDLING, og ingen feilede prosessinstanser.
+   * SYNK_SKJEMA_SAKSSTATUS (siste steg i avslutt-flyten), og ingen
+   * feilede prosessinstanser.
    */
   private async verifiserBehandlingOgProsess(db: DatabaseHelper): Promise<void> {
     const behandlinger = await db.query<{ ID: number; STATUS: string }>(
@@ -179,9 +181,11 @@ export class TrygdeavtaleUnntaksregistreringAssertions {
     );
     expect(prosess, 'Forventet en REGISTRERE_UNNTAK_FRA_MEDLEMSKAP-prosessinstans').not.toBeNull();
     expect(prosess!.STATUS).toBe('FERDIG');
-    expect(prosess!.SIST_FULLFORT_STEG).toBe('AVSLUTT_SAK_OG_BEHANDLING');
+    // SYNK_SKJEMA_SAKSSTATUS er siste steg i alle avslutt-flyter (no-op for
+    // saker uten skjema-kobling), jf. ProsessflytDefinisjon i melosys-api.
+    expect(prosess!.SIST_FULLFORT_STEG).toBe('SYNK_SKJEMA_SAKSSTATUS');
     console.log(
-      '✅ REGISTRERE_UNNTAK_FRA_MEDLEMSKAP FERDIG (sist fullført steg: AVSLUTT_SAK_OG_BEHANDLING)'
+      '✅ REGISTRERE_UNNTAK_FRA_MEDLEMSKAP FERDIG (sist fullført steg: SYNK_SKJEMA_SAKSSTATUS)'
     );
   }
 

--- a/pages/trygdeavtale/trygdeavtale-unntaksregistrering.assertions.ts
+++ b/pages/trygdeavtale/trygdeavtale-unntaksregistrering.assertions.ts
@@ -181,8 +181,6 @@ export class TrygdeavtaleUnntaksregistreringAssertions {
     );
     expect(prosess, 'Forventet en REGISTRERE_UNNTAK_FRA_MEDLEMSKAP-prosessinstans').not.toBeNull();
     expect(prosess!.STATUS).toBe('FERDIG');
-    // SYNK_SKJEMA_SAKSSTATUS er siste steg i alle avslutt-flyter (no-op for
-    // saker uten skjema-kobling), jf. ProsessflytDefinisjon i melosys-api.
     expect(prosess!.SIST_FULLFORT_STEG).toBe('SYNK_SKJEMA_SAKSSTATUS');
     console.log(
       '✅ REGISTRERE_UNNTAK_FRA_MEDLEMSKAP FERDIG (sist fullført steg: SYNK_SKJEMA_SAKSSTATUS)'

--- a/tests/utenfor-avtaleland/komplett-sak-flere-land-flereinntektskilder.spec.ts
+++ b/tests/utenfor-avtaleland/komplett-sak-flere-land-flereinntektskilder.spec.ts
@@ -29,6 +29,10 @@ import { expect } from '@playwright/test';
 
 test.describe('Komplett saksflyt - FTRL flere land', () => {
   test('skal fullføre komplett saksflyt - delevis skattepliktig - med flere inntektskilder', async ({ page, request }) => {
+    // Flyten lå allerede tett på 60s-defaulten; SYNK_SKJEMA_SAKSSTATUS-steget i
+    // avslutt-flytene tippet den over. 120s som de øvrige komplett-sak-testene.
+    test.setTimeout(120000);
+
     // Setup
     const auth = new AuthHelper(page);
     await auth.login();

--- a/tests/utenfor-avtaleland/komplett-sak-flere-land-flereinntektskilder.spec.ts
+++ b/tests/utenfor-avtaleland/komplett-sak-flere-land-flereinntektskilder.spec.ts
@@ -29,8 +29,6 @@ import { expect } from '@playwright/test';
 
 test.describe('Komplett saksflyt - FTRL flere land', () => {
   test('skal fullføre komplett saksflyt - delevis skattepliktig - med flere inntektskilder', async ({ page, request }) => {
-    // Flyten lå allerede tett på 60s-defaulten; SYNK_SKJEMA_SAKSSTATUS-steget i
-    // avslutt-flytene tippet den over. 120s som de øvrige komplett-sak-testene.
     test.setTimeout(120000);
 
     // Setup


### PR DESCRIPTION
Etter at melosys-api fikk SYNK_SKJEMA_SAKSSTATUS som siste steg i alle avslutt-flyter (no-op for saker uten skjema-kobling) feilet tre e2e-tester:

- **trygdeavtale-unntaksregistrering (begge tester)**: assertions forventet `SIST_FULLFORT_STEG=AVSLUTT_SAK_OG_BEHANDLING` for REGISTRERE_UNNTAK_FRA_MEDLEMSKAP; faktisk siste steg er nå `SYNK_SKJEMA_SAKSSTATUS`. Forventningen (og doc/logg) er oppdatert.
- **komplett-sak-flere-land-flereinntektskilder**: flyten lå allerede tett på 60s-default-timeouten (1.0m grønn i siste kjøring før synk-steget); det ekstra steget per avslutt tippet den over. Satt `test.setTimeout(120000)` som de øvrige komplett-sak-testene.

Alle tre er verifisert grønne lokalt mot merget main av melosys-api/skjema-api (3 passed, 2.4m). `npm run check:tests` OK. Kun testsiden er endret.