### PR TITLE
NOJIRA E2E-test for ugyldig dato i unntaksperiode-kontrollen

### DIFF
--- a/pages/eu-eos/registrering-unntaksperiode.assertions.ts
+++ b/pages/eu-eos/registrering-unntaksperiode.assertions.ts
@@ -1,0 +1,168 @@
+import { APIRequestContext, Page, expect } from '@playwright/test';
+import * as dotenv from 'dotenv';
+import * as path from 'node:path';
+import { withDatabase } from '../../helpers/db-helper';
+import { UnntaksperiodeKontrollKall } from './registrering-unntaksperiode.page';
+
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+dotenv.config({ path: path.resolve(__dirname, '../../.env.local'), override: true });
+
+const API_BASE_URL = process.env.MELOSYS_API_BASE_URL || 'http://localhost:8080/api';
+
+/**
+ * Assertions for «Registrering av unntaksperioder» — inkludert kontrakten mot
+ * live-kontroll-endepunktet `POST /api/kontroll/{behandlingID}/unntaksperiode`.
+ */
+export class RegistreringUnntaksperiodeAssertions {
+  constructor(private readonly page: Page) {}
+
+  /**
+   * Registerkontrollen (UfmKontroll, kjørt i REGISTERKONTROLL-steget) skal ha gitt
+   * treff, slik at behandlingen IKKE ble registrert automatisk men havnet hos
+   * saksbehandler (BestemBehandlingsmåteSed).
+   *
+   * @param treffTekst - Forventet kontrollbegrunnelse, f.eks. «Periodelengde er mer enn 24 måneder»
+   */
+  async verifiserRegisterkontrolltreff(treffTekst: string): Promise<void> {
+    await expect(
+      this.page.getByText('Treff ved automatisk kontroll'),
+      'Registerkontrollen skal ha gitt treff (ellers ville behandlingen blitt registrert automatisk)'
+    ).toBeVisible({ timeout: 30000 });
+
+    await expect(
+      this.page.getByText(treffTekst),
+      `Forventet kontrollbegrunnelsen «${treffTekst}»`
+    ).toBeVisible({ timeout: 15000 });
+
+    console.log(`✅ Registerkontrolltreff bekreftet: «${treffTekst}»`);
+  }
+
+  /**
+   * Live-kontrollen skal ha blitt kalt med den angitte perioden og svart med
+   * forventet status: 400 (ValideringException med feilkoder) for en periode som
+   * bryter regelsettet, 204 for en gyldig periode.
+   *
+   * Merk: melosys-web viser ikke disse feilkodene i dag — `KontrollFeilSelector`
+   * leser `data.kontrollfeilList`, mens ExceptionMapper svarer med `feilkoder`.
+   * Vi asserter derfor på HTTP-kontrakten, ikke på UI-tilstand.
+   *
+   * @param kall - Innsamlede kontrollkall fra `overvåkKontrollkall()`
+   * @param periode - Forventet periode i ISO-format
+   * @param forventetStatus - 400 (avvist) eller 204 (godtatt)
+   */
+  verifiserKontrollForPeriode(
+    kall: UnntaksperiodeKontrollKall[],
+    periode: { fom: string; tom: string },
+    forventetStatus: number
+  ): void {
+    const forventetBody = `{"periodeFom":"${periode.fom}","periodeTom":"${periode.tom}"}`;
+    const treff = kall.filter(k => k.body === forventetBody);
+    expect(
+      treff.length,
+      `Forventet minst ett live-kontrollkall med ${forventetBody}. Observerte kall: ${JSON.stringify(kall)}`
+    ).toBeGreaterThan(0);
+    expect(
+      treff.map(k => k.status),
+      `Live-kontrollen skal svare ${forventetStatus} på perioden ${periode.fom} – ${periode.tom}`
+    ).toContain(forventetStatus);
+    console.log(`✅ Live-kontroll ${periode.fom} – ${periode.tom} → ${forventetStatus}`);
+  }
+
+  /**
+   * Rotårsaken (melosys-web): live-kontrollen skal ALDRI få den literale
+   * strengen «Invalid date» som dato. Før fiksen returnerte
+   * `formatterDatoTilISO` sentinelstrengen som default, og truthiness-guarden i
+   * `mapDispatchToProps` slapp den gjennom for hvert halvskrevet tastetrykk.
+   */
+  verifiserIngenUgyldigDatoSendt(kall: UnntaksperiodeKontrollKall[]): void {
+    const ugyldige = kall.filter(k => k.body.includes('Invalid date'));
+    expect(
+      ugyldige.map(k => k.body),
+      'melosys-web skal ikke sende sentinelstrengen «Invalid date» til unntaksperiode-kontrollen'
+    ).toEqual([]);
+    console.log(`✅ Ingen av ${kall.length} kontrollkall inneholdt «Invalid date»`);
+  }
+
+  /**
+   * Positivt bevis på at guarden faktisk virker: minst ett tastetrykk ga en
+   * uparsebar dato (f.eks. «0» eller «05.0») og skal da ha blitt stoppet i
+   * frontend — altså færre kontrollkall enn tastetrykk. Uten fiksen ville hvert
+   * eneste tastetrykk gitt et kall, flere av dem med «Invalid date».
+   *
+   * @param antallSendt - Antall kontrollkall observert mens datoen ble skrevet
+   * @param dato - Datoen som ble skrevet tegn for tegn
+   */
+  verifiserUgyldigeTastetrykkStoppet(antallSendt: number, dato: string): void {
+    expect(
+      antallSendt,
+      'Live-kontrollen skal ha blitt kalt mens datoen ble skrevet (ellers tester vi ingenting)'
+    ).toBeGreaterThan(0);
+    expect(
+      antallSendt,
+      `Minst ett av de ${dato.length} tastetrykkene i «${dato}» gir en uparsebar dato og skal stoppes i frontend`
+    ).toBeLessThan(dato.length);
+    console.log(`✅ ${dato.length - antallSendt} av ${dato.length} tastetrykk stoppet i frontend (ugyldig dato)`);
+  }
+
+  /**
+   * Ingen av live-kontrollkallene skal gi 5xx. Kontrollfeil (periode over 24 md)
+   * er en forventet 400 med feilkoder — det er serverfeilen som er bugen.
+   */
+  verifiserIngenServerfeil(kall: UnntaksperiodeKontrollKall[]): void {
+    const serverfeil = kall.filter(k => (k.status ?? 0) >= 500);
+    expect(
+      serverfeil.map(k => `${k.status}: ${k.body}`),
+      'Live-kontrollen skal aldri gi 5xx — en tastefeil er en klientfeil'
+    ).toEqual([]);
+    console.log(`✅ Ingen serverfeil i ${kall.length} kontrollkall`);
+  }
+
+  /**
+   * Den ENDREDE perioden (ikke SED-perioden) skal være persistert på
+   * lovvalgsperioden. Beviser at «Godkjenn, men endre periode» faktisk
+   * overstyrer perioden fra SED-en.
+   *
+   * @param fom - Forventet startdato (dd.MM.yyyy)
+   * @param tom - Forventet sluttdato (dd.MM.yyyy)
+   */
+  async verifiserEndretPeriodeLagret(fom: string, tom: string): Promise<void> {
+    await withDatabase(async (db) => {
+      const periode = await db.queryOne<{ FOM: string; TOM: string }>(
+        `SELECT TO_CHAR(FOM_DATO, 'DD.MM.YYYY') AS FOM, TO_CHAR(TOM_DATO, 'DD.MM.YYYY') AS TOM
+         FROM LOVVALG_PERIODE ORDER BY ID DESC FETCH FIRST 1 ROWS ONLY`, {});
+      expect(periode, 'Forventet en lovvalgsperiode').not.toBeNull();
+      expect(periode!.FOM, 'Startdato skal være den saksbehandler registrerte').toBe(fom);
+      expect(periode!.TOM, 'Sluttdato skal være den ENDREDE (forkortede) datoen, ikke SED-ens').toBe(tom);
+      console.log(`✅ Endret periode lagret: ${periode!.FOM} – ${periode!.TOM}`);
+    });
+  }
+
+  /**
+   * API-kontrakten (melosys-api): en ugyldig datostreng skal gi 400 med en fast,
+   * sanert melding — ikke 500 med Jackson-stacktrace i loggen. Kalles direkte mot
+   * api-et fordi frontenden etter fiksen aldri sender slike verdier.
+   */
+  async verifiserApiAvviserUgyldigDato(request: APIRequestContext, behandlingID: number): Promise<void> {
+    const response = await request.post(
+      `${API_BASE_URL}/kontroll/${behandlingID}/unntaksperiode`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${process.env.LOCAL_AUTH_TOKEN}`,
+        },
+        data: '{"periodeFom":"2026-01-01","periodeTom":"Invalid date"}',
+      }
+    );
+
+    const body = await response.text();
+    expect(
+      response.status(),
+      `Ugyldig dato skal gi 400 (klientfeil), ikke ${response.status()}. Body: ${body}`
+    ).toBe(400);
+    expect(body, 'Responsen skal ikke lekke Jackson-/klassedetaljer').not.toContain('Invalid date');
+    expect(body, 'Responsen skal ikke lekke interne klassenavn').not.toContain('no.nav.melosys');
+    expect(JSON.parse(body).message).toBe('Ugyldig format på forespørselen');
+
+    console.log('✅ melosys-api avviser ugyldig dato med 400 og sanert melding');
+  }
+}

--- a/pages/eu-eos/registrering-unntaksperiode.page.ts
+++ b/pages/eu-eos/registrering-unntaksperiode.page.ts
@@ -1,0 +1,187 @@
+import { Page, Request, Response, expect } from '@playwright/test';
+import { BasePage } from '../shared/base.page';
+import { RegistreringUnntaksperiodeAssertions } from './registrering-unntaksperiode.assertions';
+
+/**
+ * Én observert POST mot live-kontrollen
+ * (`POST /api/kontroll/{behandlingID}/unntaksperiode`).
+ */
+export interface UnntaksperiodeKontrollKall {
+  url: string;
+  body: string;
+  status?: number;
+}
+
+/**
+ * Page Object for «Registrering av unntaksperioder» (EU/EØS,
+ * behandlingstema REGISTRERING_UNNTAK_NORSK_TRYGD_*).
+ *
+ * Siden vises når en inngående A009/A010 IKKE kan registreres automatisk, dvs.
+ * når registerkontrollen (UfmKontroll) har gitt minst ett treff — f.eks.
+ * PERIODEN_OVER_24_MD. Da opprettes en oppgave i stedet for automatisk
+ * godkjenning (BestemBehandlingsmåteSed), og saksbehandler må ta stilling til
+ * unntaksperioden i UI-et:
+ *
+ *   ( ) Godkjenn unntaksperiode        ← deaktivert så lenge det finnes kontrollfeil
+ *   ( ) Godkjenn, men endre periode    ← åpner Startdato/Sluttdato + begrunnelse
+ *   ( ) Ikke godkjenn
+ *
+ * Datofeltene er «live»: hvert tastetrykk trigger en
+ * `POST /api/kontroll/{behandlingID}/unntaksperiode` (saksopplysninger.jsx:88-96),
+ * som er kjernen i «Invalid date»-feilen denne POM-en brukes til å vokte.
+ *
+ * @example
+ * const unntak = new RegistreringUnntaksperiodePage(page);
+ * await unntak.ventPåSiden();
+ * await unntak.velgGodkjennMenEndrePeriode();
+ * const kall = unntak.overvåkKontrollkall();
+ * await unntak.skrivSluttdatoTegnForTegn('31.12.2027');
+ */
+export class RegistreringUnntaksperiodePage extends BasePage {
+  readonly assertions: RegistreringUnntaksperiodeAssertions;
+
+  private readonly heading = this.page.getByRole('heading', { name: 'Registrering av unntaksperioder' });
+  private readonly godkjennRadio = this.page.getByRole('radio', { name: 'Godkjenn unntaksperiode' });
+  private readonly endrePeriodeRadio = this.page.getByRole('radio', { name: 'Godkjenn, men endre periode' });
+  private readonly ikkeGodkjennRadio = this.page.getByRole('radio', { name: 'Ikke godkjenn' });
+  private readonly startdatoFelt = this.page.getByRole('textbox', { name: 'Startdato' });
+  private readonly sluttdatoFelt = this.page.getByRole('textbox', { name: 'Sluttdato' });
+  private readonly begrunnelseSelect = this.page.getByRole('combobox', { name: 'Begrunnelse for endret periode' });
+  private readonly lagreButton = this.page.getByRole('button', { name: 'Lagre' });
+
+  constructor(page: Page) {
+    super(page);
+    this.assertions = new RegistreringUnntaksperiodeAssertions(page);
+  }
+
+  /**
+   * Vent til registreringssiden er lastet. Ved mount kjører frontenden én
+   * kontroll på SED-perioden, så vi venter også på at nettverket roer seg.
+   */
+  async ventPåSiden(): Promise<void> {
+    await this.heading.waitFor({ state: 'visible', timeout: 60000 });
+    await this.page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+    console.log('✅ «Registrering av unntaksperioder» er åpen');
+  }
+
+  /**
+   * behandlingID fra URL-en (`?behandlingID=123`).
+   */
+  hentBehandlingID(): number {
+    const id = new URL(this.page.url()).searchParams.get('behandlingID');
+    expect(id, `Fant ikke behandlingID i URL: ${this.page.url()}`).not.toBeNull();
+    return Number(id);
+  }
+
+  /**
+   * Velg «Godkjenn, men endre periode», som åpner Startdato/Sluttdato-feltene.
+   */
+  async velgGodkjennMenEndrePeriode(): Promise<void> {
+    await this.endrePeriodeRadio.waitFor({ state: 'visible', timeout: 30000 });
+    await this.endrePeriodeRadio.check();
+    await this.sluttdatoFelt.waitFor({ state: 'visible', timeout: 15000 });
+    console.log('✅ Valgte «Godkjenn, men endre periode» — datofeltene er åpne');
+  }
+
+  /**
+   * Start overvåking av live-kontrollkallene. Returnerer en liste som fylles
+   * fortløpende med request-body og responsstatus for hver
+   * `POST /api/kontroll/{behandlingID}/unntaksperiode`.
+   *
+   * Må kalles FØR man skriver i datofeltene.
+   */
+  overvåkKontrollkall(): UnntaksperiodeKontrollKall[] {
+    const kall: UnntaksperiodeKontrollKall[] = [];
+    const erKontrollkall = (url: string) => /\/kontroll\/\d+\/unntaksperiode(\?|$)/.test(url);
+
+    this.page.on('request', (request: Request) => {
+      if (request.method() === 'POST' && erKontrollkall(request.url())) {
+        kall.push({ url: request.url(), body: request.postData() ?? '' });
+      }
+    });
+
+    this.page.on('response', (response: Response) => {
+      if (response.request().method() !== 'POST' || !erKontrollkall(response.url())) return;
+      const body = response.request().postData() ?? '';
+      const treff = kall.find(k => k.status === undefined && k.body === body);
+      if (treff) {
+        treff.status = response.status();
+      } else {
+        kall.push({ url: response.url(), body, status: response.status() });
+      }
+      console.log(`   ↪ kontroll: ${body} → ${response.status()}`);
+    });
+
+    return kall;
+  }
+
+  /**
+   * Skriv en dato tegn for tegn i Sluttdato-feltet — slik en saksbehandler
+   * gjør. Hvert tastetrykk gir en halvferdig verdi ("3", "31", "31.", …) som
+   * frontenden forsøker å formatere og sende til live-kontrollen.
+   *
+   * Feltet blurres bevisst IKKE her: poenget er tilstanden mens man skriver.
+   */
+  async skrivSluttdatoTegnForTegn(dato: string): Promise<void> {
+    await this.sluttdatoFelt.click();
+    await this.sluttdatoFelt.fill('');
+    await this.sluttdatoFelt.pressSequentially(dato, { delay: 120 });
+    // La de siste kallene rekke å bli sendt/besvart før vi inspiserer dem.
+    await this.page.waitForTimeout(1500);
+    console.log(`✅ Skrev sluttdato «${dato}» tegn for tegn`);
+  }
+
+  /**
+   * Sett en gyldig periode og fullfør skrivingen (blur), slik at frontenden
+   * formaterer verdiene og kjører en siste kontroll.
+   */
+  async settPeriode(startdato: string, sluttdato: string): Promise<void> {
+    await this.startdatoFelt.click();
+    await this.startdatoFelt.fill('');
+    await this.startdatoFelt.pressSequentially(startdato, { delay: 60 });
+    await this.startdatoFelt.press('Tab');
+
+    await this.sluttdatoFelt.click();
+    await this.sluttdatoFelt.fill('');
+    await this.sluttdatoFelt.pressSequentially(sluttdato, { delay: 60 });
+    await this.sluttdatoFelt.press('Tab');
+
+    await this.page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {});
+    console.log(`✅ Satte periode ${startdato} – ${sluttdato}`);
+  }
+
+  /**
+   * Velg begrunnelse for endret periode (verdien i nedtrekkslisten).
+   * Default er PERIODE_FEILREGISTRERT, som allerede er forhåndsvalgt.
+   */
+  async velgBegrunnelse(term: string): Promise<void> {
+    await this.begrunnelseSelect.waitFor({ state: 'visible', timeout: 15000 });
+    await this.selectByVisibleText(this.begrunnelseSelect, term);
+    console.log(`✅ Valgte begrunnelse «${term}»`);
+  }
+
+  /**
+   * Lagre registreringen. Venter på det kritiske godkjenningskallet
+   * (`POST /saksflyt/unntaksperioder/{id}/godkjenn`).
+   */
+  async lagre(): Promise<void> {
+    await expect(this.lagreButton).toBeEnabled({ timeout: 30000 });
+    const responsePromise = this.page.waitForResponse(
+      response => response.url().includes('/saksflyt/unntaksperioder/') &&
+                  response.url().includes('/godkjenn') &&
+                  response.request().method() === 'POST',
+      { timeout: 60000 }
+    );
+    await this.lagreButton.click();
+    const response = await responsePromise;
+    expect(response.status(), 'Godkjenning av unntaksperioden skal gå gjennom').toBeLessThan(300);
+    console.log(`✅ Lagret registrering av unntaksperiode → ${response.status()}`);
+  }
+
+  // Eksponert for assertions/tester som trenger å sjekke tilstanden på feltene.
+  get godkjennUnntaksperiodeRadio() { return this.godkjennRadio; }
+  get ikkeGodkjennUnntaksperiodeRadio() { return this.ikkeGodkjennRadio; }
+  get lagreKnapp() { return this.lagreButton; }
+  get sluttdato() { return this.sluttdatoFelt; }
+  get startdato() { return this.startdatoFelt; }
+}

--- a/specs/eu-eos-unntaksperiode-ugyldig-dato.md
+++ b/specs/eu-eos-unntaksperiode-ugyldig-dato.md
@@ -1,0 +1,131 @@
+---
+jira: NOJIRA
+status: bundet
+date: 2026-07-29
+kilde: melosys-kode-wiki/archive/melosys-api/2026-07-28-invalid-date-unntaksperiode-kontroll-plan.md
+---
+
+# «Invalid date» skal aldri sendes til – eller velte – unntaksperiode-kontrollen
+
+## Forretningsregel
+
+Ved registrering av unntak fra norsk trygd (inngående A009/A010) kan saksbehandler
+godkjenne unntaksperioden slik den står, avslå den, eller godkjenne med en **endret**
+periode. Endring er påkrevd når registerkontrollen har gitt treff — f.eks. når SED-en
+oppgir en periode over 24 måneder, som ikke kan innvilges uten videre.
+
+Mens saksbehandler skriver den nye perioden, kontrollerer systemet fortløpende om
+perioden kan godkjennes. En halvskrevet dato er en normal, forventet mellomtilstand i
+den prosessen: den skal ikke gi feilmelding til saksbehandler, og den skal ikke logges
+som en systemfeil hos NAV. Systemet skiller mellom **saksbehandlerens tastefeil**
+(klientfeil) og **feil i systemet** (serverfeil).
+
+## Scenario
+
+```gherkin
+Gitt at det er mottatt en A009 med en unntaksperiode på over 24 måneder
+  Og registerkontrollen har gitt treff, slik at saken må behandles manuelt
+ Når saksbehandler velger «Godkjenn, men endre periode»
+  Og skriver en ny sluttdato tegn for tegn
+ Så skal halvskrevne datoer ikke sendes til kontrollen
+  Og kontrollen skal aldri svare med en systemfeil (5xx)
+  Og en ugyldig dato som likevel når fram skal avvises som en klientfeil
+ Når saksbehandler har skrevet en gyldig, forkortet periode og lagrer
+ Så skal unntaket registreres med den endrede perioden
+```
+
+## Akseptansekriterier (det fagperson signerer av på)
+
+- [ ] Saksbehandler får ingen feilmelding av å skrive en dato tegn for tegn (utledet — bekreft med fagperson)
+- [ ] En tastefeil i datofeltet logges ikke som systemfeil hos NAV (operasjonelt krav fra prod-loggstøy 19.06.2026)
+- [ ] Unntaket registreres med den perioden saksbehandler faktisk registrerte, ikke perioden fra SED-en
+- [ ] Kontrollen avviser fortsatt en for lang periode (regresjonsvern for selve kontrollregelen)
+
+## Kjente avgrensninger (ikke dekket her)
+
+- **Debounce av live-kontrollen (T3 i planen) er ikke gjort.** Testen dokumenterer
+  dagens oppførsel: ett kontrollkall per tastetrykk med parsebar dato.
+- **UI-visning av kontrollfeil er ikke dekket.** Under arbeidet ble det avdekket at
+  `KontrollFeilSelector` (melosys-web `src/ducks/kontroll/selectors.ts`) leser
+  `data.kontrollfeilList`, mens `ExceptionMapper` svarer med `feilkoder` på 400. Det
+  betyr at `unntaksperiodeKontrollfeil` i praksis alltid er tom for dette endepunktet,
+  og at «Godkjenn unntaksperiode»-radioen derfor ikke deaktiveres slik koden legger opp
+  til. Testen asserter derfor på HTTP-kontrakten, ikke på knappetilstand. Egen sak.
+- Submit-stien (`POST /saksflyt/unntaksperioder/{id}/godkjenn`) er yup-gatet i frontend
+  og har aldri hatt dette problemet — den dekkes kun som happy-path her.
+
+---
+
+## Teknisk binding
+
+### Kontrakten som testes
+
+- **Endepunkt:** `POST /api/kontroll/{behandlingID}/unntaksperiode`
+  (`ValideringUnntaksperiodeController`, melosys-api)
+- **Avsender:** `saksopplysninger.jsx:88-96` (melosys-web,
+  `src/sider/eu_eøs/registrering/unntaksperioder/`) — `useEffect` som fyrer på hvert
+  tastetrykk i Startdato/Sluttdato.
+- **Bug (two-sided, latent siden 2022):**
+  - web: `formatterDatoTilISO` returnerte strengen `"Invalid date"` som default, og
+    guarden `if (periodeFom && periodeTom)` slapp den gjennom (truthy).
+  - api: ingen `@ExceptionHandler` for `HttpMessageNotReadableException` → catch-all →
+    **HTTP 500 + ERROR med stacktrace** for en ren klientinputfeil.
+- **Fiks:** api [#3426](https://github.com/navikt/melosys-api/pull/3426) (T1+T4: 400 +
+  INFO + sanert melding `Ugyldig format på forespørselen`), web
+  [#3121](https://github.com/navikt/melosys-web/pull/3121) (T2:
+  `formatterDatoTilISO(..., null)` på kallstedet).
+
+### Testfil
+
+`tests/eu-eos/eu-eos-unntaksperiode-ugyldig-dato.spec.ts` med POM
+`pages/eu-eos/registrering-unntaksperiode.page.ts` (+ `.assertions.ts`).
+
+Ny testfil, ikke bundet til en eksisterende flyt: ingen annen test når
+«Registrering av unntaksperioder»-skjermen. A009/A010 registreres normalt **helt
+automatisk** (`tests/core/sed-mottak.spec.ts`); skjermen vises kun når
+registerkontrollen har gitt treff.
+
+### Slik framtvinges den manuelle skjermen
+
+`UfmKontrollsett.REGELSETT_A009` inneholder `periodeOver24MånederOgEnDag`. Regelen er
+implementert som «over 2 år **og** minst én dag» (`PeriodeRegler.periodeOver2ÅrOgEnDag`
+— hele måneder teller *ikke*, så en 30-måneders periode gir **ikke** treff). Testen
+sender derfor en SED-periode på nøyaktig `fom + 2 år + 1 dag`. Treffet lagres som
+kontrollresultat, og `BestemBehandlingsmåteSed` oppretter oppgave i stedet for å
+godkjenne automatisk.
+
+### Binding av scenariolinjene
+
+| Gherkin-linje | Binding i testen |
+|---|---|
+| Gitt … A009 med periode over 24 måneder | `SedHelper.sendSed({sedType:'A009', landkode:'DE', periodeFom: i dag, periodeTom: i dag + 2 år + 1 dag})` |
+| Og registerkontrollen har gitt treff | `verifiserRegisterkontrolltreff('Periodelengde er mer enn 24 måneder')` — treffpanelet «Treff ved automatisk kontroll» |
+| Når … velger «Godkjenn, men endre periode» | `velgGodkjennMenEndrePeriode()`; forhåndsutfyllingen trigger første kontroll, som asserteres til **400** på SED-perioden |
+| Og skriver ny sluttdato tegn for tegn | `skrivSluttdatoTegnForTegn('05.MM.YYYY')` — `pressSequentially`, ingen blur. Dag `05` sikrer at minst ett tastetrykk («0») er uparsebart uansett årstid |
+| Så skal halvskrevne datoer ikke sendes | `verifiserUgyldigeTastetrykkStoppet(antallSendt, dato)` — færre kontrollkall enn tastetrykk + `verifiserIngenUgyldigDatoSendt` (ingen payload med `Invalid date`) |
+| Og kontrollen skal aldri svare 5xx | `verifiserIngenServerfeil(kall)` over alle observerte kontrollkall |
+| Og en ugyldig dato skal avvises som klientfeil | `verifiserApiAvviserUgyldigDato` — direkte `POST` med `{"periodeTom":"Invalid date"}` → **400**, `message = "Ugyldig format på forespørselen"`, ingen lekkasje av `Invalid date`/`no.nav.melosys` |
+| Når … gyldig forkortet periode og lagrer | `settPeriode(fom, fom+12md)` → kontroll asserteres til **204** → `lagre()` (venter på `POST /saksflyt/unntaksperioder/{id}/godkjenn`) |
+| Så skal unntaket registreres med endret periode | `EuEosUtpekingAssertions.verifiserRegistrertUnntakIverksatt({lovvalgsland:'DE', medlLovvalgsland:'DEU'})` + `verifiserEndretPeriodeLagret(fom, tom)` på `LOVVALG_PERIODE` |
+
+### Akseptansekriterier → vern
+
+1. **Ingen feilmelding ved skriving:** ingen `Invalid date`-payload + ingen 5xx i noen av kontrollkallene.
+2. **Ingen systemfeil i logg:** testen kjører uten `@expect-docker-errors`, så docker-log-fixturen feiler ved ERROR i melosys-api. Direktekallet i Del C treffer nå INFO-stien (`HttpMessageNotReadableException` → 400), ikke ERROR-stien.
+3. **Registrert periode = saksbehandlers periode:** DB-assert på `LOVVALG_PERIODE.FOM_DATO/TOM_DATO`.
+4. **Kontrollregelen består:** SED-perioden (2 år + 1 dag) asserteres til 400, den forkortede (12 md) til 204.
+
+### Mutasjonsverifisering
+
+2026-07-29: web-fiksen ble midlertidig reversert (`git revert --no-commit` på
+melosys-web `nojira-invalid-date-unntaksperiode`, Vite HMR) og testen ble kjørt på nytt.
+Den feilet som forventet — 10 kontrollkall for 10 tastetrykk, hvorav to med
+`{"periodeTom":"Invalid date"}`. Fiksen ble deretter gjenopprettet og testen er grønn.
+
+### Endringslogg (teknisk binding)
+
+- 2026-07-29: Spec + test opprettet. Assertion på deaktivert «Godkjenn unntaksperiode»-radio
+  ble forkastet etter live-verifisering: `unntaksperiodeKontrollfeil` populeres aldri
+  (se avgrensninger), så UI-tilstanden er ikke et gyldig signal på kontrollresultatet.
+- 2026-07-29: Periodelengde endret fra 30 md til `2 år + 1 dag` etter at 30 md **ikke**
+  ga kontrolltreff — `periodeOver2ÅrOgEnDag` ser kun på år og dager, ikke måneder.

--- a/tests/eu-eos/eu-eos-unntaksperiode-ugyldig-dato.spec.ts
+++ b/tests/eu-eos/eu-eos-unntaksperiode-ugyldig-dato.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from '../../fixtures';
+import { AuthHelper } from '../../helpers/auth-helper';
+import { SedHelper } from '../../helpers/sed-helper';
+import { HovedsidePage } from '../../pages/hovedside.page';
+import { RegistreringUnntaksperiodePage } from '../../pages/eu-eos/registrering-unntaksperiode.page';
+import { EuEosUtpekingPage } from '../../pages/behandling/eu-eos-utpeking.page';
+import { waitForProcessInstances } from '../../helpers/api-helper';
+import { formatDateISO, formatDateNorwegian, getDateMonthsFromNow } from '../../helpers/date-helper';
+import { BRUKERNAVN_VALID } from '../../pages/shared/constants';
+
+/**
+ * EU/EØS – «Invalid date» i live-kontrollen av unntaksperiode
+ *
+ * Regresjonsvakt for two-sided-bugen beskrevet i
+ * melosys-kode-wiki/archive/melosys-api/2026-07-28-invalid-date-unntaksperiode-kontroll-plan.md:
+ *
+ *  - **melosys-web (T2, rotårsak):** «Endre periode»-feltene på registrering av
+ *    unntaksperioder kjører en live-kontroll per tastetrykk. `formatterDatoTilISO`
+ *    returnerte sentinelstrengen `"Invalid date"` som default, og truthiness-guarden
+ *    i `mapDispatchToProps` slapp den gjennom — så en halvskrevet dato ble POSTet
+ *    som `{"periodeTom":"Invalid date"}`.
+ *  - **melosys-api (T1):** ingen handler for `HttpMessageNotReadableException` →
+ *    catch-all → **HTTP 500 + ERROR med full stacktrace** for en ren tastefeil.
+ *    Latent siden 2022, oppdaget som logstøy i prod 19.06.2026.
+ *
+ * Scenario:
+ * 1. Injiser en inngående A009 fra Tyskland med en periode på 2 år og 1 dag, som
+ *    gir treff i registerkontrollen (UfmKontroll::periodeOver24MånederOgEnDag),
+ *    slik at behandlingen IKKE registreres
+ *    automatisk (BestemBehandlingsmåteSed) men havner på saksbehandlers bord.
+ * 2. Åpne behandlingen: «Godkjenn unntaksperiode» er deaktivert pga. kontrolltreffet,
+ *    saksbehandler må velge «Godkjenn, men endre periode».
+ * 3. Skriv en ny sluttdato TEGN FOR TEGN — den nøyaktige brukerhandlingen som
+ *    trigget bugen. Verifiser at ingen av kontrollkallene inneholder «Invalid date»
+ *    og at ingen av dem gir 5xx.
+ * 4. Verifiser API-kontrakten direkte: en ugyldig datostreng skal gi 400 med
+ *    sanert melding (frontenden sender den aldri lenger, så den må testes direkte).
+ * 5. Sett en gyldig, forkortet periode (12 md) → kontrollfeilen forsvinner →
+ *    Lagre → REGISTRERT_UNNTAK med den ENDREDE perioden persistert.
+ */
+test.describe('EU/EØS - Registrering av unntaksperiode (ugyldig dato i live-kontrollen)', () => {
+  test('skal ikke sende «Invalid date» eller få 500 når sluttdato skrives tegn for tegn', async ({ page, request }) => {
+    test.setTimeout(300000);
+
+    // Perioden må gi treff i UfmKontroll::periodeOver24MånederOgEnDag, som er
+    // implementert som «over 2 år OG minst én dag» (PeriodeRegler:33-37 — måneder
+    // teller ikke, så 30 md gir IKKE treff). Fom kan ikke ligge mer enn 1 år frem
+    // i tid (PERIODE_LANGT_FREM_I_TID) eller før 01.06.2012.
+    const fom = new Date();
+    const sedTom = new Date(fom);
+    sedTom.setFullYear(sedTom.getFullYear() + 2);
+    sedTom.setDate(sedTom.getDate() + 1);
+    const nyTom = getDateMonthsFromNow(12);
+    // Dag 05 gjør at det ALLTID finnes minst ett halvskrevet, uparsebart tastetrykk
+    // («0») uansett når på året testen kjører — det er den tilstanden guarden i
+    // saksopplysninger.jsx må fange.
+    nyTom.setDate(5);
+
+    // === DEL A: Inngående A009 med for lang periode → manuell behandling ===
+    console.log('📝 Del A: Injiserer inngående A009 (DE) med periode på 2 år + 1 dag...');
+    const sed = new SedHelper(request);
+    const result = await sed.sendSed({
+      sedType: 'A009',
+      bucType: 'LA_BUC_02',
+      landkode: 'DE',
+      avsenderId: 'DE:DRV',
+      lovvalgsland: 'DE',
+      periodeFom: formatDateISO(fom),
+      periodeTom: formatDateISO(sedTom),
+    });
+    expect(result.success, `Send A009 feilet: ${result.message}`).toBe(true);
+    await waitForProcessInstances(request, 60);
+
+    const auth = new AuthHelper(page);
+    await auth.login();
+    const hovedside = new HovedsidePage(page);
+    const unntak = new RegistreringUnntaksperiodePage(page);
+
+    await hovedside.goto();
+    await hovedside.åpneBehandling(`${BRUKERNAVN_VALID} -`);
+    await unntak.ventPåSiden();
+
+    // Kontrolltreffet (PERIODEN_OVER_24_MD) er forutsetningen for hele scenariet:
+    // uten det ville A009-en blitt registrert automatisk, uten UI i det hele tatt.
+    await unntak.assertions.verifiserRegisterkontrolltreff('Periodelengde er mer enn 24 måneder');
+
+    // === DEL B: Skriv sluttdato tegn for tegn (reproduserer bugen) ===
+    console.log('📝 Del B: Skriver ny sluttdato tegn for tegn...');
+    const kontrollkall = unntak.overvåkKontrollkall();
+
+    // Valget forhåndsutfyller datofeltene med SED-perioden, som trigger den første
+    // live-kontrollen. Den skal avvise perioden (for lang) med 400 + feilkoder.
+    await unntak.velgGodkjennMenEndrePeriode();
+    unntak.assertions.verifiserKontrollForPeriode(
+      kontrollkall,
+      { fom: formatDateISO(fom), tom: formatDateISO(sedTom) },
+      400
+    );
+
+    const nyTomNorsk = formatDateNorwegian(nyTom);
+    const antallFørTyping = kontrollkall.length;
+    await unntak.skrivSluttdatoTegnForTegn(nyTomNorsk);
+
+    unntak.assertions.verifiserUgyldigeTastetrykkStoppet(kontrollkall.length - antallFørTyping, nyTomNorsk);
+    unntak.assertions.verifiserIngenUgyldigDatoSendt(kontrollkall);
+    unntak.assertions.verifiserIngenServerfeil(kontrollkall);
+
+    // === DEL C: API-kontrakten – ugyldig dato er en klientfeil (400), ikke 500 ===
+    console.log('📝 Del C: Verifiserer at melosys-api svarer 400 på ugyldig datostreng...');
+    await unntak.assertions.verifiserApiAvviserUgyldigDato(request, unntak.hentBehandlingID());
+
+    // === DEL D: Gyldig forkortet periode → kontrollen godtar → lagre ===
+    console.log('📝 Del D: Setter gyldig periode (12 md) og lagrer...');
+    await unntak.settPeriode(formatDateNorwegian(fom), nyTomNorsk);
+    unntak.assertions.verifiserKontrollForPeriode(
+      kontrollkall,
+      { fom: formatDateISO(fom), tom: formatDateISO(nyTom) },
+      204
+    );
+    await unntak.lagre();
+    await waitForProcessInstances(request, 90);
+
+    const utpeking = new EuEosUtpekingPage(page);
+    await utpeking.assertions.verifiserRegistrertUnntakIverksatt(request, {
+      lovvalgsland: 'DE',
+      medlLovvalgsland: 'DEU',
+    });
+    await unntak.assertions.verifiserEndretPeriodeLagret(formatDateNorwegian(fom), nyTomNorsk);
+
+    console.log('✅ Ugyldig dato i live-kontrollen gir verken «Invalid date»-payload eller 500');
+  });
+});


### PR DESCRIPTION
E2E-regresjonsvakt for «Invalid date»-bugen i live-kontrollen av unntaksperiode
(melosys-api#3426 + melosys-web#3121). Dekker begge sider av den two-sided bugen.

melosys-web sendte sentinelstrengen "Invalid date" til
`POST /api/kontroll/{behandlingID}/unntaksperiode` for hvert halvskrevet tastetrykk,
og melosys-api hadde ingen handler for `HttpMessageNotReadableException` — en
saksbehandlers tastefeil ble logget som ERROR + HTTP 500. Latent siden 2022, oppdaget
som loggstøy i prod 19.06.2026. Analyse og fiksplan ligger i melosys-kode-wiki
(`archive/melosys-api/2026-07-28-invalid-date-unntaksperiode-kontroll-plan.md`).

- Ny test: A009 med periode på 2 år + 1 dag → registerkontrolltreff → manuell
  behandling → sluttdato skrives tegn for tegn → ingen `Invalid date`-payload, ingen 5xx
- API-kontrakten verifiseres med direkte kall (400 + `Ugyldig format på forespørselen`,
  ingen lekkasje), siden frontenden ikke lenger sender slike verdier
- Ny POM `RegistreringUnntaksperiodePage` + assertions — første test som når
  «Registrering av unntaksperioder»-skjermen
- Spec-dokument `specs/eu-eos-unntaksperiode-ugyldig-dato.md` med teknisk binding

## Testing
- [x] Kjørt lokalt mot begge fiks-brancher (grønn, ~16 s)
- [x] Mutasjonsverifisert: med web-fiksen reversert sender frontenden 2
      `Invalid date`-kall og testen feiler
- [ ] E2E på CI (krever at fiksene er i imagene)

## Notater
Forutsetter melosys-api `fiks-400-ved-ugyldig-dato-unntaksperiode` og melosys-web
`nojira-invalid-date-unntaksperiode`. To funn under testarbeidet, dokumentert i
spec-en og wikien:
1. `unntaksperiodeKontrollfeil` populeres aldri — `KontrollFeilSelector` leser
   `data.kontrollfeilList`, api svarer `feilkoder`. «Godkjenn unntaksperiode»/«Lagre»
   deaktiveres derfor aldri av live-kontrollen. Egen sak.
2. `periodeOver2ÅrOgEnDag` teller kun år og dager, ikke måneder — 30 md gir ikke treff,
   2 år + 1 dag gjør. Ser utilsiktet ut.