### PR TITLE
8185 Fjern referanser til utgått eos-fakturering-toggle

### DIFF
--- a/helpers/unleash-helper.ts
+++ b/helpers/unleash-helper.ts
@@ -442,7 +442,6 @@ export class UnleashHelper {
         'melosys.arsavregning',
         'melosys.arsavregning.uten.flyt',
         'melosys.faktureringskomponenten.ikke-tidligere-perioder',
-        'melosys.eos_fakturering_av_trygdeavgift',
       ];
 
       const features = featureNames || defaultFeatures;

--- a/recordings/skal-fullfore-arbeid-i-flere-land-arbeidsflyt.json
+++ b/recordings/skal-fullfore-arbeid-i-flere-land-arbeidsflyt.json
@@ -55,7 +55,7 @@
       "durationMs": 12,
       "request": {
         "method": "GET",
-        "url": "http://localhost:3000/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
+        "url": "http://localhost:3000/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "query": {
           "features": "melosys.cdm-4-4"
@@ -81,7 +81,6 @@
           "melosys.arsavregning": true,
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
-          "melosys.eos_fakturering_av_trygdeavgift": true,
           "melosys.arsavregning.uten.flyt": false,
           "melosys.cdm-4-4": true
         }
@@ -160,7 +159,7 @@
       "durationMs": 5,
       "request": {
         "method": "GET",
-        "url": "http://localhost:3000/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
+        "url": "http://localhost:3000/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "query": {
           "features": "melosys.cdm-4-4"
@@ -186,7 +185,6 @@
           "melosys.arsavregning": true,
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
-          "melosys.eos_fakturering_av_trygdeavgift": true,
           "melosys.arsavregning.uten.flyt": false,
           "melosys.cdm-4-4": true
         }
@@ -1679,7 +1677,7 @@
       "durationMs": 7,
       "request": {
         "method": "GET",
-        "url": "http://localhost:3000/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.eos_fakturering_av_trygdeavgift&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
+        "url": "http://localhost:3000/api/featuretoggle?features=melosys.ftrl.begrense_periode_vedtak&features=melosys.11_3_a_Norge_er_utpekt&features=melosys.pensjonist&features=melosys.pensjonist_eos&features=standardvedlegg_eget_vedlegg_avtaleland&features=melosys.arsavregning&features=melosys.arsavregning.uten.flyt&features=melosys.faktureringskomponenten.ikke-tidligere-perioder&features=melosys.faktureringskomponent.vis_referanse&features=melosys.cdm-4-4",
         "pathname": "/api/featuretoggle",
         "query": {
           "features": "melosys.cdm-4-4"
@@ -1705,7 +1703,6 @@
           "melosys.arsavregning": true,
           "melosys.faktureringskomponenten.ikke-tidligere-perioder": true,
           "melosys.11_3_a_Norge_er_utpekt": true,
-          "melosys.eos_fakturering_av_trygdeavgift": true,
           "melosys.arsavregning.uten.flyt": false,
           "melosys.cdm-4-4": true
         }


### PR DESCRIPTION
Fjerner referanser til feature-togglen `melosys.eos_fakturering_av_trygdeavgift`, som er fjernet fra melosys-web fordi funksjonaliteten nå er permanent på.

Togglen eksisterer ikke lenger i melosys-web (fjernet i MELOSYS-8185), så referansene i e2e-testene er foreldet og ryddes bort for å unngå forvirring.
[MELOSYS-8185](https://jira.adeo.no/browse/MELOSYS-8185)

- Fjernet togglen fra default-lista i `logFrontendToggleStates()` i unleash-helper.ts
- Fjernet togglen fra URL-query og body i innspilt recording-fil

## Testing
- [x] JSON-validering av recording-fil OK
- [x] Verifisert ingen gjenværende referanser til togglen
- [ ] E2E-tester ikke funksjonelt påvirket (kun foreldede referanser)