### PR TITLE
NOJIRA Ta i bruk race-fri prosessventing i e2e-testene

### DIFF
--- a/docs/guides/RECORDING-TO-POM.md
+++ b/docs/guides/RECORDING-TO-POM.md
@@ -99,21 +99,25 @@ sequenceDiagram
 
 | Situasjon | Hva du gjør |
 |-----------|-------------|
-| Etter `klikkOpprettNyBehandling()` | `await waitForProcessInstances(page.request, 30)` |
+| Rundt en handling som starter en prosess | `await runAndWaitForProcessInstances(page.request, () => handling())` |
 | Etter `fattVedtak()` som siste steg | Ingenting — fixturen håndterer det |
-| Etter `fattVedtak()` og testen fortsetter | `await waitForProcessInstances(page.request, 30)` |
-| Etter journalføring | `await waitForProcessInstances(page.request, 30)` |
+| Du har allerede kjørt handlingen | `getProcessMarker()` FØR handlingen, så `waitForNewProcessInstances(request, markør)` |
 
-> Tallet er **kun** Playwrights HTTP-timeout mot endepunktet. `waitForProcessInstances`
-> sender det ikke videre som query-parameter, så serveren venter alltid sine egne 30 s
-> (`@RequestParam(defaultValue = "30")`). Å be om 60 gir altså ikke lengre venting —
-> helperen må utvides først.
+`runAndWaitForProcessInstances` henter markør → kjører handlingen → venter på prosessene
+*handlingen* startet. Bruk den. Den er umulig å bruke feil, fordi markøren alltid tas først.
 
-#### Fallgruve: waitForProcessInstances venter ikke på prosesser som ikke finnes ennå
+```typescript
+await runAndWaitForProcessInstances(page.request, () => vedtak.klikkFattVedtak());
 
-Endepunktet `/internal/e2e/process-instances/await` svarer COMPLETED så snart det ser
+// Starter handlingen flere prosesser, si en per SED:
+await runAndWaitForProcessInstances(page.request, () => sendAlleSed(), {expectedNew: 3});
+```
+
+#### Fallgruve: `waitForProcessInstances` venter ikke på prosesser som ikke finnes ennå
+
+Den **markørløse** varianten (`waitForProcessInstances`) svarer COMPLETED så snart den ser
 *noe* fullført arbeid — også instanser fra forrige steg (`recentInstances`, 60 s vindu).
-Kalles det umiddelbart etter en UI-handling, kan det rekke å svare «alle N ferdige» før
+Kalles den umiddelbart etter en UI-handling, kan den rekke å svare «alle N ferdige» før
 handlingens egen instans er registrert, og da er ventingen verdiløs.
 
 Observert på CI (kjøring 30331105445 og 30452518268): rett etter annullering svarte
@@ -121,11 +125,17 @@ endepunktet «8 av 8 ferdige» ~200 ms etter klikket, mens grønne kjøringer vi
 instanser. ANNULLER_SAK-steget hadde altså ikke kjørt, krediteringen var ikke gjort, og
 `expect(sum).toBe(0)` feilet med 121482.
 
-Endepunktet har en query-parameter `expectedInstances=N`, men merk semantikken: kravet er
-at det finnes **minst N instanser totalt i 60 s-vinduet** (`recentInstances.size >= N`) —
-ikke N *nye* siden handlingen din. `expectedInstances=1` blir derfor trivielt oppfylt av
-instanser fra forrige steg. Skal den brukes riktig, må kalleren telle instanser før
-handlingen og sende `før + forventet`. `waitForProcessInstances` sender den ikke i dag.
+Racet er reprodusert kunstig og målt: med `melosys.e2e.initial-settling-delay-ms=0` og en
+treg backend løy den markørløse varianten i 9 av 10 forsøk, mens markør-varianten traff
+0 av 10 (`scripts/prosessinstans-race-repro.ts`).
+
+**Derfor: bruk `runAndWaitForProcessInstances`.** Den tar en markør før handlingen, og
+serveren krever da at minst én prosessinstans registrert *etter* markøren finnes og er
+FERDIG. Forrige stegs arbeid kan ikke oppfylle den.
+
+`expectedInstances=N` (gammel parameter) løser ikke dette: kravet er «minst N instanser
+**totalt** i 60 s-vinduet», ikke N *nye* siden handlingen din. Den kan ikke kombineres med
+`after` — serveren svarer 400 om du prøver.
 
 Leser du tilstand som settes *etter* at instansen er registrert — særlig i en annen
 tjeneste — poll på den faktiske tilstanden i stedet:

--- a/docs/guides/RECORDING-TO-POM.md
+++ b/docs/guides/RECORDING-TO-POM.md
@@ -101,10 +101,18 @@ sequenceDiagram
 |-----------|-------------|
 | Rundt en handling som starter en prosess | `await runAndWaitForProcessInstances(page.request, () => handling())` |
 | Etter `fattVedtak()` som siste steg | Ingenting — fixturen håndterer det |
-| Du har allerede kjørt handlingen | `getProcessMarker()` FØR handlingen, så `waitForNewProcessInstances(request, markør)` |
+| Handlingen lar seg ikke pakke inn | `getProcessMarker()` FØR handlingen, så `waitForNewProcessInstances(request, markør)` |
 
 `runAndWaitForProcessInstances` henter markør → kjører handlingen → venter på prosessene
-*handlingen* startet. Bruk den. Den er umulig å bruke feil, fordi markøren alltid tas først.
+*handlingen* startet. Bruk den — da kan ikke markøren havne på feil side av handlingen.
+
+To ting å vite:
+
+* **Handlingen må faktisk starte en prosessinstans.** Gjør den ikke det, venter serveren ut hele
+  timeouten og kastet feilen sier «only 0 of 1 expected new process instance(s)». Skal du bare
+  vente på at det som allerede kjører blir ferdig, er det tømming — bruk `expectedNew: 0`.
+* **`timeoutSeconds` sendes nå til serveren.** Før var tallet kun Playwrights HTTP-timeout, og
+  serveren ventet alltid sine egne 30 s. Ber du om 90, kan et kall som feiler nå blokkere i 90 s.
 
 ```typescript
 await runAndWaitForProcessInstances(page.request, () => vedtak.klikkFattVedtak());

--- a/fixtures/cleanup.ts
+++ b/fixtures/cleanup.ts
@@ -1,4 +1,4 @@
-import {test as base} from '@playwright/test';
+import {APIRequestContext, test as base} from '@playwright/test';
 import {DatabaseHelper} from '../helpers/db-helper';
 import {PgDatabaseHelper} from '../helpers/pg-db-helper';
 import {clearMockDataSilent} from '../helpers/mock-helper';
@@ -122,7 +122,7 @@ async function cleanupTestData(page: any, waitForProcesses: boolean = false): Pr
  * Markør-endepunktet finnes bare i melosys-api-images som har den race-frie ventingen.
  * Mangler det, faller fixturen tilbake til den gamle tømmingen i stedet for å velte testen.
  */
-async function hentMarkørEllerNull(request: any): Promise<string | null> {
+async function hentMarkørEllerNull(request: APIRequestContext): Promise<string | null> {
     try {
         return await getProcessMarker(request);
     } catch (error: any) {
@@ -138,8 +138,11 @@ export const cleanupFixture = base.extend<{ autoCleanup: void }>({
         await cleanupTestData(page, false); // Don't wait for processes
         console.log('');
 
-        // Markør tatt før testen kjører: tømmingen etterpå venter da på ALT testen startet,
-        // ikke bare på det som ligger innenfor serverens 60-sekundersvindu.
+        // Markør tatt før testen kjører: tømmingen etterpå dekker da alt testen har rukket å
+        // registrere, ikke bare det som ligger innenfor serverens 60-sekundersvindu. En lang test
+        // lekket før uferdige prosesser videre til neste test. Merk at en prosess som ennå ikke er
+        // registrert når tømmingen starter, fortsatt bare dekkes av serverens settling-forsinkelse
+        // — markøren hjelper ikke der, siden en tømming per definisjon ikke vet hva den venter på.
         const markør = await hentMarkørEllerNull(page.request);
 
         // Run the test
@@ -149,7 +152,7 @@ export const cleanupFixture = base.extend<{ autoCleanup: void }>({
         try {
             if (markør) {
                 // expectedNew: 0 — testen kan ha startet null prosesser (f.eks. rene søketester),
-                // men alt den faktisk startet må være ferdig før vi rydder.
+                // men alt som er registrert må være ferdig før vi rydder.
                 await waitForNewProcessInstances(page.request, markør, {expectedNew: 0, timeoutSeconds: 30});
             } else {
                 await waitForProcessInstances(page.request, 30);

--- a/fixtures/cleanup.ts
+++ b/fixtures/cleanup.ts
@@ -2,7 +2,7 @@ import {test as base} from '@playwright/test';
 import {DatabaseHelper} from '../helpers/db-helper';
 import {PgDatabaseHelper} from '../helpers/pg-db-helper';
 import {clearMockDataSilent} from '../helpers/mock-helper';
-import {clearApiCaches, waitForProcessInstances} from '../helpers/api-helper';
+import {clearApiCaches, getProcessMarker, waitForNewProcessInstances, waitForProcessInstances} from '../helpers/api-helper';
 import {UnleashHelper} from '../helpers/unleash-helper';
 
 /**
@@ -118,6 +118,19 @@ async function cleanupTestData(page: any, waitForProcesses: boolean = false): Pr
     }
 }
 
+/**
+ * Markør-endepunktet finnes bare i melosys-api-images som har den race-frie ventingen.
+ * Mangler det, faller fixturen tilbake til den gamle tømmingen i stedet for å velte testen.
+ */
+async function hentMarkørEllerNull(request: any): Promise<string | null> {
+    try {
+        return await getProcessMarker(request);
+    } catch (error: any) {
+        console.log(`   ⚠️  Prosessmarkør utilgjengelig, bruker gammel tømming: ${error.message || error}`);
+        return null;
+    }
+}
+
 export const cleanupFixture = base.extend<{ autoCleanup: void }>({
     autoCleanup: [async ({page, request}, use) => {
         // BEFORE test: clean for fresh start
@@ -125,12 +138,22 @@ export const cleanupFixture = base.extend<{ autoCleanup: void }>({
         await cleanupTestData(page, false); // Don't wait for processes
         console.log('');
 
+        // Markør tatt før testen kjører: tømmingen etterpå venter da på ALT testen startet,
+        // ikke bare på det som ligger innenfor serverens 60-sekundersvindu.
+        const markør = await hentMarkørEllerNull(page.request);
+
         // Run the test
         await use();
 
         // AFTER test: wait for processes to complete
         try {
-            await waitForProcessInstances(page.request, 30);
+            if (markør) {
+                // expectedNew: 0 — testen kan ha startet null prosesser (f.eks. rene søketester),
+                // men alt den faktisk startet må være ferdig før vi rydder.
+                await waitForNewProcessInstances(page.request, markør, {expectedNew: 0, timeoutSeconds: 30});
+            } else {
+                await waitForProcessInstances(page.request, 30);
+            }
         } catch (error: any) {
             const errorMessage = error.message || String(error);
             console.log(`   ⚠️  Process instance check failed: ${errorMessage}`);

--- a/helpers/api-helper.ts
+++ b/helpers/api-helper.ts
@@ -239,12 +239,18 @@ export async function getProcessMarker(request: APIRequestContext): Promise<stri
 
   if (!response.ok()) {
     throw new Error(
-      `Kunne ikke hente prosessmarkør (HTTP ${response.status()}). ` +
-      `Kjører melosys-api et image med markør-endepunktet?`
+      `Kunne ikke hente prosessmarkør (HTTP ${response.status()}). melosys-api-imaget må ha ` +
+      `/internal/e2e/process-instances/marker (navikt/melosys-api#3436) — kjører du et eldre image?`
     );
   }
 
-  return (await response.json()).marker;
+  const {marker} = await response.json();
+  if (typeof marker !== 'string' || marker.length === 0) {
+    // Uten dette ville en tom respons gitt `after=undefined`, som serveren avviser med 400
+    // FØRST etter at handlingen er kjørt — altså en langt mer forvirrende feilmelding.
+    throw new Error(`Prosessmarkør-endepunktet svarte uten markør: ${JSON.stringify(marker)}`);
+  }
+  return marker;
 }
 
 /**

--- a/helpers/api-helper.ts
+++ b/helpers/api-helper.ts
@@ -220,11 +220,90 @@ export class AdminApiHelper {
    */
 }
 
+const PROCESS_INSTANCE_BASE_URL = 'http://localhost:8080/internal/e2e/process-instances';
+
+/**
+ * Hent en markør (servertid) FØR handlingen som starter en prosess.
+ *
+ * Markøren er nøkkelen til race-fri venting: sendes den til `waitForNewProcessInstances`,
+ * teller kun prosessinstanser registrert etter den — forrige stegs arbeid kan ikke oppfylle
+ * ventingen.
+ *
+ * Bruk helst `runAndWaitForProcessInstances`, som gjør dette for deg.
+ */
+export async function getProcessMarker(request: APIRequestContext): Promise<string> {
+  const response = await request.get(`${PROCESS_INSTANCE_BASE_URL}/marker`, {
+    failOnStatusCode: false,
+    timeout: 10_000
+  });
+
+  if (!response.ok()) {
+    throw new Error(
+      `Kunne ikke hente prosessmarkør (HTTP ${response.status()}). ` +
+      `Kjører melosys-api et image med markør-endepunktet?`
+    );
+  }
+
+  return (await response.json()).marker;
+}
+
+/**
+ * Vent på at prosessene som ble startet ETTER markøren er ferdige.
+ *
+ * I motsetning til `waitForProcessInstances` kan denne ikke svare COMPLETED på forrige stegs
+ * arbeid: serveren krever at minst `expectedNew` prosessinstanser registrert etter markøren
+ * finnes, og at alle er FERDIG.
+ *
+ * @param markør - fra `getProcessMarker`, hentet FØR handlingen
+ * @param expectedNew - antall nye prosessinstanser handlingen starter (default 1).
+ *                      0 betyr ren tømming: «alt som er registrert etter markøren skal være
+ *                      ferdig», uten å kreve at noe nytt finnes. Brukes av cleanup-fixturen.
+ */
+export async function waitForNewProcessInstances(
+  request: APIRequestContext,
+  markør: string,
+  options: { expectedNew?: number; timeoutSeconds?: number } = {}
+): Promise<void> {
+  const {expectedNew = 1, timeoutSeconds = 30} = options;
+
+  return await awaitProcessInstances(request, timeoutSeconds, {
+    after: markør,
+    expectedNew: String(expectedNew)
+  });
+}
+
+/**
+ * Hent markør → kjør handlingen → vent på prosessene handlingen startet.
+ *
+ * Dette er den anbefalte formen. Den er umulig å bruke feil, fordi markøren alltid tas før
+ * handlingen:
+ *
+ * ```typescript
+ * await runAndWaitForProcessInstances(page.request, () => vedtak.klikkFattVedtak());
+ * ```
+ *
+ * Returverdien fra handlingen sendes videre, så den kan brukes rundt handlinger som gir data.
+ */
+export async function runAndWaitForProcessInstances<T>(
+  request: APIRequestContext,
+  handling: () => Promise<T>,
+  options: { expectedNew?: number; timeoutSeconds?: number } = {}
+): Promise<T> {
+  const markør = await getProcessMarker(request);
+  const resultat = await handling();
+  await waitForNewProcessInstances(request, markør, options);
+  return resultat;
+}
+
 /**
  * Wait for all process instances to complete
  *
  * This calls the melosys-api test endpoint that monitors async process instances.
  * It ensures all background processes complete before we clean up the database.
+ *
+ * ⚠️ Uten markør kan endepunktet svare COMPLETED på arbeid fra FORRIGE steg — det ser bare
+ * på alt som er registrert de siste 60 sekundene. For venting rundt en konkret handling,
+ * bruk `runAndWaitForProcessInstances`.
  *
  * Returns:
  * - COMPLETED: All processes finished successfully
@@ -233,8 +312,18 @@ export class AdminApiHelper {
  * - ERROR: Unexpected error occurred
  */
 export async function waitForProcessInstances(request: APIRequestContext, timeoutSeconds: number = 30): Promise<void> {
+  return await awaitProcessInstances(request, timeoutSeconds);
+}
+
+async function awaitProcessInstances(
+  request: APIRequestContext,
+  timeoutSeconds: number,
+  ekstraParametre: Record<string, string> = {}
+): Promise<void> {
+  const params = new URLSearchParams({timeoutSeconds: String(timeoutSeconds), ...ekstraParametre});
+
   try {
-    const response = await request.get('http://localhost:8080/internal/e2e/process-instances/await', {
+    const response = await request.get(`${PROCESS_INSTANCE_BASE_URL}/await?${params}`, {
       failOnStatusCode: false,
       timeout: (timeoutSeconds + 5) * 1000 // Add 5s buffer
     });

--- a/scripts/prosessinstans-race-repro.ts
+++ b/scripts/prosessinstans-race-repro.ts
@@ -23,6 +23,7 @@
 import * as dotenv from 'dotenv';
 import * as path from 'node:path';
 import oracledb from 'oracledb';
+import {USER_ID_VALID} from '../pages/shared/constants';
 
 dotenv.config({path: path.resolve(__dirname, '../.env')});
 dotenv.config({path: path.resolve(__dirname, '../.env.local'), override: true});
@@ -45,7 +46,7 @@ async function opprettSak(): Promise<number> {
         headers: {'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json; charset=utf-8'},
         body: JSON.stringify({
             hovedpart: 'BRUKER',
-            brukerID: '30056928150',
+            brukerID: USER_ID_VALID,
             sakstype: 'FTRL',
             sakstema: 'MEDLEMSKAP_LOVVALG',
             behandlingstema: 'YRKESAKTIV',
@@ -81,20 +82,30 @@ async function ventNy(markør: string): Promise<any> {
     return res.json();
 }
 
-async function tellInstanser(conn: oracledb.Connection): Promise<{ total: number; uferdige: number }> {
+type Instans = { id: string; status: string };
+
+/**
+ * Leser instansene som IDer, ikke som antall: da kan «nye siden handlingen» avgjøres eksakt,
+ * uten å blande inn eldre uferdige rader fra tidligere kjøringer.
+ */
+async function hentInstanser(conn: oracledb.Connection): Promise<Instans[]> {
     const r: any = await conn.execute(
-        `SELECT COUNT(*) AS TOTAL, SUM(CASE WHEN STATUS <> 'FERDIG' THEN 1 ELSE 0 END) AS UFERDIGE FROM PROSESSINSTANS`,
+        `SELECT RAWTOHEX(UUID) AS ID, STATUS FROM PROSESSINSTANS`,
         [], {outFormat: oracledb.OUT_FORMAT_OBJECT}
     );
-    return {total: r.rows[0].TOTAL, uferdige: r.rows[0].UFERDIGE ?? 0};
+    return r.rows.map((rad: any) => ({id: rad.ID, status: rad.STATUS}));
 }
 
-/** Venter til den nye instansen faktisk er registrert og ferdig — fasit på hvor lang tid det tar. */
-async function ventPåSannheten(conn: oracledb.Connection, før: number, maxMs = 30000): Promise<number> {
+function nyeSiden(før: Set<string>, etter: Instans[]): Instans[] {
+    return etter.filter(i => !før.has(i.id));
+}
+
+/** Venter til handlingens egen instans faktisk er registrert og ferdig — fasit på hvor lang tid det tar. */
+async function ventPåSannheten(conn: oracledb.Connection, før: Set<string>, maxMs = 30000): Promise<number> {
     const start = Date.now();
     while (Date.now() - start < maxMs) {
-        const n = await tellInstanser(conn);
-        if (n.total > før && n.uferdige === 0) return Date.now() - start;
+        const nye = nyeSiden(før, await hentInstanser(conn));
+        if (nye.length > 0 && nye.every(i => i.status === 'FERDIG')) return Date.now() - start;
         await new Promise(r => setTimeout(r, 50));
     }
     return -1;
@@ -103,10 +114,21 @@ async function ventPåSannheten(conn: oracledb.Connection, før: number, maxMs =
 (async () => {
     const conn = await oracledb.getConnection(dbConfig);
     let løgner = 0;
-    console.log(`\n=== waitForProcessInstances-race — modus: ${MODE.toUpperCase()}, ${ITERATIONS} iterasjoner ===\n`);
+    let forkastet = 0;
+    console.log(`\n=== prosessinstans-race — modus: ${MODE.toUpperCase()}, ${ITERATIONS} iterasjoner ===`);
+    if (MODE === 'old') {
+        // Uten dette leses «0 løgner» lett som «racet finnes ikke», når det egentlig betyr
+        // «betingelsene som fremkaller racet er ikke satt opp».
+        console.log(
+            'NB: `old` gir 0 løgner på en frisk backend — POST-en committer på ~20 ms og rekker\n' +
+            '    innenfor settling-forsinkelsen. Racet krever settling-delay 0 OG treg registrering\n' +
+            '    (se filhodet). Er de ikke satt opp, måler denne kjøringen ingenting.'
+        );
+    }
+    console.log('');
 
     for (let i = 1; i <= ITERATIONS; i++) {
-        const før = await tellInstanser(conn);
+        const før = new Set((await hentInstanser(conn)).map(x => x.id));
 
         const markør = MODE === 'new' ? await hentMarkør() : null;
 
@@ -118,27 +140,36 @@ async function ventPåSannheten(conn: oracledb.Connection, før: number, maxMs =
         const svar = markør ? await ventNy(markør) : await ventGammel();
         const ventetMs = Date.now() - t0;
 
-        const etter = await tellInstanser(conn);
-        const nye = etter.total - før.total;
-        const løy = svar.status === 'COMPLETED' && (nye < 1 || etter.uferdige > 0);
-        if (løy) løgner++;
+        const nye = nyeSiden(før, await hentInstanser(conn));
 
+        // Iterasjoner der handlingen aldri traff må forkastes FØR de telles: en feilet POST
+        // oppretter ingen instans, og ville da garantert blitt bokført som en løgn.
         const status = await postPromise;
         if (status !== 204) {
             console.log(`  ${i}: POST /api/fagsaker ga ${status} — iterasjonen forkastes`);
+            forkastet++;
             continue;
         }
 
-        const sannhetMs = await ventPåSannheten(conn, før.total);
+        const uferdige = nye.filter(x => x.status !== 'FERDIG').length;
+        const løy = svar.status === 'COMPLETED' && (nye.length < 1 || uferdige > 0);
+        if (løy) løgner++;
+
+        const sannhetMs = await ventPåSannheten(conn, før);
 
         console.log(
             `  ${i}: ${løy ? '❌ LØY  ' : '✅ ok   '} svar=${svar.status} etter ${ventetMs}ms | ` +
-            `nye instanser ved svartidspunkt=${nye}, uferdige=${etter.uferdige} | ` +
-            `faktisk ferdig etter ~${sannhetMs}ms`
+            `nye instanser ved svartidspunkt=${nye.length}, uferdige=${uferdige} | ` +
+            `faktisk ferdig etter ${sannhetMs < 0 ? 'ALDRI (timeout)' : `~${sannhetMs}ms`}`
         );
     }
 
-    console.log(`\n=== ${løgner}/${ITERATIONS} falske COMPLETED (${MODE}) ===\n`);
+    const talt = ITERATIONS - forkastet;
+    console.log(`\n=== ${løgner}/${talt} falske COMPLETED (${MODE})${forkastet ? `, ${forkastet} forkastet` : ''} ===`);
+    console.log(
+        'Merk: skriptet lager ekte saker og rydder ikke opp. Kjør cleanup-fixturen eller\n' +
+        '`npx playwright test` etterpå hvis du vil ha ren database.\n'
+    );
     await conn.close();
     process.exit(løgner > 0 && MODE === 'new' ? 1 : 0);
 })();

--- a/scripts/prosessinstans-race-repro.ts
+++ b/scripts/prosessinstans-race-repro.ts
@@ -1,0 +1,144 @@
+/**
+ * Kunstig reproduksjon av prosessinstans-racet — fasiten på om ventingen faktisk virker.
+ *
+ * Trigger: POST /api/fagsaker (oppretter én OPPRETT_SAK-prosessinstans, asynkront dispatchet
+ * AFTER_COMMIT). POST-en ventes IKKE på, akkurat som et UI-klikk: AnnulleringPage.bekreft()
+ * klikker knappen og returnerer med én gang. Rett etterpå kalles ventemetoden, og
+ * PROSESSINSTANS-tabellen leses ØYEBLIKKELIG. Svarte ventemetoden COMPLETED uten at det finnes
+ * en ny, ferdig instans, har den løyet — den ventet på forrige stegs arbeid.
+ *
+ * Racet oppstår bare når backend er treg nok. På en frisk lokal maskin committer POST-en på
+ * ~20 ms og rekker innenfor settling-forsinkelsen, så racet må fremtvinges:
+ *
+ *   1. Kjør melosys-api med `melosys.e2e.initial-settling-delay-ms=0`
+ *      (compose: `MELOSYS_E2E_INITIAL_SETTLING_DELAY_MS: "0"` på melosys-api).
+ *   2. Legg en kort forsinkelse i registreringen — f.eks. `Thread.sleep(400)` først i
+ *      `ProsessinstansService.lagre(...)` i melosys-api. IKKE commit den.
+ *
+ * Målt 2026-07-31 under de betingelsene: `old` løy 9/10, `new` 0/10.
+ *
+ * Kjør:  npx ts-node --transpile-only scripts/prosessinstans-race-repro.ts [iterasjoner] [old|new]
+ *        (trenger TS_NODE_COMPILER_OPTIONS='{"module":"commonjs","moduleResolution":"node"}')
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'node:path';
+import oracledb from 'oracledb';
+
+dotenv.config({path: path.resolve(__dirname, '../.env')});
+dotenv.config({path: path.resolve(__dirname, '../.env.local'), override: true});
+
+const API = 'http://localhost:8080';
+const MODE = (process.argv[3] || 'old') as 'old' | 'new';
+const ITERATIONS = Number(process.argv[2] || 10);
+
+const dbConfig = {
+    user: process.env.DB_USER || 'MELOSYS',
+    password: process.env.DB_PASSWORD || 'melosyspwd',
+    connectString: process.env.DB_CONNECT_STRING || `localhost:1521/${process.env.MELOSYS_ORACLE_DB_NAME || 'freepdb1'}`
+};
+
+const token = process.env.LOCAL_AUTH_TOKEN!;
+
+async function opprettSak(): Promise<number> {
+    const res = await fetch(`${API}/api/fagsaker`, {
+        method: 'POST',
+        headers: {'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json; charset=utf-8'},
+        body: JSON.stringify({
+            hovedpart: 'BRUKER',
+            brukerID: '30056928150',
+            sakstype: 'FTRL',
+            sakstema: 'MEDLEMSKAP_LOVVALG',
+            behandlingstema: 'YRKESAKTIV',
+            behandlingstype: 'FØRSTEGANG',
+            behandlingsaarsakType: 'SØKNAD',
+            mottaksdato: '2026-07-31',
+            soknadDto: {
+                periode: {fom: '2026-01-01', tom: '2026-12-31'},
+                land: {landkoder: ['SWE'], flereLandUkjentHvilke: false}
+            }
+        })
+    });
+    return res.status;
+}
+
+/** Dagens kontrakt: helperen sender kun timeout, serveren bestemmer alt annet. */
+async function ventGammel(): Promise<any> {
+    const res = await fetch(`${API}/internal/e2e/process-instances/await?timeoutSeconds=30`);
+    return res.json();
+}
+
+/** Ny kontrakt: markør tatt FØR handlingen, og krav om N nye instanser etter markøren. */
+async function hentMarkør(): Promise<string> {
+    const res = await fetch(`${API}/internal/e2e/process-instances/marker`);
+    if (!res.ok) throw new Error(`marker-endepunktet mangler (${res.status}) — er ny api-image deployet?`);
+    return (await res.json()).marker;
+}
+
+async function ventNy(markør: string): Promise<any> {
+    const res = await fetch(
+        `${API}/internal/e2e/process-instances/await?timeoutSeconds=30&after=${encodeURIComponent(markør)}&expectedNew=1`
+    );
+    return res.json();
+}
+
+async function tellInstanser(conn: oracledb.Connection): Promise<{ total: number; uferdige: number }> {
+    const r: any = await conn.execute(
+        `SELECT COUNT(*) AS TOTAL, SUM(CASE WHEN STATUS <> 'FERDIG' THEN 1 ELSE 0 END) AS UFERDIGE FROM PROSESSINSTANS`,
+        [], {outFormat: oracledb.OUT_FORMAT_OBJECT}
+    );
+    return {total: r.rows[0].TOTAL, uferdige: r.rows[0].UFERDIGE ?? 0};
+}
+
+/** Venter til den nye instansen faktisk er registrert og ferdig — fasit på hvor lang tid det tar. */
+async function ventPåSannheten(conn: oracledb.Connection, før: number, maxMs = 30000): Promise<number> {
+    const start = Date.now();
+    while (Date.now() - start < maxMs) {
+        const n = await tellInstanser(conn);
+        if (n.total > før && n.uferdige === 0) return Date.now() - start;
+        await new Promise(r => setTimeout(r, 50));
+    }
+    return -1;
+}
+
+(async () => {
+    const conn = await oracledb.getConnection(dbConfig);
+    let løgner = 0;
+    console.log(`\n=== waitForProcessInstances-race — modus: ${MODE.toUpperCase()}, ${ITERATIONS} iterasjoner ===\n`);
+
+    for (let i = 1; i <= ITERATIONS; i++) {
+        const før = await tellInstanser(conn);
+
+        const markør = MODE === 'new' ? await hentMarkør() : null;
+
+        const t0 = Date.now();
+        // Fire-and-forget, akkurat som et UI-klikk: AnnulleringPage.bekreft() klikker knappen
+        // og returnerer med én gang — den venter ikke på at POST-en er committet.
+        const postPromise = opprettSak();
+
+        const svar = markør ? await ventNy(markør) : await ventGammel();
+        const ventetMs = Date.now() - t0;
+
+        const etter = await tellInstanser(conn);
+        const nye = etter.total - før.total;
+        const løy = svar.status === 'COMPLETED' && (nye < 1 || etter.uferdige > 0);
+        if (løy) løgner++;
+
+        const status = await postPromise;
+        if (status !== 204) {
+            console.log(`  ${i}: POST /api/fagsaker ga ${status} — iterasjonen forkastes`);
+            continue;
+        }
+
+        const sannhetMs = await ventPåSannheten(conn, før.total);
+
+        console.log(
+            `  ${i}: ${løy ? '❌ LØY  ' : '✅ ok   '} svar=${svar.status} etter ${ventetMs}ms | ` +
+            `nye instanser ved svartidspunkt=${nye}, uferdige=${etter.uferdige} | ` +
+            `faktisk ferdig etter ~${sannhetMs}ms`
+        );
+    }
+
+    console.log(`\n=== ${løgner}/${ITERATIONS} falske COMPLETED (${MODE}) ===\n`);
+    await conn.close();
+    process.exit(løgner > 0 && MODE === 'new' ? 1 : 0);
+})();

--- a/tests/aarsavregning/komplett-sak-nyvurdering-annullering-lukker-aapne-aarsavregninger.spec.ts
+++ b/tests/aarsavregning/komplett-sak-nyvurdering-annullering-lukker-aapne-aarsavregninger.spec.ts
@@ -10,7 +10,7 @@ import {TrygdeavgiftPage} from '../../pages/trygdeavgift/trygdeavgift.page';
 import {VedtakPage} from '../../pages/vedtak/vedtak.page';
 import {USER_ID_VALID} from '../../pages/shared/constants';
 import {getYearFromDate, TestPeriods} from '../../helpers/date-helper';
-import {waitForProcessInstances} from '../../helpers/api-helper';
+import {runAndWaitForProcessInstances} from '../../helpers/api-helper';
 import {hentSaksnummerFraUrl} from '../../helpers/url-helper';
 import {withFaktureringDatabase} from '../../helpers/pg-db-helper';
 import {getFakturaserieReferanse, withDatabase} from '../../helpers/db-helper';
@@ -105,12 +105,9 @@ test.describe('Komplett saksflyt - Nyvurdering annullering lukker åpne årsavre
 
         // Step 8: Vedtak
         console.log('Step 8: Making decision...');
-        await vedtak.klikkFattVedtak();
+        await runAndWaitForProcessInstances(page.request, () => vedtak.klikkFattVedtak());
 
         // Step 9: Wait for processes and set faktura to BESTILT
-        console.log('Step 9: Waiting for processes and updating faktura...');
-        await waitForProcessInstances(page.request, 30);
-
         await withFaktureringDatabase(async (db) => {
             const updated = await db.execute("UPDATE faktura SET status = 'BESTILT'");
             console.log(`Updated ${updated} faktura rows to BESTILT`);
@@ -119,8 +116,10 @@ test.describe('Komplett saksflyt - Nyvurdering annullering lukker åpne årsavre
         // Step 10: Opprett ny vurdering
         console.log('Step 10: Creating nyvurdering...');
         await hovedside.klikkOpprettNySak();
-        await opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD', saksnummer);
-        await waitForProcessInstances(page.request, 30);
+        await runAndWaitForProcessInstances(
+            page.request,
+            () => opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD', saksnummer)
+        );
 
         // Step 11: Åpne ny behandling
         console.log('Step 11: Opening new behandling...');
@@ -133,8 +132,7 @@ test.describe('Komplett saksflyt - Nyvurdering annullering lukker åpne årsavre
 
         // Step 12: Annuller saken
         console.log('Step 12: Annullering...');
-        await annullering.annullerSak();
-        await waitForProcessInstances(page.request, 30);
+        await runAndWaitForProcessInstances(page.request, () => annullering.annullerSak());
 
         console.log('✅ Workflow completed successfully!');
 
@@ -180,9 +178,9 @@ test.describe('Komplett saksflyt - Nyvurdering annullering lukker åpne årsavre
 
         const faktureringHelper = new FaktureringHelper(request);
         const avregningsÅr = getYearFromDate(period.end)
-        // waitForProcessInstances kan svare COMPLETED før annulleringens egen
-        // prosessinstans er registrert (se FaktureringHelper.ventPåKjedeSum) – poll i
-        // stedet for å lese kjeden rett etterpå.
+        // Beholdt som defense-in-depth: markør-ventingen over dekker prosessinstansen,
+        // mens pollingen i tillegg dekker forsinkelse mot faktureringskomponenten
+        // (se FaktureringHelper.ventPåKjedeSum).
         const opprinneligKjede = await faktureringHelper.ventPåKjedeSum(
             [opprinneligFakturaserieReferanse],
             0,

--- a/tests/aarsavregning/komplett-sak-nyvurdering-periode-endres-til-kun-tidligere-aar.spec.ts
+++ b/tests/aarsavregning/komplett-sak-nyvurdering-periode-endres-til-kun-tidligere-aar.spec.ts
@@ -11,7 +11,7 @@ import {VedtakPage} from '../../pages/vedtak/vedtak.page';
 import {USER_ID_VALID} from '../../pages/shared/constants';
 import {UnleashHelper} from '../../helpers/unleash-helper';
 import {getYearFromDate, TestPeriods} from '../../helpers/date-helper';
-import {waitForProcessInstances} from '../../helpers/api-helper';
+import {runAndWaitForProcessInstances} from '../../helpers/api-helper';
 import {hentSaksnummerFraUrl} from '../../helpers/url-helper';
 import {withFaktureringDatabase} from '../../helpers/pg-db-helper';
 import {getFakturaserieReferanse} from '../../helpers/db-helper';
@@ -105,12 +105,9 @@ test.describe('Komplett saksflyt - Nyvurdering periode endres til kun tidligere 
 
         // Step 8: Vedtak
         console.log('Step 8: Making decision...');
-        await vedtak.klikkFattVedtak();
+        await runAndWaitForProcessInstances(page.request, () => vedtak.klikkFattVedtak());
 
         // Step 9: Wait for processes and set faktura to BESTILT
-        console.log('Step 9: Waiting for processes and updating faktura...');
-        await waitForProcessInstances(page.request, 30);
-
         await withFaktureringDatabase(async (db) => {
             const updated = await db.execute("UPDATE faktura SET status = 'BESTILT'");
             console.log(`Updated ${updated} faktura rows to BESTILT`);
@@ -121,10 +118,11 @@ test.describe('Komplett saksflyt - Nyvurdering periode endres til kun tidligere 
         // Step 10: Create nyvurdering - endre skattestatus til skattepliktig
         console.log('Step 10: Creating nyvurdering...');
         await hovedside.klikkOpprettNySak();
-        await opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD', saksnummer);
-
-        console.log('Step 11: Waiting for behandling creation...');
-        await waitForProcessInstances(page.request, 30);
+        console.log('Step 11: Creating nyvurdering and waiting for behandling creation...');
+        await runAndWaitForProcessInstances(
+            page.request,
+            () => opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD', saksnummer)
+        );
 
         // Åpne ny behandling
         await hovedside.goto();
@@ -159,8 +157,10 @@ test.describe('Komplett saksflyt - Nyvurdering periode endres til kun tidligere 
 
         // Vedtak for ny vurdering med grunn
         console.log('📝 Fatter vedtak for ny vurdering...');
-        await vedtak.fattVedtakForNyVurdering('FEIL_I_BEHANDLING');
-        await waitForProcessInstances(page.request, 30);
+        await runAndWaitForProcessInstances(
+            page.request,
+            () => vedtak.fattVedtakForNyVurdering('FEIL_I_BEHANDLING')
+        );
 
         console.log('✅ Ny vurdering med FTRL 2.1 fullført!');
 
@@ -181,9 +181,9 @@ test.describe('Komplett saksflyt - Nyvurdering periode endres til kun tidligere 
         // vakuøst grønn hvert andre halvår (observert: «Sum kjede for 2027: 0 kr» på en kjede
         // som kun hadde 2026-linjer).
         const avregningsÅr = getYearFromDate(period.start)
-        // waitForProcessInstances kan svare COMPLETED før nyvurderingens egen
-        // prosessinstans er registrert (se FaktureringHelper.ventPåKjedeSum) – poll i
-        // stedet for å lese kjeden rett etterpå.
+        // Beholdt som defense-in-depth: markør-ventingen over dekker prosessinstansen,
+        // mens pollingen i tillegg dekker forsinkelse mot faktureringskomponenten
+        // (se FaktureringHelper.ventPåKjedeSum).
         const alleSerier = await faktureringHelper.ventPåKjedeSum(
             [opprinneligFakturaserieReferanse, fakturaserieReferanse],
             0,

--- a/tests/utenfor-avtaleland/komplett-sak-flere-land-arbeidsinntekt-nyvurdering-annullering.spec.ts
+++ b/tests/utenfor-avtaleland/komplett-sak-flere-land-arbeidsinntekt-nyvurdering-annullering.spec.ts
@@ -9,7 +9,7 @@ import {ResultatPeriodePage} from '../../pages/behandling/resultat-periode.page'
 import {TrygdeavgiftPage} from '../../pages/trygdeavgift/trygdeavgift.page';
 import {VedtakPage} from '../../pages/vedtak/vedtak.page';
 import {USER_ID_VALID} from '../../pages/shared/constants';
-import {waitForProcessInstances} from '../../helpers/api-helper';
+import {runAndWaitForProcessInstances} from '../../helpers/api-helper';
 import {hentSaksnummerFraUrl} from '../../helpers/url-helper';
 import {withFaktureringDatabase} from '../../helpers/pg-db-helper';
 import {AnnulleringPage} from '../../pages/behandling/annullering.page';
@@ -105,13 +105,9 @@ test.describe('Komplett saksflyt - Flere land med pensjon-dekning og nyvurdering
         await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
         await trygdeavgift.klikkBekreftOgFortsett();
 
-        // Step 8: Vedtak
+        // Step 8-9: Vedtak + vent på prosessene vedtaket starter
         console.log('Step 8: Making decision...');
-        await vedtak.klikkFattVedtak();
-
-        // Step 9: Vent på prosesser
-        console.log('Step 9: Waiting for processes...');
-        await waitForProcessInstances(page.request, 30);
+        await runAndWaitForProcessInstances(page.request, () => vedtak.klikkFattVedtak());
 
         // Step 10: Søk opp bruker og åpne årsavregningsbehandling
         console.log('Step 10: Opening årsavregning behandling...');
@@ -136,9 +132,7 @@ test.describe('Komplett saksflyt - Flere land med pensjon-dekning og nyvurdering
 
         // Step 12: Fatt vedtak for årsavregning
         console.log('Step 12: Making årsavregning decision...');
-        await vedtak.klikkFattVedtak();
-
-        await waitForProcessInstances(page.request, 30);
+        await runAndWaitForProcessInstances(page.request, () => vedtak.klikkFattVedtak());
         console.log('✅ Årsavregning vedtak completed');
 
         await withFaktureringDatabase(async (db) => {
@@ -149,8 +143,10 @@ test.describe('Komplett saksflyt - Flere land med pensjon-dekning og nyvurdering
         // Step 13: Opprett ny vurdering
         console.log('Step 13: Creating nyvurdering...');
         await hovedside.klikkOpprettNySak();
-        await opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD', saksnummer);
-        await waitForProcessInstances(page.request, 30);
+        await runAndWaitForProcessInstances(
+            page.request,
+            () => opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD', saksnummer)
+        );
 
         // Step 14: Åpne ny behandling
         console.log('Step 14: Opening new behandling...');
@@ -163,8 +159,9 @@ test.describe('Komplett saksflyt - Flere land med pensjon-dekning og nyvurdering
 
         // Step 15: Annuller saken
         console.log('Step 15: Annullering...');
-        await annullering.annullerSak();
-        await waitForProcessInstances(page.request, 30);
+        // Markøren tas før klikket, så ventingen ikke kan svare COMPLETED på forrige stegs
+        // prosessinstanser — annulleringens egen ANNULLER_SAK er den vi faktisk venter på.
+        await runAndWaitForProcessInstances(page.request, () => annullering.annullerSak());
 
         console.log('✅ Workflow completed successfully!');
 
@@ -179,9 +176,9 @@ test.describe('Komplett saksflyt - Flere land med pensjon-dekning og nyvurdering
         }
 
         const faktureringHelper = new FaktureringHelper(request);
-        // waitForProcessInstances kan svare COMPLETED før annulleringens egen
-        // prosessinstans er registrert – selve krediteringen er synkron, så det er
-        // registreringen vi poller rundt (se FaktureringHelper.ventPåKjedeSum).
+        // Beholdt som defense-in-depth: markør-ventingen over dekker annulleringens egen
+        // prosessinstans, mens denne pollingen i tillegg dekker forsinkelse mot
+        // faktureringskomponenten (se FaktureringHelper.ventPåKjedeSum).
         const alleSerier = await faktureringHelper.ventPåKjedeSum(
             [opprinneligFakturaserieReferanse, arsavregningFakturaserieRef],
             0

--- a/tests/utenfor-avtaleland/komplett-sak-flere-land-arbeidsinntekt.spec.ts
+++ b/tests/utenfor-avtaleland/komplett-sak-flere-land-arbeidsinntekt.spec.ts
@@ -11,7 +11,7 @@ import {TrygdeavgiftPage} from '../../pages/trygdeavgift/trygdeavgift.page';
 import {VedtakPage} from '../../pages/vedtak/vedtak.page';
 import {USER_ID_VALID} from '../../pages/shared/constants';
 import {getYearFromDate, TestPeriods} from '../../helpers/date-helper';
-import {waitForProcessInstances} from '../../helpers/api-helper';
+import {runAndWaitForProcessInstances} from '../../helpers/api-helper';
 import {hentSaksnummerFraUrl} from '../../helpers/url-helper';
 import {withFaktureringDatabase} from '../../helpers/pg-db-helper';
 import {getFakturaserieReferanse} from '../../helpers/db-helper';
@@ -102,13 +102,9 @@ test.describe('Komplett saksflyt - Flere land med arbeidsinntekt', () => {
         await trygdeavgift.fyllInnBruttoinntektMedApiVent('100000');
         await trygdeavgift.klikkBekreftOgFortsett();
 
-        // Step 8: Vedtak
+        // Step 8-9: Vedtak + vent på prosessene vedtaket starter, så faktura til BESTILT
         console.log('Step 8: Making decision...');
-        await vedtak.klikkFattVedtak();
-
-        // Step 9: Wait for processes and set faktura to BESTILT
-        console.log('Step 9: Waiting for processes and updating faktura...');
-        await waitForProcessInstances(page.request, 30);
+        await runAndWaitForProcessInstances(page.request, () => vedtak.klikkFattVedtak());
 
         await withFaktureringDatabase(async (db) => {
             const updated = await db.execute("UPDATE faktura SET status = 'BESTILT'");
@@ -118,10 +114,11 @@ test.describe('Komplett saksflyt - Flere land med arbeidsinntekt', () => {
         // Step 10: Create nyvurdering - endre skattestatus til skattepliktig
         console.log('Step 10: Creating nyvurdering...');
         await hovedside.klikkOpprettNySak();
-        await opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD', saksnummer);
-
-        console.log('Step 11: Waiting for behandling creation...');
-        await waitForProcessInstances(page.request, 30);
+        console.log('Step 11: Creating nyvurdering and waiting for behandling creation...');
+        await runAndWaitForProcessInstances(
+            page.request,
+            () => opprettSak.opprettNyVurdering(USER_ID_VALID, 'SØKNAD', saksnummer)
+        );
 
         // Step 12: Open the new active behandling
         console.log('Step 12: Opening new behandling...');
@@ -140,8 +137,10 @@ test.describe('Komplett saksflyt - Flere land med arbeidsinntekt', () => {
         // Step 14: Fatt vedtak for nyvurdering
         console.log('Step 14: Submitting vedtak for nyvurdering...');
         await page.waitForLoadState('networkidle');
-        await vedtak.fattVedtakForNyVurdering('FEIL_I_BEHANDLING');
-        await waitForProcessInstances(page.request, 30);
+        await runAndWaitForProcessInstances(
+            page.request,
+            () => vedtak.fattVedtakForNyVurdering('FEIL_I_BEHANDLING')
+        );
 
 
         console.log('Workflow completed successfully!');
@@ -158,9 +157,9 @@ test.describe('Komplett saksflyt - Flere land med arbeidsinntekt', () => {
 
         const faktureringHelper = new FaktureringHelper(request);
         const avregningsÅr = getYearFromDate(period.end)
-        // waitForProcessInstances kan svare COMPLETED før nyvurderingens egen
-        // prosessinstans er registrert (se FaktureringHelper.ventPåKjedeSum) – poll i
-        // stedet for å lese kjeden rett etterpå.
+        // Beholdt som defense-in-depth: markør-ventingen over dekker prosessinstansen,
+        // mens pollingen i tillegg dekker forsinkelse mot faktureringskomponenten
+        // (se FaktureringHelper.ventPåKjedeSum).
         const alleSerier = await faktureringHelper.ventPåKjedeSum(
             [opprinneligFakturaserieReferanse, fakturaserieReferanse],
             0,


### PR DESCRIPTION
## Hva

Tar i bruk den race-frie prosessventingen fra [melosys-api#3436](https://github.com/navikt/melosys-api/pull/3436).

`waitForProcessInstances()` kunne svare `COMPLETED` på arbeid fra **forrige** steg: endepunktet ser bare på alt som er registrert de siste 60 sekundene, og i en flerstegs-test er det aldri tomt. [#313](https://github.com/navikt/melosys-e2e-tests/pull/313) fikset symptomet fire steder ved å polle på sluttilstanden — dette fjerner årsaken.

Nye helpere i `helpers/api-helper.ts`:

```typescript
// Anbefalt form: markør → handling → vent på det handlingen startet
await runAndWaitForProcessInstances(page.request, () => vedtak.klikkFattVedtak());

// Lavnivå, når handlingen ikke lar seg pakke inn
const markør = await getProcessMarker(page.request);
await noeSomStarterProsess();
await waitForNewProcessInstances(page.request, markør, {expectedNew: 2});
```

`runAndWaitForProcessInstances` er umulig å bruke feil, fordi markøren alltid tas før handlingen.

## Migrert i denne omgang

Planen sier DB-assertions først, deretter cleanup-fixturen — det er gjort:

* **De fire testene som faktisk flaket av dette** (annullering/kreditering, de samme som fikk symptomfiksen i #313)
* **`fixtures/cleanup.ts`** — tar nå markør *før* testen og tømmer med `expectedNew: 0`. Den venter dermed på ALT testen startet, ikke bare det som ligger innenfor serverens 60-sekundersvindu; en lang test lekket før prosesser videre til neste test. Mangler markør-endepunktet (eldre api-image), faller fixturen tilbake til gammel oppførsel i stedet for å velte testen.

De øvrige ~110 kallstedene står igjen med **uendret** oppførsel og migreres stegvis. Rene «vent litt»-kall kan bli stående.

Sidefiks: `waitForProcessInstances` sender nå `timeoutSeconds` videre til serveren. Før var tallet kun Playwrights HTTP-timeout, mens serveren alltid ventet sine egne 30 s — `waitForProcessInstances(request, 60)` ga altså ikke 60 s.

## Verifisering — racet er reprodusert, ikke antatt

Racet lar seg ikke fremkalle ved gjentatte kjøringer: på en frisk maskin committer handlingen på ~20 ms og rekker godt innenfor settling-forsinkelsen på 200 ms. Suiten var grønn før også, så «suiten er grønn» er verdiløst som bevis her.

`scripts/prosessinstans-race-repro.ts` fremtvinger det i stedet: trigger `POST /api/fagsaker` **uten å vente på svaret** (akkurat som `AnnulleringPage.bekreft()`, som klikker og returnerer med én gang), kaller ventemetoden, og leser `PROSESSINSTANS` øyeblikkelig etterpå. Svarte den `COMPLETED` uten at det finnes en ny, ferdig instans, har den løyet.

Med `melosys.e2e.initial-settling-delay-ms=0` og en kunstig treg registrering i melosys-api:

| Betingelse | `waitForProcessInstances` | `runAndWaitForProcessInstances` |
|---|---|---|
| Frisk backend (settling 200 ms) | 0/10 falske COMPLETED | 0/10 |
| Settling 0 | 0/10 | – |
| **Treg backend + settling 0** | **9/10 falske COMPLETED** | **0/10** |

Skriptet dokumenterer selv hvordan betingelsene settes opp.

Bonus: markør-varianten er også raskere i normal drift (~90 ms mot ~225 ms), fordi markøren erstatter settling-forsinkelsen.

## Testing

Kjørt lokalt mot full docker-stack med api-imaget fra #3436:

* de fire migrerte testene — grønne
* `tests/core/sok-og-navigasjon.spec.ts` (5 tester som starter **null** prosessinstanser) — grønne, altså håndterer den nye tømmingen i fixturen 0-instans-tester riktig
* `npm run check:tests` — grønn

## Avhengighet

Krever melosys-api med markør-endepunktet ([#3436](https://github.com/navikt/melosys-api/pull/3436)). Fixturen faller tilbake til gammel oppførsel på eldre images, men de migrerte testene gjør ikke det — de vil feile med «Kunne ikke hente prosessmarkør» hvis api mangler endepunktet.

## Review

Kjørt `code-reviewer` (Opus, empirisk pass mot live-stacken) på hele diffen. 11 funn, seks rettet i `6b6cb7c`:

* **Reproduksjonsskriptets regnskap** bokførte en iterasjon som løgn *før* det sjekket at handlingen traff — en feilet POST oppretter ingen instans og ble derfor garantert talt som løgn. Det telte også uferdige instanser i hele tabellen, ikke bare de nye. Regnskapet er nå ID-basert, og **målingen er kjørt på nytt med det rettede regnskapet: 9/10 mot 0/10 står uendret.**
* `getProcessMarker` validerer nå svaret — en tom respons ga før `after=undefined`, som serveren avviste med 400 *etter* at handlingen var kjørt.
* Kommentaren i cleanup-fixturen lovet mer enn tømmingen gir; presisert.
* Skriptet sier fra i `old`-modus at 0 løgner betyr «betingelsene er ikke satt opp», ikke «racet finnes ikke».
* Dokumentasjonen advarer nå om at handlingen faktisk må starte en prosess, og at `timeoutSeconds` nå sendes til serveren.
* `request: any` typet.

Bevisst beholdt:

* **De migrerte testene har ingen fallback** når api mangler markør-endepunktet — de feiler høylytt. Det er poenget: en stille tilbakefall til den racy ventingen er nøyaktig anti-mønsteret denne PR-en fjerner. Derfor merge-rekkefølgen under.
* **`timeoutSeconds` sendes videre.** For grønne kjøringer endrer det ingenting (serveren svarte alltid innen 30 s, ellers hadde testene feilet); det forlenger kun feilstien for de 38 kallstedene som ber om 60/90.

## Verifisering lokalt

Alle fire migrerte spec-filer er kjørt lokalt mot full docker-stack med api-imaget fra #3436 — altså alle 11 innpakkede kallsteder — pluss `sok-og-navigasjon` (5 tester som starter null prosessinstanser, som treffer den nye tømmingen i fixturen). Alt grønt, både før og etter review-fiksene.

## Merge-rekkefølge

1. [melosys-api #3436](https://github.com/navikt/melosys-api/pull/3436) merges (CI grønn: build + unit + integration)
2. api-imaget havner i `latest`
3. E2E-CI dispatches på denne branchen, så merges den
